### PR TITLE
Move consensus state and logic out of `Node`

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -212,7 +212,7 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
     let mut transaction = transaction_from_rlp(&transaction).unwrap();
     transaction.gas_limit = 100000000000000;
 
-    let transaction_hash = H256(node.lock().unwrap().new_transaction(transaction)?.0);
+    let transaction_hash = H256(node.lock().unwrap().create_transaction(transaction)?.0);
 
     Ok(transaction_hash.to_hex())
 }

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -132,7 +132,6 @@ async fn main() -> Result<()> {
 
     let node = Node::new(
         config.clone(),
-        peer_id,
         args.secret_key,
         message_sender,
         reset_timeout_sender,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1,0 +1,698 @@
+use std::collections::BTreeMap;
+
+use anyhow::{anyhow, Result};
+use bitvec::bitvec;
+use itertools::Itertools;
+use libp2p::PeerId;
+use tracing::{debug, trace};
+
+use crate::{
+    crypto::{verify_messages, Hash, PublicKey, SecretKey, Signature},
+    message::{AggregateQc, BitSlice, BitVec, Block, NewView, QuorumCertificate, Vote},
+    state::{NewTransaction, State, Transaction},
+};
+
+struct NewViewVote {
+    signatures: Vec<Signature>,
+    signers: Vec<u16>,
+    cosigned: BitVec,
+    cosigned_weight: u128,
+    qcs: Vec<QuorumCertificate>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct Validator {
+    pub public_key: PublicKey,
+    pub peer_id: PeerId,
+    pub weight: u128,
+}
+
+pub struct Consensus {
+    secret_key: SecretKey,
+    committee: Vec<Validator>,
+    blocks: BTreeMap<Hash, Block>,
+    votes: BTreeMap<Hash, (Vec<Signature>, BitVec, u128)>,
+    new_views: BTreeMap<u64, NewViewVote>,
+    high_qc: Option<QuorumCertificate>, // none before we receive the first proposal
+    view: u64,
+    /// The latest finalized block.
+    finalized: Hash,
+    /// Peers that have appeared between the last view and this one. They will be added to the committee before the next view.
+    pending_peers: Vec<(PeerId, PublicKey)>,
+    /// Transactions that have been sent to this node. They will be added to the next block we author.
+    // TODO(#82): Add transactions to the next block, not *MY* next block.
+    pending_transactions: Vec<Hash>,
+    /// Transactions that have been broadcasted by the network, but not yet executed. Transactions will be removed from this map once they are executed.
+    new_transactions: BTreeMap<Hash, NewTransaction>,
+    /// Transactions that have been executed and included in a block.
+    transactions: BTreeMap<Hash, Transaction>,
+    /// The account store.
+    state: State,
+}
+
+impl Consensus {
+    pub fn new(secret_key: SecretKey) -> Self {
+        let validator = Validator {
+            public_key: secret_key.public_key(),
+            peer_id: secret_key.to_libp2p_keypair().public().to_peer_id(),
+            weight: 100,
+        };
+
+        Consensus {
+            secret_key,
+            committee: vec![validator],
+            blocks: BTreeMap::new(),
+            votes: BTreeMap::new(),
+            new_views: BTreeMap::new(),
+            high_qc: None,
+            view: 0,
+            finalized: Hash::ZERO,
+            pending_peers: Vec::new(),
+            pending_transactions: Vec::new(),
+            new_transactions: BTreeMap::new(),
+            transactions: BTreeMap::new(),
+            state: State::new(),
+        }
+    }
+
+    fn update_view(&mut self, view: u64) {
+        self.view = view;
+        let pending_peers = self.pending_peers.drain(..);
+
+        for (peer_id, public_key) in pending_peers {
+            if self
+                .committee
+                .iter()
+                .filter(|v| v.peer_id == peer_id)
+                .count()
+                > 0
+            {
+                continue;
+            }
+
+            let validator = Validator {
+                peer_id,
+                public_key,
+                weight: 100, // Arbitrary weight
+            };
+            self.committee.push(validator);
+        }
+        // We always keep the committee sorted by the peer ID to give a stable ordering across the network.
+        self.committee.sort_unstable_by_key(|v| v.peer_id);
+    }
+
+    pub fn add_peer(
+        &mut self,
+        peer: PeerId,
+        public_key: PublicKey,
+    ) -> Result<Option<(PeerId, Vote)>> {
+        if self.pending_peers.contains(&(peer, public_key)) {
+            return Ok(None);
+        }
+
+        debug!(%peer, "added pending peer");
+
+        self.pending_peers.push((peer, public_key));
+
+        // Before we have at least 3 other nodes (not including ourselves) there is no point trying to propose blocks,
+        // because the supermajority condition is impossible to achieve.
+        if self.pending_peers.len() >= 3 && self.view == 0 {
+            let genesis = Block::genesis(self.committee.len());
+            self.high_qc = Some(genesis.qc.clone());
+            self.add_block(genesis.clone());
+            self.update_view(1);
+            let vote = self.vote_from_block(&genesis);
+            let leader = self.get_leader(self.view).peer_id;
+            return Ok(Some((leader, vote)));
+        }
+
+        Ok(None)
+    }
+
+    pub fn timeout(&mut self) -> Result<Option<(PeerId, NewView)>> {
+        if self.view == 0 {
+            return Ok(None);
+        }
+
+        self.update_view(self.view + 1);
+
+        if let Some(high_qc) = &self.high_qc {
+            let new_view = self.new_view_from_qc(high_qc);
+            return Ok(Some((self.get_leader(self.view).peer_id, new_view)));
+        }
+
+        Ok(None)
+    }
+
+    pub fn proposal(&mut self, block: Block) -> Result<Option<(PeerId, Vote)>> {
+        // derive the sender from the proposal's view
+        let sender = self.get_leader(block.view);
+        // verify the sender's signature on the proposal
+        sender
+            .public_key
+            .verify(block.hash.as_bytes(), block.signature)?;
+        // in the future check if we already have another block with the same view as proposal, which means that the sender equivocates; also figure out who voted for both of these blocks and thus equivocated
+        // check if the co-signers of the proposal's qc represent the supermajority
+        self.check_quorum_in_bits(&block.qc.cosigned)?;
+
+        // FIXME: Sane validation of genesis blocks
+        let proposal_view = block.view;
+        if proposal_view > 2 {
+            // verify the block qc's signature
+            self.verify_qc_signature(&block.qc)?;
+        }
+
+        if let Some(agg) = &block.agg {
+            // check if the signers of the proposal's agg represent the supermajority
+            self.check_quorum_in_indices(&agg.signers)?;
+
+            // verify the block aggregate qc's signature
+            self.batch_verify_agg_signature(agg)?;
+        }
+
+        // retrieve the highest among the aggregated qcs and check if it equals the block's qc
+        let proposal_high_qc = self.get_high_qc_from_block(&block)?;
+
+        self.add_block(block.clone());
+        self.update_high_qc_and_view(block.agg.is_some(), proposal_high_qc.clone())?;
+
+        let proposal_view = block.view;
+        if self.check_safe_block(&block) {
+            for txn in &block.transactions {
+                // TODO(#83): Currently we return an error if the transaction's hash was not in `self.new_transactions`.
+                // However, it is quite possible that we haven't yet received the transaction. We should do something
+                // in this case (Request from another node and wait for a response? Just wait for the gossip to
+                // arrive?)
+                let txn = self
+                    .new_transactions
+                    .remove(txn)
+                    .ok_or_else(|| anyhow!("missing transaction"))?;
+
+                let txn = self.state.apply_transaction(txn, block.hash)?;
+
+                self.transactions.insert(txn.hash(), txn);
+            }
+            // TODO(#84): compare state roots
+            // TODO: Download blocks up to `proposal_view - 1`.
+            self.update_view(proposal_view + 1);
+            let leader = self.get_leader(self.view).peer_id;
+            trace!(proposal_view, "voting for block");
+            let vote = self.vote_from_block(&block);
+
+            Ok(Some((leader, vote)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn vote(&mut self, _: PeerId, vote: Vote) -> Result<Option<Block>> {
+        let Ok(block) = self.get_block(&vote.block_hash) else { return Ok(None); }; // TODO: Is this the right response when we recieve a vote for a block we don't know about?
+        let block_hash = block.hash;
+        let block_view = block.view;
+        trace!(block_view, "handling vote");
+        // if we are not the leader of the round in which the vote counts
+        if self.get_leader(block_view + 1).public_key != self.secret_key.public_key() {
+            trace!(vote_view = block_view + 1, "skipping vote, not the leader");
+            return Ok(None);
+        }
+        // if the vote is too old and does not count anymore
+        if block_view + 1 < self.view {
+            return Ok(None);
+        }
+        // verify the sender's signature on block_hash
+        let sender = self.get_member(vote.index);
+        sender
+            .public_key
+            .verify(block.hash.as_bytes(), vote.signature)?;
+
+        let (mut signatures, mut cosigned, mut cosigned_weight) =
+            self.votes.remove(&block_hash).unwrap_or_else(|| {
+                (
+                    Vec::new(),
+                    bitvec![u8, bitvec::order::Msb0; 0; self.committee.len()],
+                    0,
+                )
+            });
+
+        let mut supermajority = false;
+        // if the vote is new, store it
+        if !cosigned[vote.index as usize] {
+            signatures.push(vote.signature);
+            cosigned.set(vote.index as usize, true);
+            cosigned_weight += sender.weight;
+
+            supermajority = cosigned_weight * 3 > self.committee_weight() * 2;
+            trace!(
+                cosigned_weight,
+                supermajority,
+                self.view,
+                vote_view = block_view + 1,
+                "storing vote"
+            );
+            // if we are already in the round in which the vote counts and have reached supermajority
+            if block_view + 1 == self.view && supermajority {
+                let qc = self.qc_from_bits(block_hash, &signatures, cosigned.clone());
+                let parent = qc.block_hash;
+                let transactions = self.pending_transactions.drain(..).collect();
+                let proposal = self.block_from_qc(self.view, qc, parent, transactions);
+                // as a future improvement, process the proposal before broadcasting it
+                trace!("vote successful");
+                return Ok(Some(proposal));
+                // we don't want to keep the collected votes if we proposed a new block
+                // we should remove the collected votes if we couldn't reach supermajority within the view
+            }
+        }
+        if !supermajority {
+            self.votes
+                .insert(block_hash, (signatures, cosigned, cosigned_weight));
+        }
+
+        Ok(None)
+    }
+
+    pub fn new_view(&mut self, _: PeerId, new_view: NewView) -> Result<Option<Block>> {
+        // if we are not the leader of the round in which the vote counts
+        if self.get_leader(new_view.view).public_key != self.secret_key.public_key() {
+            trace!(new_view.view, "skipping new view, not the leader");
+            return Ok(None);
+        }
+        // if the vote is too old and does not count anymore
+        if new_view.view < self.view {
+            return Ok(None);
+        }
+        // verify the sender's signature on the block hash
+        let mut message = Vec::new();
+        message.extend_from_slice(new_view.qc.compute_hash().as_bytes());
+        message.extend_from_slice(&new_view.index.to_be_bytes());
+        message.extend_from_slice(&new_view.view.to_be_bytes());
+        let sender = self.get_member(new_view.index);
+        sender.public_key.verify(&message, new_view.signature)?;
+
+        // check if the sender's qc is higher than our high_qc or even higher than our view
+        self.update_high_qc_and_view(false, new_view.qc.clone())?;
+
+        let NewViewVote {
+            mut signatures,
+            mut signers,
+            mut cosigned,
+            mut cosigned_weight,
+            mut qcs,
+        } = self
+            .new_views
+            .remove(&new_view.view)
+            .unwrap_or_else(|| NewViewVote {
+                signatures: Vec::new(),
+                signers: Vec::new(),
+                cosigned: bitvec![u8, bitvec::order::Msb0; 0; self.committee.len()],
+                cosigned_weight: 0,
+                qcs: Vec::new(),
+            });
+
+        let mut supermajority = false;
+        // if the vote is new, stores it
+        if !cosigned[new_view.index as usize] {
+            signatures.push(new_view.signature);
+            signers.push(new_view.index);
+            cosigned.set(new_view.index as usize, true);
+            cosigned_weight += sender.weight;
+            qcs.push(new_view.qc);
+            supermajority = cosigned_weight * 3 > self.committee_weight() * 2;
+            let num_signers = signers.len();
+            trace!(
+                num_signers,
+                cosigned_weight,
+                supermajority,
+                self.view,
+                new_view.view,
+                "storing vote for new view"
+            );
+            // if we are already in the round in which the vote counts and have reached supermajority
+            if new_view.view == self.view && supermajority {
+                // todo: the aggregate qc is an aggregated signature on the qcs, view and validator index which can be batch verified
+                let agg =
+                    self.aggregate_qc_from_indexes(new_view.view, qcs, &signatures, signers)?;
+                let high_qc = self.get_highest_from_agg(&agg)?;
+                let parent = high_qc.block_hash;
+                let proposal = self.block_from_agg(self.view, high_qc.clone(), agg, parent);
+                // as a future improvement, process the proposal before broadcasting it
+                return Ok(Some(proposal));
+                // we don't want to keep the collected votes if we proposed a new block
+                // we should remove the collected votes if we couldn't reach supermajority within the view
+            }
+        }
+        if !supermajority {
+            self.new_views.insert(
+                new_view.view,
+                NewViewVote {
+                    signatures,
+                    signers,
+                    cosigned,
+                    cosigned_weight,
+                    qcs,
+                },
+            );
+        }
+
+        Ok(None)
+    }
+
+    pub fn create_transaction(&mut self, txn: &NewTransaction) -> Result<()> {
+        self.pending_transactions.push(txn.hash());
+
+        Ok(())
+    }
+
+    pub fn new_transaction(&mut self, txn: NewTransaction) -> Result<()> {
+        self.new_transactions.insert(txn.hash(), txn);
+
+        Ok(())
+    }
+
+    pub fn get_transaction_by_hash(&self, hash: Hash) -> Option<Transaction> {
+        Some(self.transactions.get(&hash)?.clone())
+    }
+
+    fn update_high_qc_and_view(
+        &mut self,
+        from_agg: bool,
+        new_high_qc: QuorumCertificate,
+    ) -> Result<()> {
+        let Some(new_high_qc_block) = self.blocks.get(&new_high_qc.block_hash) else {
+            // We don't set high_qc to a qc if we don't have its block.
+            return Ok(());
+        };
+        match &self.high_qc {
+            None => {
+                self.high_qc = Some(new_high_qc);
+            }
+            Some(high_qc) => {
+                let current_high_qc_view = self.get_block(&high_qc.block_hash)?.view;
+                // If `from_agg` then we always release the lock because the supermajority has a different high_qc.
+                if from_agg || new_high_qc_block.view > current_high_qc_view {
+                    self.high_qc = Some(new_high_qc);
+                }
+            }
+        }
+        // TODO: Download the missing blocks
+        self.update_view(new_high_qc_block.view);
+        Ok(())
+    }
+
+    fn aggregate_qc_from_indexes(
+        &self,
+        view: u64,
+        qcs: Vec<QuorumCertificate>,
+        signatures: &[Signature],
+        signers: Vec<u16>,
+    ) -> Result<AggregateQc> {
+        assert_eq!(qcs.len(), signatures.len());
+        assert_eq!(signatures.len(), signers.len());
+        Ok(AggregateQc {
+            signature: Signature::aggregate(signatures)?,
+            signers,
+            view,
+            qcs,
+        })
+    }
+
+    fn block_from_qc(
+        &self,
+        view: u64,
+        qc: QuorumCertificate,
+        parent_hash: Hash,
+        transactions: Vec<Hash>,
+    ) -> Block {
+        let digest = Hash::compute(&[
+            &view.to_be_bytes(),
+            qc.compute_hash().as_bytes(),
+            // hash of agg missing here intentionally
+            parent_hash.as_bytes(),
+            &self.state.root_hash().to_be_bytes(),
+        ]);
+        let signature = self.secret_key.sign(digest.as_bytes());
+        Block {
+            view,
+            qc,
+            agg: None,
+            hash: digest,
+            parent_hash,
+            signature,
+            state_root_hash: self.state.root_hash(),
+            transactions,
+        }
+    }
+
+    fn block_from_agg(
+        &self,
+        view: u64,
+        qc: QuorumCertificate,
+        agg: AggregateQc,
+        parent_hash: Hash,
+    ) -> Block {
+        let digest = Hash::compute(&[
+            &view.to_be_bytes(),
+            qc.compute_hash().as_bytes(),
+            agg.compute_hash().as_bytes(),
+            parent_hash.as_bytes(),
+            &self.state.root_hash().to_be_bytes(),
+        ]);
+        let signature = self.secret_key.sign(digest.as_bytes());
+        Block {
+            view,
+            qc,
+            agg: Some(agg),
+            hash: digest,
+            parent_hash,
+            signature,
+            state_root_hash: self.state.root_hash(),
+            transactions: vec![],
+        }
+    }
+
+    fn qc_from_bits(
+        &self,
+        block_hash: Hash,
+        signatures: &[Signature],
+        cosigned: BitVec,
+    ) -> QuorumCertificate {
+        // we've already verified the signatures upon receipt of the responses so there's no need to do it again
+        QuorumCertificate {
+            signature: Signature::aggregate(signatures).unwrap(),
+            cosigned,
+            block_hash,
+        }
+    }
+
+    fn block_extends_from(&self, block: &Block, ancestor: &Block) -> Result<bool> {
+        // todo: the block extends from another block through a chain of parent hashes and not qcs
+        let mut current = block;
+        while current.view > ancestor.view {
+            current = self.get_block(&current.parent_hash)?;
+        }
+        Ok(current.hash == ancestor.hash)
+    }
+
+    fn check_safe_block(&mut self, proposal: &Block) -> bool {
+        let Ok(qc_block) = self.get_block(&proposal.qc.block_hash) else { return false; };
+        // We don't vote on blocks older than our view
+        let not_outdated = proposal.view >= self.view;
+        match proposal.agg {
+            // we check elsewhere that qc is the highest among the qcs in the agg
+            Some(_) => match self.block_extends_from(proposal, qc_block) {
+                Ok(true) => {
+                    let block_hash = proposal.hash;
+                    self.check_and_commit(block_hash);
+                    not_outdated
+                }
+                Ok(false) | Err(_) => false,
+            },
+            None => {
+                if proposal.view == qc_block.view + 1 {
+                    self.check_and_commit(proposal.hash);
+                    not_outdated
+                } else {
+                    false
+                }
+            }
+        }
+    }
+
+    fn check_and_commit(&mut self, proposal_hash: Hash) {
+        let Ok(proposal) = self.get_block(&proposal_hash) else { return; };
+        let Ok(prev_1) = self.get_block(&proposal.qc.block_hash) else { return; };
+        let Ok(prev_2) = self.get_block(&prev_1.qc.block_hash) else { return; };
+
+        if prev_1.view == prev_2.view + 1 {
+            let committed_block = prev_2;
+            let Ok(finalized_block) = self.get_block(&self.finalized) else { return; };
+            let mut current = committed_block;
+            // commit blocks back to the last finalized block
+            while current.view > finalized_block.view {
+                let Ok(new) = self.get_block(&current.parent_hash) else { return; };
+                current = new;
+            }
+            if current.hash == self.finalized {
+                self.finalized = committed_block.hash;
+                // discard blocks that can't be committed anymore
+            }
+        }
+    }
+
+    pub fn add_block(&mut self, block: Block) {
+        trace!(?block.hash, "added block");
+        self.blocks.insert(block.hash, block);
+    }
+
+    fn vote_from_block(&self, block: &Block) -> Vote {
+        Vote {
+            block_hash: block.hash,
+            signature: self.secret_key.sign(block.hash.as_bytes()),
+            index: self.index(),
+        }
+    }
+
+    fn get_high_qc_from_block<'a>(&self, block: &'a Block) -> Result<&'a QuorumCertificate> {
+        let Some(agg) = &block.agg else { return Ok(&block.qc); };
+
+        let high_qc = self.get_highest_from_agg(agg)?;
+
+        if &block.qc != high_qc {
+            return Err(anyhow!("qc mismatch"));
+        }
+
+        Ok(&block.qc)
+    }
+
+    pub fn get_block(&self, key: &Hash) -> Result<&Block> {
+        self.blocks
+            .get(key)
+            .ok_or_else(|| anyhow!("block not found: {key:?}"))
+    }
+
+    pub fn get_block_by_view(&self, view: u64) -> Option<&Block> {
+        // TODO: Inefficient - Use an index.
+        self.blocks.values().find(|b| b.view == view)
+    }
+
+    pub fn view(&self) -> u64 {
+        self.view
+    }
+
+    pub fn state(&self) -> &State {
+        &self.state
+    }
+
+    fn get_highest_from_agg<'a>(&self, agg: &'a AggregateQc) -> Result<&'a QuorumCertificate> {
+        agg.qcs
+            .iter()
+            .map(|qc| (qc, self.get_block(&qc.block_hash)))
+            .try_fold(None, |acc, (qc, block)| {
+                if let Some((_, acc_view)) = acc {
+                    let block = block?;
+                    if acc_view < block.view {
+                        Ok::<_, anyhow::Error>(Some((qc, block.view)))
+                    } else {
+                        Ok(acc)
+                    }
+                } else {
+                    Ok(Some((qc, block?.view)))
+                }
+            })?
+            .ok_or_else(|| anyhow!("no qcs in agg"))
+            .map(|(qc, _)| qc)
+    }
+
+    fn verify_qc_signature(&self, _: &QuorumCertificate) -> Result<()> {
+        // TODO: Build aggregate signature from public keys and validate `qc.block_hash` against `qc.signature`.
+        Ok(())
+    }
+
+    fn batch_verify_agg_signature(&self, agg: &AggregateQc) -> Result<()> {
+        let messages: Vec<_> = agg
+            .qcs
+            .iter()
+            .enumerate()
+            .map(|(i, qc)| {
+                let mut bytes = Vec::new();
+                bytes.extend_from_slice(qc.compute_hash().as_bytes());
+                bytes.extend_from_slice(&agg.signers[i].to_be_bytes());
+                bytes.extend_from_slice(&agg.view.to_be_bytes());
+                bytes
+            })
+            .collect();
+        let messages: Vec<_> = messages.iter().map(|m| m.as_slice()).collect();
+
+        let public_keys: Vec<_> = agg
+            .signers
+            .iter()
+            .map(|i| self.committee[*i as usize].public_key)
+            .collect();
+
+        verify_messages(agg.signature, &messages, &public_keys)
+    }
+
+    fn new_view_from_qc(&self, qc: &QuorumCertificate) -> NewView {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(qc.compute_hash().as_bytes());
+        bytes.extend_from_slice(&self.index().to_be_bytes());
+        bytes.extend_from_slice(&self.view.to_be_bytes());
+
+        NewView {
+            signature: self.secret_key.sign(&bytes),
+            qc: qc.clone(),
+            view: self.view,
+            index: self.index(),
+        }
+    }
+
+    fn get_leader(&self, view: u64) -> Validator {
+        // currently it's a simple round robin but later
+        // we will select the leader based on the weights
+        self.committee[(view % (self.committee.len() as u64)) as usize]
+    }
+
+    fn get_member(&self, index: u16) -> Validator {
+        self.committee[index as usize]
+    }
+
+    fn committee_weight(&self) -> u128 {
+        self.committee.iter().map(|v| v.weight).sum()
+    }
+
+    fn check_quorum_in_bits(&self, cosigned: &BitSlice) -> Result<()> {
+        let cosigned_sum: u128 = self
+            .committee
+            .iter()
+            .enumerate()
+            .map(|(i, v)| if cosigned[i] { v.weight } else { 0 })
+            .sum();
+
+        if cosigned_sum * 3 <= self.committee_weight() * 2 {
+            return Err(anyhow!("no quorum"));
+        }
+
+        Ok(())
+    }
+
+    fn check_quorum_in_indices(&self, signers: &[u16]) -> Result<()> {
+        let signed_sum: u128 = signers
+            .iter()
+            .map(|i| self.committee[*i as usize].weight)
+            .sum();
+
+        if signed_sum * 3 <= self.committee_weight() * 2 {
+            return Err(anyhow!("no quorum"));
+        }
+
+        Ok(())
+    }
+
+    /// My own index within the committee.
+    fn index(&self) -> u16 {
+        self.committee
+            .iter()
+            .find_position(|v| v.public_key == self.secret_key.public_key())
+            .expect("node should be in committee")
+            .0 as u16
+    }
+}

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -9,7 +9,10 @@ use evm::{
 use primitive_types::{H160, H256, U256};
 use tracing::info;
 
-use crate::state::{Address, NewTransaction, State, Transaction};
+use crate::{
+    crypto,
+    state::{Address, NewTransaction, State, Transaction},
+};
 
 pub struct CallContext<'a> {
     state: &'a State,
@@ -38,7 +41,11 @@ impl State {
         StackExecutor::new_with_precompiles(stack_state, &CONFIG, &())
     }
 
-    pub fn apply_transaction(&mut self, txn: NewTransaction) -> Result<Transaction> {
+    pub fn apply_transaction(
+        &mut self,
+        txn: NewTransaction,
+        block_hash: crypto::Hash,
+    ) -> Result<Transaction> {
         let context = self.call_context(txn.gas_price.into(), txn.from_addr.0);
         let mut executor = self.executor(&context, txn.gas_limit);
 
@@ -150,6 +157,7 @@ impl State {
             contract_address: contract_address.map(Address),
             amount: txn.amount,
             payload: txn.payload,
+            block_hash,
         };
 
         info!(?logs, "transaction processed");

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api;
 pub mod cfg;
+pub mod consensus;
 pub mod crypto;
 mod exec;
 pub mod message;

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -66,6 +66,7 @@ impl Message {
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct QuorumCertificate {
+    /// An aggregated signature from `n - f` distinct replicas, built by signing a block hash in a specific view.
     pub signature: Signature,
     pub cosigned: BitVec,
     pub block_hash: Hash,
@@ -81,6 +82,7 @@ impl QuorumCertificate {
     }
 }
 
+/// A collection of `n - f` [QuorumCertificate]s.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AggregateQc {
     pub signature: Signature,
@@ -113,7 +115,11 @@ impl AggregateQc {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Block {
     pub view: u64, // the proposer's index can be derived from the block's view
+    /// A block's quorum certificate (QC) is proof that more than `2n/3` nodes (out of `n`) have voted for this block.
+    /// It also includes a pointer to the parent block.
     pub qc: QuorumCertificate,
+    /// The block will include an [AggregateQc] if the previous leader failed, meaning we couldn't construct a QC. When
+    /// this is not `None`, `qc` will contain a clone of the highest QC within this [AggregateQc];
     pub agg: Option<AggregateQc>,
     pub hash: Hash,
     pub parent_hash: Hash,

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -111,6 +111,7 @@ pub struct Transaction {
     pub contract_address: Option<Address>,
     pub amount: u128,
     pub payload: Vec<u8>,
+    pub block_hash: crypto::Hash,
 }
 
 impl Transaction {


### PR DESCRIPTION
Instead, we add a new `Consensus` struct which stores the state and logic and `Node` contains a `Consensus`.

Originally, I was hoping to keep the complexity of `Consensus` down by only including the direct consensus protocol and omitting state and transaction execution.

However, having experiemented a bit, I feel like these elements are too heavily integrated with consensus to make their separation feasible. Therefore, `Consensus` also holds the `State` and is responsible for calling `State::apply_transaction`, etc.

I have further plans to refactor the consensus, but I think it makes sense to merge this first and raise further PRs for subsequent changes.