### PR TITLE
Implement `web3_sha3`

### DIFF
--- a/zilliqa/src/api/web3.rs
+++ b/zilliqa/src/api/web3.rs
@@ -1,16 +1,33 @@
-use super::*;
+use super::{to_hex::ToHex, *};
+
 use std::sync::{Arc, Mutex};
 
 use anyhow::Result;
 use jsonrpsee::{types::Params, RpcModule};
+use sha3::{Digest, Keccak256};
 
 use crate::node::Node;
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
-    super::declare_module!(node, [("web3_clientVersion", client_version)])
+    super::declare_module!(
+        node,
+        [("web3_clientVersion", client_version), ("web3_sha3", sha3)],
+    )
 }
 
 fn client_version(_: Params, _: &Arc<Mutex<Node>>) -> Result<&'static str> {
     // Format: "<name>/<version>"
     Ok(concat!("zilliqa2/v", env!("CARGO_PKG_VERSION")))
+}
+
+fn sha3(params: Params, _: &Arc<Mutex<Node>>) -> Result<String> {
+    let data: String = params.one()?;
+    let data = data
+        .strip_prefix("0x")
+        .ok_or_else(|| anyhow!("no 0x prefix"))?;
+    let data = hex::decode(data)?;
+
+    let hashed = Keccak256::digest(data);
+
+    Ok(hashed.to_hex())
 }

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1,5 +1,6 @@
 mod consensus;
 mod eth;
+mod web3;
 
 use std::{
     fmt::Debug,

--- a/zilliqa/tests/it/web3.rs
+++ b/zilliqa/tests/it/web3.rs
@@ -1,0 +1,17 @@
+use crate::Network;
+
+#[tokio::test]
+async fn sha3() {
+    let network = Network::new(4);
+    let provider = network.provider(0);
+
+    // Example from https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_sha3
+    let result: String = provider
+        .request("web3_sha3", ["0x68656c6c6f20776f726c64"])
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        "0x47173285a8d7341e5e972fc677286384f802f8ef42a5ec5f03bbfa254cb01fad"
+    )
+}


### PR DESCRIPTION
I have no idea why someone would use this instead of computing it themselves, but it is less effort to implement than to justify not implementing it.