### PR TITLE
Fix double-execution of transactions and simplify execution logic

### DIFF
--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -106,7 +106,6 @@ impl Node {
 
     pub fn create_transaction(&mut self, txn: NewTransaction) -> Result<Hash> {
         let hash = txn.hash();
-        self.consensus.create_transaction(&txn)?;
         self.broadcast_message(Message::NewTransaction(txn))?;
 
         Ok(hash)


### PR DESCRIPTION
Previously, we would execute transactions against our state both when forming and proposing a block and also when voting on the same block.

Instead, we remove the transaction from `new_transactions` whenever it is executed, guaranteeing we will only execute it once.

There are probably problems here if a node proposes a block, but the network does a view change and does not accept the block. In this case, the node may need to rollback its state changes, but I am deferring these problems for later.

Also, we remove the `pending_tranasctions` list from `Consensus`, because it was basically redundant with the list of keys in `new_transactions` anyway. When constructing a block to propose, we just use everything in `new_transactions`. This contains all transactions we've been broadcasted, but haven't yet executed.

This also nicely resolves https://github.com/Zilliqa/zq2/issues/82 since all nodes should have the same list of `new_transactions` (ignoring latency of transaction broadcasts).