### PR TITLE
Fix Eth transaction signature verification

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -279,8 +279,7 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
         .ok_or_else(|| anyhow!("no 0x prefix"))?;
     let transaction = hex::decode(transaction)?;
     let chain_id = node.lock().unwrap().config.eth_chain_id;
-    let mut transaction = transaction_from_rlp(&transaction, chain_id).unwrap();
-    transaction.gas_limit = 100000000000000;
+    let transaction = transaction_from_rlp(&transaction, chain_id)?;
 
     let transaction_hash = H256(node.lock().unwrap().create_transaction(transaction)?.0);
 

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -77,10 +77,13 @@ impl State {
     /// address will be added to the transaction.
     pub fn apply_transaction(
         &mut self,
-        txn: Transaction,
+        mut txn: Transaction,
         chain_id: u64,
         current_block: BlockHeader,
     ) -> Result<TransactionApplyResult> {
+        // Workaround until gas is implemented.
+        txn.gas_limit = 100000000000000;
+
         let context = self.call_context(
             txn.gas_price.into(),
             txn.addr_from().0,


### PR DESCRIPTION
We were overriding the gas limit to workaround not having gas implemented. This meant verifying the transaction later failed. So instead we override the gas limit later, once the transaction has already been verified.