### PR TITLE
Execute `eth_call` in non-static mode

### DIFF
--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -198,7 +198,7 @@ impl State {
             caller: H160::zero(),
             apparent_value: U256::zero(),
         };
-        let call = executor.call(contract.0, None, data, None, true, context);
+        let call = executor.call(contract.0, None, data, None, false, context);
         let (reason, data) = match call {
             Capture::Exit(e) => e,
             Capture::Trap(i) => match i {},


### PR DESCRIPTION
Originally I thought we should set `is_static` to `true` to avoid state updates from `eth_call`. However, state updates only apply after execution anyway and we don't perform them for `eth_call`. Therefore, we can happily set `is_static` to `false` which allows callers to execute and get the return value of state-mutating transactions, without actually mutating state.