### PR TITLE
Add stub implementations for basic Eth APIs

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -1,0 +1,66 @@
+//! The Ethereum API, as documented at <https://ethereum.org/en/developers/docs/apis/json-rpc>.
+
+use std::sync::{Arc, Mutex};
+
+use jsonrpsee::{core::RpcResult, types::Params, RpcModule};
+
+use crate::node::Node;
+
+use super::to_hex::ToHex;
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    let mut module = RpcModule::new(node);
+
+    macro_rules! method {
+        ($name:expr, $imp:path) => {
+            module.register_method($name, $imp).unwrap();
+        };
+    }
+
+    method!("eth_accounts", accounts);
+    method!("eth_blockNumber", block_number);
+    method!("eth_chainId", chain_id);
+    method!("eth_estimateGas", estimate_gas);
+    method!("eth_getBalance", get_balance);
+    method!("eth_gasPrice", gas_price);
+    method!("net_version", version);
+
+    module
+}
+
+fn accounts(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<[(); 0]> {
+    Ok([])
+}
+
+fn block_number(_: Params, node: &Arc<Mutex<Node>>) -> RpcResult<Option<String>> {
+    if let Some(block) = node.lock().unwrap().view().checked_sub(1) {
+        Ok(Some(block.to_hex()))
+    } else {
+        Ok(None)
+    }
+}
+
+fn chain_id(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<&'static str> {
+    // TODO: #68
+    Ok("0x1")
+}
+
+fn estimate_gas(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<&'static str> {
+    // TODO: #69
+    Ok("0x100")
+}
+
+fn get_balance(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<&'static str> {
+    // TODO: #70
+    Ok("0xf000000000000000")
+}
+
+fn gas_price(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<&'static str> {
+    // TODO: #71
+    Ok("0x454b7b38e70")
+}
+
+fn version(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<&'static str> {
+    // TODO: #68
+    Ok("1")
+}

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,1 +1,3 @@
+pub mod eth;
+mod to_hex;
 pub mod zilliqa;

--- a/zilliqa/src/api/to_hex.rs
+++ b/zilliqa/src/api/to_hex.rs
@@ -1,0 +1,65 @@
+use primitive_types::{H128, H160, H256, H384, H512, H768};
+
+/// A version of [hex::ToHex] which is also implemented for integer types. This version also prefixes the produced
+/// string with `"0x"`.
+pub trait ToHex {
+    fn to_hex(&self) -> String;
+}
+
+/// Generates an implementation of [ToHex] for types which implement `AsRef<[u8]>`.
+macro_rules! as_ref_impl {
+    ($T:ty) => {
+        impl ToHex for $T {
+            fn to_hex(&self) -> String {
+                format!("0x{}", hex::encode(self))
+            }
+        }
+    };
+}
+
+/// Generates an implementation of [ToHex] for types which have a `.to_be_bytes()` method.
+macro_rules! int_impl {
+    ($T:ty) => {
+        impl ToHex for $T {
+            fn to_hex(&self) -> String {
+                format!("0x{}", hex::encode(self.to_be_bytes()))
+            }
+        }
+    };
+}
+
+impl<T: ToHex> ToHex for &T {
+    fn to_hex(&self) -> String {
+        (*self).to_hex()
+    }
+}
+
+impl<const N: usize> ToHex for [u8; N] {
+    fn to_hex(&self) -> String {
+        format!("0x{}", hex::encode(self))
+    }
+}
+
+as_ref_impl!(str);
+as_ref_impl!(String);
+as_ref_impl!([u8]);
+as_ref_impl!(Vec<u8>);
+as_ref_impl!(H128);
+as_ref_impl!(H160);
+as_ref_impl!(H256);
+as_ref_impl!(H384);
+as_ref_impl!(H512);
+as_ref_impl!(H768);
+
+int_impl!(i8);
+int_impl!(i16);
+int_impl!(i32);
+int_impl!(i64);
+int_impl!(i128);
+int_impl!(u8);
+int_impl!(u16);
+int_impl!(u32);
+int_impl!(u64);
+int_impl!(u128);
+int_impl!(isize);
+int_impl!(usize);

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -148,7 +148,8 @@ async fn main() -> Result<()> {
         .set_middleware(middleware)
         .build((Ipv4Addr::UNSPECIFIED, config.json_rpc_port))
         .await?;
-    let rpc_module = api::zilliqa::rpc_module(Arc::clone(&node));
+    let mut rpc_module = api::zilliqa::rpc_module(Arc::clone(&node));
+    rpc_module.merge(api::eth::rpc_module(Arc::clone(&node)))?;
     let handle = server.start(rpc_module)?;
     tokio::spawn(handle.stopped());
 


### PR DESCRIPTION
Mostly these return hardcoded responses for now. The aim is just to get Metamask + Remix IDE working for now.
Merge after #65 