### PR TITLE
Implement `ots_searchTransactions{Before,After}`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,8 +1365,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "evm"
 version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a49a4e11987c51220aa89dbe1a5cc877f5079fa6864c0a5b4533331db44e9365"
+source = "git+https://github.com/Zilliqa/evm.git?rev=d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d#d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d"
 dependencies = [
  "auto_impl",
  "environmental",
@@ -1386,8 +1385,7 @@ dependencies = [
 [[package]]
 name = "evm-core"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f1f13264b044cb66f0602180f0bc781c29accb41ff560669a3ec15858d5b606"
+source = "git+https://github.com/Zilliqa/evm.git?rev=d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d#d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d"
 dependencies = [
  "parity-scale-codec",
  "primitive-types",
@@ -1398,8 +1396,7 @@ dependencies = [
 [[package]]
 name = "evm-gasometer"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d43eadc395bd1a52990787ca1495c26b0248165444912be075c28909a853b8c"
+source = "git+https://github.com/Zilliqa/evm.git?rev=d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d#d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d"
 dependencies = [
  "environmental",
  "evm-core",
@@ -1410,8 +1407,7 @@ dependencies = [
 [[package]]
 name = "evm-runtime"
 version = "0.39.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aa5b32f59ec582a5651978004e5c784920291263b7dcb6de418047438e37f4f"
+source = "git+https://github.com/Zilliqa/evm.git?rev=d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d#d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d"
 dependencies = [
  "auto_impl",
  "environmental",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -22,7 +22,7 @@ bls-signatures = "0.14.0"
 bls12_381 = "0.8.0"
 clap = { version = "4.3.1", features = ["derive"] }
 ethabi = "18.0.0"
-evm = { version = "0.39.0", features = ["tracing"] }
+evm = { git = "https://github.com/Zilliqa/evm.git", rev = "d3ebfbdeab0ccb0da38f1ccfee4fed41fd931d1d", features = ["tracing"] }
 futures = "0.3.28"
 generic-array = "0.14.7"
 hex = { version = "0.4.3", features = ["serde"] }

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, Mutex};
+use std::{
+    sync::{Arc, Mutex},
+    time::SystemTime,
+};
 
 use anyhow::{anyhow, Result};
 use jsonrpsee::{types::Params, RpcModule};
@@ -9,7 +12,10 @@ use crate::{crypto::Hash, node::Node, state::Address};
 
 use super::{
     eth::{get_transaction_inner, get_transaction_receipt_inner},
-    types::{OtterscanBlockDetails, OtterscanBlockTransactions, OtterscanBlockWithTransactions},
+    types::{
+        EthTransaction, EthTransactionReceiptWithTimestamp, OtterscanBlockDetails,
+        OtterscanBlockTransactions, OtterscanBlockWithTransactions, OtterscanTransactions,
+    },
 };
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
@@ -21,6 +27,8 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
             ("ots_getBlockDetailsByHash", get_block_details_by_hash),
             ("ots_getBlockTransactions", get_block_transactions),
             ("ots_hasCode", has_code),
+            ("ots_searchTransactionsAfter", search_transactions_after),
+            ("ots_searchTransactionsBefore", search_transactions_before),
         ],
     )
 }
@@ -119,4 +127,122 @@ fn has_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
         .is_empty();
 
     Ok(!empty)
+}
+
+fn search_transactions_inner(
+    node: &Arc<Mutex<Node>>,
+    address: Address,
+    block_number: u64,
+    page_size: usize,
+    reverse: bool,
+) -> Result<OtterscanTransactions> {
+    let mut touched = node.lock().unwrap().get_touched_transactions(address);
+
+    // If searching in reverse, we should start with the most recent transaction and work backwards.
+    if reverse {
+        touched.reverse();
+    }
+
+    let mut transactions = Vec::with_capacity(page_size);
+    let mut receipts = Vec::with_capacity(page_size);
+
+    // Keep track of the current block number. Once we reach `page_size` transactions, we still need to continue adding
+    // transactions from the current block.
+    let mut current_block = u64::MAX;
+    // This will be set to false if we break out of the loop, indicating to the caller there are further pages.
+    let mut finished = true;
+
+    for hash in touched {
+        let txn: EthTransaction = get_transaction_inner(hash, &node.lock().unwrap())
+            .unwrap()
+            .unwrap();
+        let txn_block_number = txn.block_number;
+
+        let cmp = if !reverse {
+            PartialOrd::le
+        } else {
+            PartialOrd::ge
+        };
+        if cmp(&txn_block_number, &block_number) {
+            continue;
+        }
+
+        // Don't break until we have at least `page_size` transactions AND we've added everything from the last searched block.
+        if transactions.len() >= page_size && txn_block_number != current_block {
+            finished = false;
+            break;
+        }
+
+        let timestamp = node
+            .lock()
+            .unwrap()
+            .get_block_by_hash(Hash(txn.block_hash.0))
+            .unwrap()
+            .timestamp();
+
+        transactions.push(txn);
+
+        let node = node.lock().unwrap();
+        let receipt = EthTransactionReceiptWithTimestamp {
+            receipt: get_transaction_receipt_inner(hash, &node).unwrap().unwrap(),
+            timestamp: timestamp
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        };
+        receipts.push(receipt);
+
+        current_block = txn_block_number;
+    }
+
+    // The results should always be returned in descending order (latest to earliest). If we were searching forwards
+    // in time, we should reverse the results to ensure they are in descending order.
+    if !reverse {
+        transactions.reverse();
+        receipts.reverse();
+    }
+
+    // `first_page` should be set if this was the latest page in time and `last_page` should be set if this was the
+    // earliest page in time.
+    let (first_page, last_page) = if reverse {
+        (block_number == u64::MAX, finished)
+    } else {
+        (finished, block_number == 0)
+    };
+
+    Ok(OtterscanTransactions {
+        transactions,
+        receipts,
+        first_page,
+        last_page,
+    })
+}
+
+fn search_transactions_after(
+    params: Params,
+    node: &Arc<Mutex<Node>>,
+) -> Result<OtterscanTransactions> {
+    let mut params = params.sequence();
+    let address: H160 = params.next()?;
+    let block_number: u64 = params.next()?;
+    let page_size: usize = params.next()?;
+
+    search_transactions_inner(node, Address(address), block_number, page_size, false)
+}
+
+fn search_transactions_before(
+    params: Params,
+    node: &Arc<Mutex<Node>>,
+) -> Result<OtterscanTransactions> {
+    let mut params = params.sequence();
+    let address: H160 = params.next()?;
+    let mut block_number: u64 = params.next()?;
+    let page_size: usize = params.next()?;
+
+    // A `block_number` of `0` tells us to search from the most recent block.
+    if block_number == 0 {
+        block_number = u64::MAX;
+    }
+
+    search_transactions_inner(node, Address(address), block_number, page_size, true)
 }

--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -219,6 +219,16 @@ pub struct OtterscanBlockTransactions {
     pub receipts: Vec<EthTransactionReceipt>,
 }
 
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OtterscanTransactions {
+    #[serde(rename = "txs")]
+    pub transactions: Vec<EthTransaction>,
+    pub receipts: Vec<EthTransactionReceiptWithTimestamp>,
+    pub first_page: bool,
+    pub last_page: bool,
+}
+
 /// A transaction object, returned by the Ethereum API.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -251,6 +261,14 @@ pub struct EthTransaction {
     pub r: [u8; 32],
     #[serde(serialize_with = "hex")]
     pub s: [u8; 32],
+}
+
+#[derive(Clone, Serialize)]
+pub struct EthTransactionReceiptWithTimestamp {
+    #[serde(flatten)]
+    pub receipt: EthTransactionReceipt,
+    #[serde(serialize_with = "hex")]
+    pub timestamp: u64,
 }
 
 /// A transaction receipt object, returned by the Ethereum API.

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -12,12 +12,13 @@ use tracing::{debug, trace};
 use crate::{
     cfg::Config,
     crypto::{verify_messages, Hash, NodePublicKey, NodeSignature, SecretKey},
+    exec::TouchedAddressEventListener,
     exec::TransactionApplyResult,
     message::{
         AggregateQc, BitSlice, BitVec, Block, BlockHeader, NewView, Proposal, QuorumCertificate,
         Vote,
     },
-    state::{State, Transaction, TransactionReceipt},
+    state::{Address, State, Transaction, TransactionReceipt},
 };
 
 struct NewViewVote {
@@ -56,6 +57,9 @@ pub struct Consensus {
     transaction_receipts: BTreeMap<Hash, TransactionReceipt>,
     /// The account store.
     state: State,
+    /// An index of address to a list of transaction hashes, for which this address appeared somewhere in the
+    /// transaction trace. The list of transations is ordered by execution order.
+    touched_address_index: BTreeMap<Address, Vec<Hash>>,
 }
 
 impl Consensus {
@@ -81,6 +85,7 @@ impl Consensus {
             transactions: BTreeMap::new(),
             transaction_receipts: BTreeMap::new(),
             state: State::new()?,
+            touched_address_index: BTreeMap::new(),
         })
     }
 
@@ -242,25 +247,40 @@ impl Consensus {
         txn: Transaction,
         current_block: BlockHeader,
     ) -> Result<Option<TransactionApplyResult>> {
+        let hash = txn.hash();
+
         // If we have the transaction in the mempool, remove it.
-        self.new_transactions.remove(&txn.hash());
+        self.new_transactions.remove(&hash);
 
         // Ensure the transaction has a valid signature
         txn.verify()?;
 
         // If we haven't applied the transaction yet, do so. This ensures we don't execute the transaction twice if we
         // already executed it in the process of proposing this block.
-        if let Entry::Vacant(entry) = self.transactions.entry(txn.hash()) {
-            let result = self.state.apply_transaction(
-                txn.clone(),
-                self.config.eth_chain_id,
-                current_block,
-            )?;
+        if let Entry::Vacant(entry) = self.transactions.entry(hash) {
+            let mut listener = TouchedAddressEventListener::default();
+            let result = evm::tracing::using(&mut listener, || {
+                self.state
+                    .apply_transaction(txn.clone(), self.config.eth_chain_id, current_block)
+            })?;
             entry.insert(txn);
+            for address in listener.touched {
+                self.touched_address_index
+                    .entry(Address(address))
+                    .or_default()
+                    .push(hash);
+            }
             Ok(Some(result))
         } else {
             Ok(None)
         }
+    }
+
+    pub fn get_touched_transactions(&self, address: Address) -> Vec<Hash> {
+        self.touched_address_index
+            .get(&address)
+            .cloned()
+            .unwrap_or_default()
     }
 
     pub fn vote(&mut self, _: PeerId, vote: Vote) -> Result<Option<(Block, Vec<Transaction>)>> {

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -1,12 +1,13 @@
 //! Manages execution of transactions on state.
 
-use std::{borrow::Cow, time::SystemTime};
+use std::{borrow::Cow, collections::HashSet, time::SystemTime};
 
 use anyhow::{anyhow, Result};
 use ethabi::Token;
 use evm::{
     backend::{Apply, Backend, Basic},
     executor::stack::{MemoryStackState, StackExecutor, StackSubstateMetadata},
+    tracing::EventListener,
     Config, CreateScheme, ExitReason,
 };
 use primitive_types::{H160, H256, U256};
@@ -17,6 +18,71 @@ use crate::{
     message::BlockHeader,
     state::{Address, Log, State, Transaction},
 };
+
+#[derive(Default)]
+pub struct TouchedAddressEventListener {
+    pub touched: HashSet<H160>,
+}
+
+impl EventListener for TouchedAddressEventListener {
+    fn event(&mut self, event: evm::tracing::Event<'_>) {
+        match event {
+            evm::tracing::Event::Call {
+                code_address,
+                transfer,
+                ..
+            } => {
+                self.touched.insert(code_address);
+                if let Some(transfer) = transfer {
+                    self.touched.insert(transfer.source);
+                    self.touched.insert(transfer.target); // TODO: Figure out if `transfer.target` is always equal to `code_address`?
+                }
+            }
+            evm::tracing::Event::Create {
+                caller, address, ..
+            } => {
+                self.touched.insert(caller);
+                self.touched.insert(address);
+            }
+            evm::tracing::Event::Suicide {
+                address, target, ..
+            } => {
+                self.touched.insert(address);
+                self.touched.insert(target);
+            }
+            evm::tracing::Event::Exit { .. } => {}
+            evm::tracing::Event::TransactCall {
+                caller, address, ..
+            } => {
+                self.touched.insert(caller);
+                self.touched.insert(address);
+            }
+            evm::tracing::Event::TransactCreate {
+                caller, address, ..
+            } => {
+                self.touched.insert(caller);
+                self.touched.insert(address);
+            }
+            evm::tracing::Event::TransactCreate2 {
+                caller, address, ..
+            } => {
+                self.touched.insert(caller);
+                self.touched.insert(address);
+            }
+            evm::tracing::Event::PrecompileSubcall {
+                code_address,
+                transfer,
+                ..
+            } => {
+                self.touched.insert(code_address);
+                if let Some(transfer) = transfer {
+                    self.touched.insert(transfer.source);
+                    self.touched.insert(transfer.target);
+                }
+            }
+        }
+    }
+}
 
 pub struct CallContext<'a> {
     state: &'a State,

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -172,6 +172,10 @@ impl Node {
         self.consensus.get_transaction_by_hash(hash)
     }
 
+    pub fn get_touched_transactions(&self, address: Address) -> Vec<Hash> {
+        self.consensus.get_touched_transactions(address)
+    }
+
     fn send_message(&mut self, peer: PeerId, message: Message) -> Result<()> {
         if peer == self.peer_id {
             // We need to 'send' this message to ourselves.


### PR DESCRIPTION
These are Otterscan API methods to search through the list of transactions that 'touched' an account, where touched can mean:
* A transaction sent from the account
* A transaction sent to the account
* A transaction that sent money to or called the account as part of its trace

To implement this we add an additional index to our nodes which stores a map of addresses to transactions which touched the address.

The rest of the code iterates over the index and populates the response.

I considered an alternative index that is worth mentioning and we might want to revisit in the future:

* An index of address to blocks in which this address was touched. This is the approach taken by Erigon. It makes it much easier to discount transactions which are outside of the range specified in the API request, but requires you to execute every transaction in the matched blocks to filter out the ones which don't touch the address. I didn't opt for this, because we don't have the ability to replay transactions yet (#158). Also, its easier to optimise a sparse `Vec<u64>` than a `Vec<Hash>` with (for example) a run-length encoded bitmap.