### PR TITLE
Update to Rust 1.70.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  CARGO_UNSTABLE_SPARSE_REGISTRY: true
 
 jobs:
   check:
@@ -19,9 +18,6 @@ jobs:
     - name: Install dependencies
       run: sudo apt install -y protobuf-compiler
     - uses: actions/checkout@v3
-    # Use Rust nightly so we can use the Cargo sparse registry feature, which greatly speeds up uncached builds (https://blog.rust-lang.org/2022/06/22/sparse-registry-testing.html).
-    - name: Use Rust nightly
-      run: rustup override set nightly && rustup component add clippy rustfmt
     - uses: Swatinem/rust-cache@v2
     - name: rustfmt
       run: cargo fmt --all --check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.69.0-slim-bullseye as builder
+FROM rust:1.70.0-slim-bullseye as builder
 
 RUN apt update -y && \
     apt upgrade -y && \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.69.0"
+channel = "1.70.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
This version stabilised the sparse protocol for crates.io, so we no longer need to use nightly in CI.