### PR TITLE
Return timestamp in Eth block response

### DIFF
--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -1,3 +1,5 @@
+use std::time::SystemTime;
+
 use primitive_types::{H160, H256};
 use serde::{
     de::{self, Unexpected},
@@ -79,7 +81,11 @@ impl From<&message::Block> for EthBlock {
             size: 0,
             gas_limit: 0,
             gas_used: 0,
-            timestamp: 0,
+            timestamp: block
+                .timestamp()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs(),
             transactions: block
                 .transactions
                 .iter()


### PR DESCRIPTION
Blocks have a timestamp thanks to #153, so we can now return them from `eth_getBlockBy*`.