### PR TITLE
Refactor RPC module declarations

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -1,9 +1,6 @@
 //! The Ethereum API, as documented at <https://ethereum.org/en/developers/docs/apis/json-rpc>.
 
-use std::{
-    sync::{Arc, Mutex, MutexGuard},
-    time::SystemTime,
-};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use anyhow::{anyhow, Result};
 use generic_array::{
@@ -11,12 +8,8 @@ use generic_array::{
     typenum::{U12, U20},
     GenericArray,
 };
-use jsonrpsee::{
-    types::{error::ErrorCode, ErrorObject, Params},
-    RpcModule,
-};
+use jsonrpsee::{types::Params, RpcModule};
 use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
-use opentelemetry::{metrics::Unit, Context, KeyValue};
 use primitive_types::{H160, H256};
 use rlp::{Rlp, RlpStream};
 use sha2::Digest;
@@ -35,67 +28,25 @@ use super::{
 };
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
-    let mut module = RpcModule::new(node);
-    let meter = opentelemetry::global::meter("");
-
-    macro_rules! method {
-        ($name:expr, $method:path) => {{
-            let rpc_server_duration = meter
-                .f64_histogram("rpc.server.duration")
-                .with_unit(Unit::new("ms"))
-                .init();
-            let cx = Context::new();
-            module
-                .register_method($name, move |params, context| {
-                    let mut attributes = vec![
-                        KeyValue::new("rpc.system", "jsonrpc"),
-                        KeyValue::new("rpc.service", "zilliqa.eth"),
-                        KeyValue::new("rpc.method", $name),
-                        KeyValue::new("network.transport", "tcp"),
-                        KeyValue::new("rpc.jsonrpc.version", "2.0"),
-                    ];
-
-                    let start = SystemTime::now();
-                    let result = $method(params, context).map_err(|e| {
-                        tracing::error!(?e);
-                        ErrorObject::owned(
-                            ErrorCode::InternalError.code(),
-                            e.to_string(),
-                            None as Option<String>,
-                        )
-                    });
-                    if let Err(err) = &result {
-                        attributes.push(KeyValue::new("rpc.jsonrpc.error_code", err.code() as i64));
-                    }
-                    rpc_server_duration.record(
-                        &cx,
-                        start.elapsed().map_or(0.0, |d| d.as_secs_f64() * 1000.0),
-                        &attributes,
-                    );
-                    result
-                })
-                .unwrap();
-        }};
-    }
-
-    method!("eth_accounts", accounts);
-    method!("eth_blockNumber", block_number);
-    method!("eth_call", call);
-    method!("eth_chainId", chain_id);
-    method!("eth_estimateGas", estimate_gas);
-    method!("eth_getBalance", get_balance);
-    method!("eth_getCode", get_code);
-    method!("eth_getTransactionCount", get_transaction_count);
-    method!("eth_gasPrice", gas_price);
-    method!("eth_getBlockByNumber", get_block_by_number);
-    method!("eth_getBlockByHash", get_block_by_hash);
-    method!("eth_getTransactionByHash", get_transaction_by_hash);
-    method!("eth_getTransactionReceipt", get_transaction_receipt);
-    method!("eth_sendRawTransaction", send_raw_transaction);
-    method!("net_version", version);
-    method!("web3_clientVersion", client_version);
-
-    module
+    super::declare_module!(
+        node,
+        [
+            ("eth_accounts", accounts),
+            ("eth_blockNumber", block_number),
+            ("eth_call", call),
+            ("eth_chainId", chain_id),
+            ("eth_estimateGas", estimate_gas),
+            ("eth_getBalance", get_balance),
+            ("eth_getCode", get_code),
+            ("eth_getTransactionCount", get_transaction_count),
+            ("eth_gasPrice", gas_price),
+            ("eth_getBlockByNumber", get_block_by_number),
+            ("eth_getBlockByHash", get_block_by_hash),
+            ("eth_getTransactionByHash", get_transaction_by_hash),
+            ("eth_getTransactionReceipt", get_transaction_receipt),
+            ("eth_sendRawTransaction", send_raw_transaction),
+        ],
+    )
 }
 
 fn accounts(_: Params, _: &Arc<Mutex<Node>>) -> Result<[(); 0]> {
@@ -341,15 +292,6 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
     let transaction_hash = H256(node.lock().unwrap().create_transaction(transaction)?.0);
 
     Ok(transaction_hash.to_hex())
-}
-
-fn version(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    Ok(node.lock().unwrap().config.eth_chain_id.to_string())
-}
-
-fn client_version(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
-    // Format: "<name>/<version>"
-    Ok(concat!("zilliqa2/v", env!("CARGO_PKG_VERSION")))
 }
 
 /// Decode a transaction from its RLP-encoded form.

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,4 +1,89 @@
 pub mod eth;
+mod net;
 mod to_hex;
 mod types;
