### PR TITLE
Make block production test deterministic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5641,6 +5641,7 @@ dependencies = [
  "bls12_381",
  "clap",
  "evm",
+ "futures",
  "generic-array",
  "hex",
  "http",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -22,6 +22,7 @@ bls-signatures = "0.14.0"
 bls12_381 = "0.8.0"
 clap = { version = "4.3.0", features = ["derive"] }
 evm = { version = "0.37.0", features = ["tracing"] }
+futures = "0.3.28"
 generic-array = "0.14.7"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.9"


### PR DESCRIPTION
We do this by removing the networking/libp2p layers and instead exercising `Node` directly. The test function constructs a list of nodes and manages a message stream from each of them. It probably makes sense to factor this into a test harness at some point soon, if we want to add more of these kind of tests.

Resolves #159.