### PR TITLE
Fix double-increment of account nonces

### DIFF
--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -163,9 +163,6 @@ impl State {
             }
         }
 
-        let account = self.get_account_mut(txn.from_addr);
-        account.nonce += 1;
-
         info!("transaction processed");
 
         Ok((


### PR DESCRIPTION
We switched to using the `transact_{create,call}` methods from EVM. These increment the account nonce for us, so we no longer need to do it manually.