### PR TITLE
Normalise transaction storage in `Consensus`

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -219,8 +219,8 @@ fn convert_block(node: &Arc<Mutex<Node>>, block: &Block, full: bool) -> Result<E
             .map(|h| {
                 node.lock()
                     .unwrap()
-                    .get_transaction_by_hash(h.hash())
-                    .ok_or_else(|| anyhow!("missing transaction: {}", h.hash()))
+                    .get_transaction_by_hash(*h)
+                    .ok_or_else(|| anyhow!("missing transaction: {}", h))
             })
             .map(|t| Ok(HashOrTransaction::Transaction(t?)))
             .collect::<Result<_>>()?;

--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -81,7 +81,7 @@ impl From<&message::Block> for EthBlock {
             transactions: block
                 .transactions
                 .iter()
-                .map(|h| HashOrTransaction::Hash(H256(h.hash().0)))
+                .map(|h| HashOrTransaction::Hash(H256(h.0)))
                 .collect(),
             uncles: vec![],
         }

--- a/zilliqa/tests/manual_consensus/mod.rs
+++ b/zilliqa/tests/manual_consensus/mod.rs
@@ -4,7 +4,6 @@ use zilliqa::crypto::Hash;
 use zilliqa::crypto::SecretKey;
 use zilliqa::message::Block;
 use zilliqa::message::Message;
-use zilliqa::message::Proposal;
 use zilliqa::message::Vote;
 use zilliqa::node_launcher::NodeLauncher;
 use zilliqa::state::Transaction;
@@ -162,15 +161,12 @@ impl ManualConsensus {
 
         let (_peer_id, proposal_message) = nodes[leader_idx].message_receiver.next().await.unwrap();
         let block = match proposal_message.clone() {
-            Message::Proposal(Proposal { block }) => {
+            Message::Proposal(p) => {
                 // TODO: potentially add more assertions on the state here?
+                let (block, transactions) = p.into_parts();
                 assert_eq!(block.view(), new_view);
                 assert_eq!(block.parent_hash(), current_hash);
-                let block_tx_hashes = block
-                    .transactions
-                    .iter()
-                    .map(|tx| tx.hash())
-                    .collect::<Vec<_>>();
+                let block_tx_hashes = transactions.iter().map(|tx| tx.hash()).collect::<Vec<_>>();
                 for hash in tx_hashes {
                     assert!(block_tx_hashes.contains(&hash));
                 }


### PR DESCRIPTION
We remove the duplication of committed `Transaction`s in `blocks` and in `transactions`, by removing the full `Transaction` from `Block` and instead just storing the hash.

We still want to keep the work of #157 which ensures we distribute full transactions with each block proposal, so we slightly alter the `Proposal` message to effectively be a `Block` plus a list of `Transactions`.