### PR TITLE
Update Rust version in Dockerfile to 1.69.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.67.1-slim-bullseye as builder
+FROM rust:1.69.0-slim-bullseye as builder
 
 RUN apt update -y && \
     apt upgrade -y && \


### PR DESCRIPTION
This makes builds faster because the `cargo build` call doesn't need to download Rust 1.69.0.