### PR TITLE
Store transaction success status in receipts

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -323,7 +323,7 @@ fn get_transaction_receipt(
         logs,
         logs_bloom,
         ty: 0,
-        status: true,
+        status: receipt.success,
     };
 
     Ok(Some(receipt))

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -101,6 +101,7 @@ impl Transaction {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TransactionReceipt {
     pub block_hash: crypto::Hash,
+    pub success: bool,
     pub contract_address: Option<Address>,
     pub logs: Vec<Log>,
 }


### PR DESCRIPTION
We add a `success: bool` field to `TransactionReceipt` to indicate whether the transaction succeeded or not. Failed transactions are still committed to the blockchain, but they do not change any state.