### PR TITLE
Implement `web3_clientVersion`

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -93,6 +93,7 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     method!("eth_getTransactionReceipt", get_transaction_receipt);
     method!("eth_sendRawTransaction", send_raw_transaction);
     method!("net_version", version);
+    method!("web3_clientVersion", client_version);
 
     module
 }
@@ -265,6 +266,11 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
 
 fn version(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     Ok(node.lock().unwrap().config.eth_chain_id.to_string())
+}
+
+fn client_version(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
+    // Format: "<name>/<version>"
+    Ok(concat!("zilliqa2/v", env!("CARGO_PKG_VERSION")))
 }
 
 /// Decode a transaction from its RLP-encoded form.


### PR DESCRIPTION
We return the version in the format `zilliqa2/v<VERSION>`, where `VERSION` is obtained from the current version of the `zilliqa` crate.