### PR TITLE
Revert tracing from 0.1.38 back to 0.1.37

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,10 +4359,11 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.38"
+version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -4371,13 +4372,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.24"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.3",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -42,5 +42,5 @@ tokio-stream = "0.1.14"
 toml = "0.7.3"
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors"] }
-tracing = "0.1.38"
+tracing = "0.1.37"
 tracing-subscriber = "0.3.17"


### PR DESCRIPTION
This reverts commit b914250cb81cdc220bab1fa1eeda399fbb71b9e4.

tracing 0.1.38 was yanked due to an unintended backwards-incompatible change in a patch version: https://github.com/tokio-rs/tracing/issues/2578#issuecomment-1528463295