### PR TITLE
Increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 100
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
@@ -17,3 +18,4 @@ updates:
         # These are peer deps of Cargo and should not be automatically bumped
         - dependency-name: "semver"
         - dependency-name: "crates-io"
+    open-pull-requests-limit: 100


### PR DESCRIPTION
The default value is 5 PRs. I figure we would rather know if we have lots of outdated dependencies and potentially choose to explicitly ignore that fact if we want to.