### PR TITLE
Implement `Default` for `Config`

### DIFF
--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -48,11 +48,7 @@ async fn main() -> Result<()> {
     };
     let config: Config = toml::from_str(&config)?;
 
-    let p2p_port = if let Some(port) = config.p2p_port {
-        port
-    } else {
-        0
-    };
+    let p2p_port = config.p2p_port;
     if let Some(endpoint) = &config.otlp_collector_endpoint {
         let export_config = ExportConfig {
             endpoint: endpoint.clone(),

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -3,30 +3,27 @@ use std::time::Duration;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
+#[serde(default, deny_unknown_fields)]
 pub struct Config {
     /// The port to listen for P2P messages on. Optional - If not provided a random port will be used.
-    pub p2p_port: Option<u16>,
+    pub p2p_port: u16,
     /// The port to listen for JSON-RPC requests on. Defaults to 4201.
-    #[serde(default = "default_json_rpc_port")]
     pub json_rpc_port: u16,
-    #[serde(default = "default_eth_chain_id")]
     pub eth_chain_id: u64,
     /// The base address of the OTLP collector. If not set, metrics will not be exported.
     pub otlp_collector_endpoint: Option<String>,
     /// The maximum duration between a recieved block's timestamp and the current time. Defaults to 10 seconds.
-    #[serde(default = "default_allowed_timestamp_skew")]
     pub allowed_timestamp_skew: Duration,
 }
 
-fn default_json_rpc_port() -> u16 {
-    4201
-}
-
-fn default_eth_chain_id() -> u64 {
-    1 + 0x8000
-}
-
-fn default_allowed_timestamp_skew() -> Duration {
-    Duration::from_secs(10)
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            p2p_port: 0,
+            json_rpc_port: 4201,
+            eth_chain_id: 1 + 0x8000,
+            otlp_collector_endpoint: None,
+            allowed_timestamp_skew: Duration::from_secs(10),
+        }
+    }
 }


### PR DESCRIPTION
This makes it easier to manually construct `Config` with default values (e.g. from tests).