+mod web3;
 pub mod zilliqa;
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    let mut module = RpcModule::new(node.clone());
+
+    module.merge(eth::rpc_module(node.clone())).unwrap();
+    module.merge(net::rpc_module(node.clone())).unwrap();
+    module.merge(web3::rpc_module(node.clone())).unwrap();
+    module.merge(zilliqa::rpc_module(node.clone())).unwrap();
+
+    module
+}
+
+/// Returns an `RpcModule<Arc<Mutex<Node>>>`. Call with the following syntax:
+/// ```ignore
+/// declare_module!(
+///     node,
+///     [
+///         ("method1", method_one),
+///         ("method2", method_two),
+///     ],
+/// )
+/// ```
+///
+/// where `node` is an `Arc<Mutex<Node>>` and each implementation method has the signature
+/// `Fn(jsonrpsee::types::Params, &Arc<Mutex<Node>>) -> Result<T>`.
+///
+/// Will panic if any of the method names collide.
+macro_rules! declare_module {
+    (
+        $node:expr,
+        [ $(($name:expr, $method:expr)),* $(,)? ] $(,)?
+    ) => {{
+        let mut module: jsonrpsee::RpcModule<std::sync::Arc<std::sync::Mutex<crate::node::Node>>> = jsonrpsee::RpcModule::new($node);
+        let meter = opentelemetry::global::meter("");
+
+        $(
+            let rpc_server_duration = meter
+                .f64_histogram("rpc.server.duration")
+                .with_unit(opentelemetry::metrics::Unit::new("ms"))
+                .init();
+            let cx = opentelemetry::Context::new();
+            module
+                .register_method($name, move |params, context| {
+                    let mut attributes = vec![
+                        opentelemetry::KeyValue::new("rpc.system", "jsonrpc"),
+                        opentelemetry::KeyValue::new("rpc.service", "zilliqa.eth"),
+                        opentelemetry::KeyValue::new("rpc.method", $name),
+                        opentelemetry::KeyValue::new("network.transport", "tcp"),
+                        opentelemetry::KeyValue::new("rpc.jsonrpc.version", "2.0"),
+                    ];
+
+                    let start = std::time::SystemTime::now();
+                    let result = $method(params, context).map_err(|e| {
+                        tracing::error!(?e);
+                        jsonrpsee::types::ErrorObject::owned(
+                            jsonrpsee::types::error::ErrorCode::InternalError.code(),
+                            e.to_string(),
+                            None as Option<String>,
+                        )
+                    });
+                    if let Err(err) = &result {
+                        attributes.push(opentelemetry::KeyValue::new("rpc.jsonrpc.error_code", err.code() as i64));
+                    }
+                    rpc_server_duration.record(
+                        &cx,
+                        start.elapsed().map_or(0.0, |d| d.as_secs_f64() * 1000.0),
+                        &attributes,
+                    );
+                    result
+                })
+                .unwrap();
+        )*
+
+        module
+    }}
+}
+
+use std::sync::{Arc, Mutex};
+
+use declare_module;
+use jsonrpsee::RpcModule;
+
+use crate::node::Node;

--- a/zilliqa/src/api/net.rs
+++ b/zilliqa/src/api/net.rs
@@ -1,0 +1,14 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use jsonrpsee::{types::Params, RpcModule};
+
+use crate::node::Node;
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    super::declare_module!(node, [("net_version", version)])
+}
+
+fn version(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
+    Ok(node.lock().unwrap().config.eth_chain_id.to_string())
+}

--- a/zilliqa/src/api/web3.rs
+++ b/zilliqa/src/api/web3.rs
@@ -1,0 +1,15 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use jsonrpsee::{types::Params, RpcModule};
+
+use crate::node::Node;
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    super::declare_module!(node, [("web3_clientVersion", client_version)])
+}
+
+fn client_version(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
+    // Format: "<name>/<version>"
+    Ok(concat!("zilliqa2/v", env!("CARGO_PKG_VERSION")))
+}

--- a/zilliqa/src/api/zilliqa.rs
+++ b/zilliqa/src/api/zilliqa.rs
@@ -2,18 +2,15 @@
 
 use std::sync::{Arc, Mutex};
 
-use jsonrpsee::RpcModule;
+use anyhow::Result;
+use jsonrpsee::{types::Params, RpcModule};
 
 use crate::node::Node;
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
-    let mut module = RpcModule::new(node);
+    super::declare_module!(node, [("GetCurrentMiniEpoch", get_current_mini_epoch)])
+}
 
-    module
-        .register_method("GetCurrentMiniEpoch", |_, node| {
-            node.lock().unwrap().view().to_string()
-        })
-        .unwrap();
-
-    module
+fn get_current_mini_epoch(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
+    Ok(node.lock().unwrap().view().to_string())
 }

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -93,8 +93,7 @@ impl NodeLauncher {
         )?;
         let node = Arc::new(Mutex::new(node));
 
-        let mut rpc_module = api::zilliqa::rpc_module(Arc::clone(&node));
-        rpc_module.merge(api::eth::rpc_module(Arc::clone(&node)))?;
+        let rpc_module = api::rpc_module(Arc::clone(&node));
 
         Ok(Self {
             node,


### PR DESCRIPTION
We move the `method!` macro from `eth.rs` into `api/mod.rs` so it can be used by other APIs as well. Also, instead of exposing a `method!` macro which expects various variables to be in scope and is called multiple times, we instead expose a `declare_module!` macro which should be called once with a list of methods and returns a full `RpcModule`.

This also moves the single Zilliqa API method that we've implemented to the same macro.

Finally, the `net_*` and `web3_*` methods are moved out of `eth.rs` and into their own namespace-specific module.