### PR TITLE
Default `to` field to zero address in `eth_call`

### DIFF
--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -172,6 +172,10 @@ fn bool_as_int<S: Serializer>(b: &bool, serializer: S) -> Result<S::Ok, S::Error
 /// Parameters passed to `eth_call`.
 #[derive(Deserialize)]
 pub struct CallParams {
+    // The documentation states that the `to` field is required, but some clients (notably Ethers.js) omit it for
+    // contract creations, where the `to` address is zero. Therefore, we default to the zero address if `to` is
+    // omitted.
+    #[serde(default)]
     pub to: H160,
     #[serde(deserialize_with = "deserialize_data")]
     pub data: Vec<u8>,


### PR DESCRIPTION
As mentioned in the comment, Ethers.js omits the field when calling `eth_call` for a contract creation.