### PR TITLE
Return non-zero dummy value for transaction's `gas_used`

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -260,7 +260,7 @@ pub(super) fn get_transaction_receipt_inner(
         to: transaction.to_addr.0,
         cumulative_gas_used: 0,
         effective_gas_price: 0,
-        gas_used: 0,
+        gas_used: 1,
         contract_address: receipt.contract_address.map(|a| a.0),
         logs,
         logs_bloom,


### PR DESCRIPTION
Otherwise some clients (e.g. Otterscan) explode because they try to divide by zero. Once gas is implemented, the gas used for a transaction should never be zero, so I think this is a fine solution for now.