### PR TITLE
Make Ethereum chain ID configurable

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -98,9 +98,8 @@ fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     Ok(return_value.to_hex())
 }
 
-fn chain_id(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
-    // TODO: #68
-    Ok("0x1")
+fn chain_id(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
+    Ok(node.lock().unwrap().config.eth_chain_id.to_hex())
 }
 
 fn estimate_gas(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
@@ -223,9 +222,8 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
     Ok(transaction_hash.to_hex())
 }
 
-fn version(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
-    // TODO: #68
-    Ok("1")
+fn version(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
+    Ok(node.lock().unwrap().config.eth_chain_id.to_string())
 }
 
 /// Decode a transaction from its RLP-encoded form.

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -131,6 +131,7 @@ async fn main() -> Result<()> {
     let mut reset_timeout_receiver = UnboundedReceiverStream::new(reset_timeout_receiver);
 
     let node = Node::new(
+        config.clone(),
         peer_id,
         args.secret_key,
         message_sender,

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -7,8 +7,14 @@ pub struct Config {
     /// The port to listen for JSON-RPC requests on. Defaults to 4201.
     #[serde(default = "default_json_rpc_port")]
     pub json_rpc_port: u16,
+    #[serde(default = "default_eth_chain_id")]
+    pub eth_chain_id: u64,
 }
 
 fn default_json_rpc_port() -> u16 {
     4201
+}
+
+fn default_eth_chain_id() -> u64 {
+    1 + 0x8000
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -10,6 +10,7 @@ use tracing::{debug, trace};
 
 use crate::{
     api::types::{EthTransaction, EthTransactionReceipt},
+    cfg::Config,
     crypto::{verify_messages, Hash, PublicKey, SecretKey, Signature},
     message::{
         AggregateQc, BitSlice, BitVec, Block, BlockRequest, BlockResponse, Message, NewView,
@@ -48,6 +49,7 @@ struct NewViewVote {
 /// 1. When a node recieves a block proposal, it looks up the transactions in `new_transactions` and executes them against its `state`.
 /// Successfully executed transactions are added to `transactions` so they can be returned via APIs.
 pub struct Node {
+    pub config: Config,
     committee: Vec<Validator>,
     blocks: BTreeMap<Hash, Block>,
     votes: BTreeMap<Hash, (Vec<Signature>, BitVec, u128)>,
@@ -74,6 +76,7 @@ pub struct Node {
 
 impl Node {
     pub fn new(
+        config: Config,
         peer_id: PeerId,
         secret_key: SecretKey,
         message_sender: UnboundedSender<(PeerId, Message)>,
@@ -86,6 +89,7 @@ impl Node {
         };
 
         let node = Node {
+            config,
             committee: vec![validator],
             blocks: BTreeMap::new(),
             votes: BTreeMap::new(),


### PR DESCRIPTION
The chain ID defaults to the value of the existing Zilliqa EVM mainnet (`32769` or `0x8001`).

Resolves #68.