### PR TITLE
Avoid returning `null` from `eth_blockNumber`

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -58,11 +58,11 @@ fn accounts(_: Params, _: &Arc<Mutex<Node>>) -> RpcResult<[(); 0]> {
     Ok([])
 }
 
-fn block_number(_: Params, node: &Arc<Mutex<Node>>) -> RpcResult<Option<String>> {
+fn block_number(_: Params, node: &Arc<Mutex<Node>>) -> RpcResult<String> {
     if let Some(block) = node.lock().unwrap().view().checked_sub(1) {
-        Ok(Some(block.to_hex()))
+        Ok(block.to_hex())
     } else {
-        Ok(None)
+        Err(anyhow!("no blocks").into())
     }
 }
 


### PR DESCRIPTION
Instead we return an error if no blocks exist (because the network has just started).

This is more in line with the specification which does not allow `null` to be returned from this method. Also, Metamask misbehaves if it thinks the latest block number is `null`.