### PR TITLE
Build node images in debug mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/target \
-    cargo build --release --bin zilliqa && \
-    mv /target/release/zilliqa /build/
+    cargo build --bin zilliqa && \
+    mv /target/debug/zilliqa /build/
 
 
 FROM gcr.io/distroless/cc-debian11


### PR DESCRIPTION
We can add an optional release argument when we actually start caring about performance. For now, this makes things faster.