### PR TITLE
Add `hash` to Eth transaction response

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -252,6 +252,7 @@ fn get_transaction_inner(hash: Hash, node: &Arc<Mutex<Node>>) -> Result<Option<E
         from: transaction.from_addr.0,
         gas: 0,
         gas_price: transaction.gas_price as u64,
+        hash: H256(hash.0),
         input: transaction.payload.clone(),
         nonce: transaction.nonce,
         // `to` should be `None` if `transaction` is a contract creation.

--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -105,6 +105,8 @@ pub struct EthTransaction {
     #[serde(serialize_with = "hex")]
     pub gas_price: u64,
     #[serde(serialize_with = "hex")]
+    pub hash: H256,
+    #[serde(serialize_with = "hex")]
     pub input: Vec<u8>,
     #[serde(serialize_with = "hex")]
     pub nonce: u64,


### PR DESCRIPTION
This is documented in
https://ethereum.org/en/developers/docs/apis/json-rpc/#eth_gettransactionbyhash

I must have just missed it :(