### PR TITLE
Remove `println!`

### DIFF
--- a/zilliqa/src/main.rs
+++ b/zilliqa/src/main.rs
@@ -90,7 +90,6 @@ async fn main() -> Result<()> {
 
     if let Some(port) = args.bind_port {
         addr.push(Protocol::Tcp(port));
-        println!("Zilliqa server is running on {:?}...", port);
     } else {
         addr.push(Protocol::Tcp(0));
     }


### PR DESCRIPTION
We print the listening ports at `info!` level on line 129, so this log should be unnecessary.