### PR TITLE
Support returning full blocks from `eth_getBlockBy*`

### DIFF
--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -8,46 +8,53 @@ use crate::message;
 
 use super::to_hex::ToHex;
 
+#[derive(Clone, Serialize)]
+#[serde(untagged)]
+pub enum HashOrTransaction {
+    Hash(H256),
+    Transaction(EthTransaction),
+}
+
 /// A block object, returned by the Ethereum API.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EthBlock {
     #[serde(serialize_with = "hex")]
-    number: u64,
+    pub number: u64,
     #[serde(serialize_with = "hex")]
-    hash: H256,
+    pub hash: H256,
     #[serde(serialize_with = "hex")]
-    parent_hash: H256,
+    pub parent_hash: H256,
     #[serde(serialize_with = "hex")]
-    nonce: u64,
+    pub nonce: u64,
     #[serde(serialize_with = "hex")]
-    sha_3_uncles: H256,
+    pub sha_3_uncles: H256,
     #[serde(serialize_with = "hex")]
-    logs_bloom: [u8; 256],
+    pub logs_bloom: [u8; 256],
     #[serde(serialize_with = "hex")]
-    transactions_root: H256,
+    pub transactions_root: H256,
     #[serde(serialize_with = "hex")]
-    state_root: H256,
+    pub state_root: H256,
     #[serde(serialize_with = "hex")]
-    receipts_root: H256,
+    pub receipts_root: H256,
     #[serde(serialize_with = "hex")]
-    miner: H160,
+    pub miner: H160,
     #[serde(serialize_with = "hex")]
-    difficulty: u64,
+    pub difficulty: u64,
     #[serde(serialize_with = "hex")]
-    total_difficulty: u64,
+    pub total_difficulty: u64,
     #[serde(serialize_with = "hex")]
-    extra_data: Vec<u8>,
+    pub extra_data: Vec<u8>,
     #[serde(serialize_with = "hex")]
-    size: u64,
+    pub size: u64,
     #[serde(serialize_with = "hex")]
-    gas_limit: u64,
+    pub gas_limit: u64,
     #[serde(serialize_with = "hex")]
-    gas_used: u64,
+    pub gas_used: u64,
     #[serde(serialize_with = "hex")]
-    timestamp: u64,
-    transactions: Vec<H256>,
-    uncles: Vec<H256>,
+    pub timestamp: u64,
+    pub transactions: Vec<HashOrTransaction>,
+    pub uncles: Vec<H256>,
 }
 
 impl From<&message::Block> for EthBlock {
@@ -71,7 +78,11 @@ impl From<&message::Block> for EthBlock {
             gas_limit: 0,
             gas_used: 0,
             timestamp: 0,
-            transactions: block.transactions.iter().map(|h| H256(h.0)).collect(),
+            transactions: block
+                .transactions
+                .iter()
+                .map(|h| HashOrTransaction::Hash(H256(h.0)))
+                .collect(),
             uncles: vec![],
         }
     }


### PR DESCRIPTION
When the `full` parameter is `false`, the returned block just contains the transaction hashes. When it is `true`, the returned block contains the full transactions.