### PR TITLE
Export `rpc.server.duration` metric via OpenTelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "axum"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13d8068b6ccb8b34db9de397c7043f91db8b4c66414952c6db944f238c4d3db3"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,10 +1821,23 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2536,6 +2594,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
+name = "matchit"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b87248edafb776e59e6ee64a79086f65890d3510f2c656c000bf2a7e8a0aea40"
+
+[[package]]
 name = "md-5"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +2631,12 @@ checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -2853,6 +2923,112 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opentelemetry"
+version = "0.19.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.8.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry_api",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.12.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-util",
+ "http",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.2.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "futures",
+ "futures-util",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.11.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.19.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "fnv",
+ "futures-channel",
+ "futures-util",
+ "indexmap",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.19.0"
+source = "git+https://github.com/open-telemetry/opentelemetry-rust?rev=ecf0dda5686dc45470ae02993a4748c289c407de#ecf0dda5686dc45470ae02993a4748c289c407de"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "once_cell",
+ "opentelemetry_api",
+ "ordered-float",
+ "percent-encoding",
+ "rand 0.8.5",
+ "regex",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a384337e997e6860ffbaa83708b2ef329fd8c54cb67a5f64d421e0f943254f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -3664,6 +3840,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+
+[[package]]
 name = "rw-stream-sink"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4066,6 +4248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4237,6 +4425,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,11 +4515,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64 0.21.0",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4590,6 +4825,12 @@ dependencies = [
  "idna 0.3.0",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "uuid"
@@ -5372,6 +5613,8 @@ dependencies = [
  "jsonrpsee",
  "k256",
  "libp2p",
+ "opentelemetry",
+ "opentelemetry-otlp",
  "primitive-types",
  "rand 0.8.5",
  "rand_core 0.6.4",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,11 +3,13 @@ services:
   node0:
     environment:
       RUST_BACKTRACE: 1
-      RUST_LOG: zilliqa=info
+      RUST_LOG: zilliqa=info,opentelemetry=trace,opentelemetry_otlp=trace
     build:
       context: .
       dockerfile: Dockerfile
     container_name: zilliqanode0
+    volumes:
+      - "./infra/config.toml:/config.toml"
     command:
       - /zilliqa
       - 65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227
@@ -20,6 +22,8 @@ services:
       RUST_LOG: zilliqa=info
     container_name: zilliqanode1
     image: zq2-node0
+    volumes:
+      - "./infra/config.toml:/config.toml"
     command:
       - /zilliqa
       - 62070b1a3b5b30236e43b4f1bfd617e1af7474635558314d46127a708b9d302e
@@ -30,6 +34,8 @@ services:
       RUST_LOG: zilliqa=info
     container_name: zilliqanode2
     image: zq2-node0
+    volumes:
+      - "./infra/config.toml:/config.toml"
     command:
       - /zilliqa
       - 56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364
@@ -40,6 +46,31 @@ services:
       RUST_LOG: zilliqa=info
     container_name: zilliqanode3
     image: zq2-node0
+    volumes:
+      - "./infra/config.toml:/config.toml"
     command:
       - /zilliqa
       - db670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a
+
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./infra/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+  mimir:
+    image: grafana/mimir:latest
+    volumes:
+      - "./infra/mimir.yaml:/etc/mimir/config.yaml"
+    command:
+      - "./mimir"
+      - "--config.file"
+      - "/etc/mimir/config.yaml"
+    ports:
+      - "9009:9009"
+  grafana:
+    image: grafana/grafana-oss:latest
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    ports:
+      - "3000:3000"

--- a/infra/config.toml
+++ b/infra/config.toml
@@ -1,0 +1,1 @@
+otlp_collector_endpoint = "http://otel-collector:4317"

--- a/infra/mimir.yaml
+++ b/infra/mimir.yaml
@@ -1,0 +1,45 @@
+usage_stats:
+  enabled: false
+
+multitenancy_enabled: false
+
+blocks_storage:
+  backend: filesystem
+  bucket_store:
+    sync_dir: /tmp/mimir/tsdb-sync
+  filesystem:
+    dir: /tmp/mimir/data/tsdb
+  tsdb:
+    dir: /tmp/mimir/tsdb
+
+compactor:
+  data_dir: /tmp/mimir/compactor
+  sharding_ring:
+    kvstore:
+      store: memberlist
+
+distributor:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+
+ingester:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+ruler_storage:
+  backend: filesystem
+  filesystem:
+    dir: /tmp/mimir/rules
+
+server:
+  http_listen_port: 9009
+  log_level: error
+
+store_gateway:
+  sharding_ring:
+    replication_factor: 1

--- a/infra/otel-collector-config.yaml
+++ b/infra/otel-collector-config.yaml
@@ -1,0 +1,18 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  prometheusremotewrite:
+    endpoint: "http://mimir:9009/api/v1/push"
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: []
+      exporters: [prometheusremotewrite]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -29,6 +29,9 @@ itertools = "0.10.5"
 jsonrpsee = { version = "0.18.1", features = ["server"] }
 k256 = "0.13.1"
 libp2p = { version = "0.51.0", features = ["gossipsub", "macros", "tcp", "tokio", "noise", "mplex", "mdns", "request-response", "kad", "identify"] }
+# TODO: Use "0.20.0" when released
+opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "ecf0dda5686dc45470ae02993a4748c289c407de", features = ["metrics", "rt-tokio"] }
+opentelemetry-otlp = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "ecf0dda5686dc45470ae02993a4748c289c407de", features = ["metrics", "http-proto"] }
 primitive-types = { version = "0.12.1", features = ["serde"] }
 rand = "0.8.5"
 rand_core = "0.6.4"

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     /// The port to listen for P2P messages on. Optional - If not provided a random port will be used.
     pub p2p_port: Option<u16>,
@@ -9,6 +10,8 @@ pub struct Config {
     pub json_rpc_port: u16,
     #[serde(default = "default_eth_chain_id")]
     pub eth_chain_id: u64,
+    /// The base address of the OTLP collector. If not set, metrics will not be exported.
+    pub otlp_collector_endpoint: Option<String>,
 }
 
 fn default_json_rpc_port() -> u16 {


### PR DESCRIPTION
The metric and its attributes aim to follow the OpenTelemetry semantic versions, as documented at:
https://github.com/open-telemetry/semantic-conventions/blob/main/specification/metrics/semantic_conventions/rpc-metrics.md#rpc-server

This also adds the infrastructure for instrumenting other bits of the code with OTel metrics.

We also add an OTel collector, Mimir and Grafana to `docker-compose.yaml`, so developers should get a mostly working instrumentation stack by default.
