### PR TITLE
Remove code duplication for transaction application in `Consensus`

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -12,8 +12,11 @@ use tracing::{debug, trace};
 use crate::{
     cfg::Config,
     crypto::{verify_messages, Hash, PublicKey, SecretKey, Signature},
-    message::{AggregateQc, BitSlice, BitVec, Block, NewView, Proposal, QuorumCertificate, Vote},
-    state::{State, Transaction, TransactionReceipt},
+    message::{
+        AggregateQc, BitSlice, BitVec, Block, BlockHeader, NewView, Proposal, QuorumCertificate,
+        Vote,
+    },
+    state::{Address, Log, State, Transaction, TransactionReceipt},
 };
 
 struct NewViewVote {
@@ -204,18 +207,9 @@ impl Consensus {
         let proposal_view = block.view();
         if self.check_safe_block(&block) {
             for txn in &transactions {
-                // If we have the transaction in the mempool, remove it
-                self.new_transactions.remove(&txn.hash());
-
-                // If we haven't applied it yet, do so
-                // This ensures we don't execute the transaction twice if we're the block proposer
-                if let Entry::Vacant(entry) = self.transactions.entry(txn.hash()) {
-                    let (success, contract_address, logs) = self.state.apply_transaction(
-                        txn.clone(),
-                        self.config.eth_chain_id,
-                        parent_header,
-                    )?;
-                    entry.insert(txn.clone());
+                if let Some((success, contract_address, logs)) =
+                    self.apply_transaction(txn.clone(), parent_header)?
+                {
                     let receipt = TransactionReceipt {
                         block_hash: block.hash(),
                         success,
@@ -239,6 +233,29 @@ impl Consensus {
             let vote = self.vote_from_block(&block);
 
             Ok(Some((leader, vote)))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn apply_transaction(
+        &mut self,
+        txn: Transaction,
+        current_block: BlockHeader,
+    ) -> Result<Option<(bool, Option<Address>, Vec<Log>)>> {
+        // If we have the transaction in the mempool, remove it.
+        self.new_transactions.remove(&txn.hash());
+
+        // If we haven't applied the transaction yet, do so. This ensures we don't execute the transaction twice if we
+        // already executed it in the process of proposing this block.
+        if let Entry::Vacant(entry) = self.transactions.entry(txn.hash()) {
+            let result = self.state.apply_transaction(
+                txn.clone(),
+                self.config.eth_chain_id,
+                current_block,
+            )?;
+            entry.insert(txn);
+            Ok(Some(result))
         } else {
             Ok(None)
         }
@@ -293,19 +310,19 @@ impl Consensus {
                 let parent = self.get_block(&parent_hash)?;
                 let parent_header = parent.header;
 
-                let applied_transactions: Vec<_> = self
-                    .new_transactions
-                    .values()
-                    .map(|tx| {
-                        let (success, contract_address, logs) = self.state.apply_transaction(
-                            tx.clone(),
-                            self.config.eth_chain_id,
-                            parent_header,
-                        )?;
-                        Ok((tx.clone(), success, contract_address, logs))
+                let applied_transactions: Vec<_> =
+                    self.new_transactions.values().cloned().collect();
+                let applied_transactions: Vec<_> = applied_transactions
+                    .into_iter()
+                    .filter_map(|tx| {
+                        let result = self.apply_transaction(tx.clone(), parent_header);
+                        result.transpose().map(|r| {
+                            r.map(|(success, contract_address, logs)| {
+                                (tx.clone(), success, contract_address, logs)
+                            })
+                        })
                     })
                     .collect::<Result<_>>()?;
-                self.new_transactions.clear();
                 let applied_transaction_hashes: Vec<_> = applied_transactions
                     .iter()
                     .map(|(tx, _, _, _)| tx.hash())


### PR DESCRIPTION
We need to apply transactions to state both when proposing a block and when voting on a proposed block. We add an internal method to handle both of these cases.