### PR TITLE
Use Ed25519 libp2p keypairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -705,16 +705,6 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff07008ec701e8028e2ceb8f83f0e4274ee62bd2dbdc4fefff2e9a91824081a"
@@ -1355,16 +1345,6 @@ dependencies = [
 
 [[package]]
 name = "hmac"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
-dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
@@ -1390,17 +1370,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest 0.10.6",
-]
-
-[[package]]
-name = "hmac-drbg"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ea0a1394df5b6574da6e0c1ade9e78868c9fb0a4e5ef4428e32da4676b85b1"
-dependencies = [
- "digest 0.9.0",
- "generic-array",
- "hmac 0.8.1",
 ]
 
 [[package]]
@@ -1644,7 +1613,6 @@ dependencies = [
  "futures",
  "futures-timer",
  "instant",
- "libsecp256k1",
  "log",
  "multiaddr",
  "multihash",
@@ -1968,54 +1936,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "webrtc",
-]
-
-[[package]]
-name = "libsecp256k1"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b09eff1b35ed3b33b877ced3a691fc7a481919c7e29c53c906226fcf55e2a1"
-dependencies = [
- "arrayref",
- "base64",
- "digest 0.9.0",
- "hmac-drbg",
- "libsecp256k1-core",
- "libsecp256k1-gen-ecmult",
- "libsecp256k1-gen-genmult",
- "rand 0.8.5",
- "serde",
- "sha2 0.9.9",
- "typenum",
-]
-
-[[package]]
-name = "libsecp256k1-core"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be9b9bb642d8522a44d533eab56c16c738301965504753b03ad1de3425d5451"
-dependencies = [
- "crunchy",
- "digest 0.9.0",
- "subtle",
-]
-
-[[package]]
-name = "libsecp256k1-gen-ecmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3038c808c55c87e8a172643a7d87187fc6c4174468159cb3090659d55bcb4809"
-dependencies = [
- "libsecp256k1-core",
-]
-
-[[package]]
-name = "libsecp256k1-gen-genmult"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db8d6ba2cec9eacc40e6e8ccc98931840301f1006e95647ceb2dd5c3aa06f7c"
-dependencies = [
- "libsecp256k1-core",
 ]
 
 [[package]]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -13,7 +13,7 @@ bls12_381 = "0.7.0"
 clap = { version = "4.1.4", features = ["derive"] }
 hex = "0.4.3"
 itertools = "0.10.5"
-libp2p = { version = "0.50.0", features = ["secp256k1", "gossipsub", "macros", "tcp", "tokio", "noise", "mplex", "mdns", "request-response", "kad", "identify"] }
+libp2p = { version = "0.50.0", features = ["gossipsub", "macros", "tcp", "tokio", "noise", "mplex", "mdns", "request-response", "kad", "identify"] }
 rand = "0.8.5"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93"

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -116,10 +116,12 @@ impl SecretKey {
         PublicKey(self.0.public_key())
     }
 
-    pub fn to_libp2p_keypair(self) -> Result<libp2p::identity::Keypair> {
-        Ok(libp2p::identity::Keypair::Secp256k1(
-            libp2p::identity::secp256k1::SecretKey::from_bytes(self.0.as_bytes())?.into(),
-        ))
+    pub fn to_libp2p_keypair(self) -> libp2p::identity::Keypair {
+        libp2p::identity::Keypair::Ed25519(
+            libp2p::identity::ed25519::SecretKey::from_bytes(self.0.as_bytes())
+                .expect("`SecretKey::from_bytes` returns an `Err` only when the length is not 32, we know the length is 32")
+                .into(),
+        )
     }
 }
 

--- a/zilliqa/src/main.rs
+++ b/zilliqa/src/main.rs
@@ -53,7 +53,7 @@ struct Behaviour {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    let key_pair = args.secret_key.to_libp2p_keypair()?;
+    let key_pair = args.secret_key.to_libp2p_keypair();
     let peer_id = PeerId::from(key_pair.public());
     println!("Peer ID: {peer_id:?}");
 


### PR DESCRIPTION
Ed25519 is supported by default, meaning we don't have to pull in extra dependencies for secp256k1.

Also, it appears to be an objectively better choice based on the 5 minutes of Googling I've done:
https://soatok.blog/2022/05/19/guidance-for-choosing-an-elliptic-curve-signature-algorithm-in-2022/

Finally, it has the reasonably nice property that all sequences of 256 bits are valid secret keys (though BLS does not have this property, so we can't do that much with it).