### PR TITLE
Configure nodes with a TOML configuration file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,7 +2931,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
  "thiserror",
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -3498,6 +3498,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,6 +3953,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "toml"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7afcae9e3f0fe2c370fd4657108972cbb2fa9db1b9f84849cefd80741b01cb6"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1eb0622d28f4b9c90adc4ea4b2b46b47663fde9ac5fafcb14a1369d5508825"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -4768,6 +4811,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "winnow"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09497b8f8b5ac5d3bb4d05c0a99be20f26fd3d5f2db7b0716e946d5103658"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4912,6 +4964,7 @@ dependencies = [
  "sha3",
  "tokio",
  "tokio-stream",
+ "toml 0.7.2",
  "tracing",
  "tracing-subscriber",
 ]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -34,5 +34,6 @@ serde_json = "1.0.93"
 sha3 = "0.10.6"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1.11"
+toml = "0.7.2"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,0 +1,14 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    /// The port to listen for P2P messages on. Optional - If not provided a random port will be used.
+    pub p2p_port: Option<u16>,
+    /// The port to listen for JSON-RPC requests on. Defaults to 4201.
+    #[serde(default = "default_json_rpc_port")]
+    pub json_rpc_port: u16,
+}
+
+fn default_json_rpc_port() -> u16 {
+    4201
+}

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod cfg;
 pub mod crypto;
 pub mod message;
 pub mod node;


### PR DESCRIPTION
We choose to still pass the node's secret key on the command line, to discourage operators from storing their secret key in plaintext on disk.

Also note that all configuration parameters currently have defaults, so the empty configuration file is a valid one. Therefore, we add a special case which assumes that if the config file doesn't exist, we assume the empty config file. This property may not live forever and so we might undo this special case later.

Resolves #42 