### PR TITLE
Handle logs from EVM executions

### DIFF
--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,5 +1,4 @@
 pub mod eth;
 mod to_hex;
+mod types;
 pub mod zilliqa;
-// TODO(#78): Don't leak Eth-specific types from this module. All we should need to expose is `{eth,zilliqa}::rpc_module`.
-pub mod types;

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -79,7 +79,6 @@ pub struct Transaction {
     pub gas_limit: u64,
     pub from_addr: Address,
     pub to_addr: Address,
-    pub contract_address: Option<Address>,
     pub amount: u128,
     pub payload: Vec<u8>,
 }
@@ -96,4 +95,19 @@ impl Transaction {
             &self.payload,
         ])
     }
+}
+
+/// A transaction receipt stores data about the execution of a transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransactionReceipt {
+    pub block_hash: crypto::Hash,
+    pub contract_address: Option<Address>,
+    pub logs: Vec<Log>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Log {
+    pub address: Address,
+    pub topics: Vec<H256>,
+    pub data: Vec<u8>,
 }

--- a/zilliqa/tests/consensus_tests.rs
+++ b/zilliqa/tests/consensus_tests.rs
@@ -91,7 +91,6 @@ async fn test_manual_transaction_submission() {
         nonce: 0,
         gas_price: 0,
         gas_limit: 1,
-        contract_address: None,
         from_addr: Address::DEPLOY_CONTRACT,
         to_addr: Address::DEPLOY_CONTRACT,
         amount: 0,

--- a/zilliqa/tests/manual_consensus/mod.rs
+++ b/zilliqa/tests/manual_consensus/mod.rs
@@ -127,7 +127,6 @@ impl ManualConsensus {
                     nonce,
                     gas_price,
                     gas_limit,
-                    contract_address: _, // TODO: unvalidated
                     from_addr,
                     to_addr,
                     amount,


### PR DESCRIPTION
When a contract execution produces logs, we retain them and return them in the `eth_` APIs.

I have introduced the concept of `TransactionReceipt`s for storing data about `Transaction`s which is not known until after they have been executed. I moved the `block_hash` and `contract_address` into the receipt, as well as the list of `Log`s.

I also did a bit of cleanup to remove specific types that are specific to the Ethereum API from `Node`, so this commit also resolves #78.