### PR TITLE
Fix block hash stored in transactions

### DIFF
--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -115,6 +115,24 @@ pub struct Transaction {
 }
 
 impl Transaction {
+    pub fn new(
+        new_transaction: NewTransaction,
+        contract_address: Option<Address>,
+        block_hash: crypto::Hash,
+    ) -> Self {
+        Transaction {
+            nonce: new_transaction.nonce,
+            gas_price: new_transaction.gas_price,
+            gas_limit: new_transaction.gas_limit,
+            from_addr: new_transaction.from_addr,
+            to_addr: new_transaction.to_addr,
+            contract_address,
+            amount: new_transaction.amount,
+            payload: new_transaction.payload,
+            block_hash,
+        }
+    }
+
     pub fn hash(&self) -> crypto::Hash {
         crypto::Hash::compute(&[
             &self.nonce.to_be_bytes(),


### PR DESCRIPTION
In #143, we made sure transactions were included in the block that said they included them. However, we did not change the block hash that is stored in each transaction. This meant that the block hash was invalid and pointed to the parent block.

In order to fix this, we restructure things slightly to defer the construction of `Transaction` until all the `NewTransaction`s in a block have been executed. At this point we know the block hash and so can construct the `Transaction`.