### PR TITLE
Increase gossipsub maximum transmission size

### DIFF
--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -167,6 +167,7 @@ impl NodeLauncher {
             gossipsub: gossipsub::Behaviour::new(
                 MessageAuthenticity::Signed(key_pair.clone()),
                 gossipsub::ConfigBuilder::default()
+                    .max_transmit_size(524288)
                     .build()
                     .map_err(|e| anyhow!(e))?,
             )


### PR DESCRIPTION
This is required to distribute some contract-creation transactions with reasonably large contracts. We may be able to decrease this again, once we start using a leaner encoding for our network messages (currently we're using JSON).