### PR TITLE
Terminate node when a SIGINT or SIGTERM is received

### DIFF
--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -37,7 +37,7 @@ serde = { version = "1.0.163", features = ["derive"] }
 serde_json = "1.0.96"
 sha2 = "0.10.6"
 sha3 = "0.10.8"
-tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread", "sync"] }
+tokio = { version = "1.28.1", features = ["macros", "rt-multi-thread", "signal", "sync"] }
 tokio-stream = "0.1.14"
 toml = "0.7.3"
 tower = "0.4.13"


### PR DESCRIPTION
Resolves #137.

Note that `signal::unix` means we now only build on Unix machines. I think this is fine - If its a problem we can quite easily conditionalise the handler for this signal.