### PR TITLE
Fix `eth_getBlockByNumber` with `"latest"` parameter

### DIFF
--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -125,7 +125,7 @@ impl Node {
     }
 
     pub fn get_latest_block(&self) -> Option<&Block> {
-        self.get_block_by_view(self.consensus.view())
+        self.get_block_by_view(self.consensus.view() - 1)
     }
 
     pub fn get_block_by_view(&self, view: u64) -> Option<&Block> {


### PR DESCRIPTION
`Consensus::view()` tells us the view of the _next_ block, so to return the latest block, we need to return the block at `Consensus::view() - 1`.
