### PR TITLE
Fix diff in `Cargo.lock`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,3 +32,5 @@ jobs:
       run: cargo clippy --all-targets --all-features -- -D warnings
     - name: Test
       run: cargo test --all-targets --all-features
+    - name: Verify working directory is clean
+      run: git diff --exit-code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6472,6 +6472,6 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "vergen",
  "ureq",
+ "vergen",
 ]


### PR DESCRIPTION
PR #202 added a change to `Cargo.lock` that is not inline with how Cargo automatically generates the file.

I've also added an extra check in our CI workflow to prevent this in the future.