### PR TITLE
Print hex when displaying `Hash`

### DIFF
--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -140,9 +140,9 @@ impl SecretKey {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, Deserialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct Hash([u8; 32]);
+pub struct Hash(pub [u8; 32]);
 
 impl Hash {
     pub const ZERO: Hash = Hash([0; 32]);
@@ -157,5 +157,17 @@ impl Hash {
             hasher.update(preimage);
         }
         Self(hasher.finalize().into())
+    }
+}
+
+impl Display for Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.as_bytes()))
+    }
+}
+
+impl std::fmt::Debug for Hash {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(self.as_bytes()))
     }
 }


### PR DESCRIPTION
We also expose the underlying array. This may be a bad idea, as it means in theory people can start depending on the length of hashes, but I think we should accept that for now and undo this decision if it turns out we're misusing the abstraction.