### PR TITLE
Return empty response from `eth_call` to non-contract address

### DIFF
--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -167,6 +167,11 @@ impl State {
 
     pub fn call_contract(&self, contract: Address, data: Vec<u8>) -> Result<Vec<u8>> {
         let context = self.call_context(U256::zero(), H160::zero());
+
+        if context.code(contract.0).is_empty() {
+            return Ok(vec![]);
+        }
+
         let mut executor = self.executor(&context, u64::MAX);
 
         let context = Context {


### PR DESCRIPTION
I copied this behaviour from Zilliqa 1. I haven't tried any other Ethereum implementations, but based on client behaviour, this appears to be the right thing.

I think this is the cause of #136 too, so this commit closes #136.