### PR TITLE
Implement `erigon_getHeaderByNumber`

### DIFF
--- a/zilliqa/src/api/erigon.rs
+++ b/zilliqa/src/api/erigon.rs
@@ -1,0 +1,25 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use jsonrpsee::{types::Params, RpcModule};
+
+use crate::node::Node;
+
+use super::types::EthBlock;
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    super::declare_module!(node, [("erigon_getHeaderByNumber", get_header_by_number)])
+}
+
+fn get_header_by_number(params: Params, node: &Arc<Mutex<Node>>) -> Result<Option<EthBlock>> {
+    let block: u64 = params.one()?;
+
+    // Erigon headers are a subset of the full block response. We choose to just return the full block.
+    let header = node
+        .lock()
+        .unwrap()
+        .get_block_by_view(block)
+        .map(EthBlock::from);
+
+    Ok(header)
+}

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,3 +1,4 @@
+mod erigon;
 pub mod eth;
 mod net;
 mod to_hex;
@@ -8,6 +9,7 @@ pub mod zilliqa;
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     let mut module = RpcModule::new(node.clone());
 
+    module.merge(erigon::rpc_module(node.clone())).unwrap();
     module.merge(eth::rpc_module(node.clone())).unwrap();
     module.merge(net::rpc_module(node.clone())).unwrap();
     module.merge(web3::rpc_module(node.clone())).unwrap();


### PR DESCRIPTION
As mentioned in the comment, we skip any extra effort by just using the same response type as `eth_getBlockBy*`.