### PR TITLE
Implement `ots_getApiLevel`

### DIFF
--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,5 +1,6 @@
 pub mod eth;
 mod net;
+mod ots;
 mod to_hex;
 mod types;
 mod web3;
@@ -10,6 +11,7 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
 
     module.merge(eth::rpc_module(node.clone())).unwrap();
     module.merge(net::rpc_module(node.clone())).unwrap();
+    module.merge(ots::rpc_module(node.clone())).unwrap();
     module.merge(web3::rpc_module(node.clone())).unwrap();
     module.merge(zilliqa::rpc_module(node)).unwrap();
 

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -1,0 +1,15 @@
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use jsonrpsee::{types::Params, RpcModule};
+
+use crate::node::Node;
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    super::declare_module!(node, [("ots_getApiLevel", get_otterscan_api_level)])
+}
+
+fn get_otterscan_api_level(_: Params, _: &Arc<Mutex<Node>>) -> Result<u64> {
+    // https://github.com/otterscan/otterscan/blob/0a819f3557fe19c0f47327858261881ec5f56d6c/src/params.ts#L1
+    Ok(8)
+}


### PR DESCRIPTION
This is just a simple API to check the node supports the required Otterscan APIs.

For now, we lie and return '8' to say we do support the APIs. Otterscan will only work partially, but this means we can add support for the API methods incrementally.