### PR TITLE
Add CORS layer for JSON-RPC API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range-header"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
+
+[[package]]
 name = "httparse"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4114,6 +4120,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5065,6 +5089,7 @@ dependencies = [
  "bls12_381",
  "clap",
  "hex",
+ "http",
  "itertools",
  "jsonrpsee",
  "k256",
@@ -5078,6 +5103,8 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml 0.7.2",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
 ]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -22,6 +22,7 @@ bls-signatures = "0.13.0"
 bls12_381 = "0.7.0"
 clap = { version = "4.1.8", features = ["derive"] }
 hex = "0.4.3"
+http = "0.2.9"
 itertools = "0.10.5"
 jsonrpsee = { version = "0.16.2", features = ["server"] }
 k256 = "0.13.0"
@@ -35,5 +36,7 @@ sha3 = "0.10.6"
 tokio = { version = "1.26.0", features = ["macros", "rt-multi-thread", "sync"] }
 tokio-stream = "0.1.11"
 toml = "0.7.2"
+tower = "0.4.13"
+tower-http = { version = "0.4.0", features = ["cors"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"


### PR DESCRIPTION
Otherwise Remix IDE complains when trying to point it directly at the API.