### PR TITLE
Comments clarifying intended usage constraints for `SecretKey` methods.

### DIFF
--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -171,8 +171,6 @@ pub struct SecretKey {
 impl SecretKey {
     /// Generates a random private key.
     pub fn new() -> Result<SecretKey> {
-        // let mut buf: [u8; 32] = [0; 32];
-        // rand_core::OsRng.try_fill_bytes(buf.as_mut_slice())?;
         let bls_temp = bls_signatures::PrivateKey::generate(&mut rand_core::OsRng);
         Self::from_bytes(&bls_temp.as_bytes())
     }


### PR DESCRIPTION
As there's an implicit assumption (that `SecretKey`s are correctly validated on construction) which should be spelled out for the future.