### PR TITLE
Refactor transaction types

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -4,15 +4,14 @@ use std::sync::{Arc, Mutex, MutexGuard};
 
 use anyhow::{anyhow, Result};
 use jsonrpsee::{types::Params, RpcModule};
-use k256::ecdsa::{RecoveryId, Signature, SigningKey, VerifyingKey};
 use primitive_types::{H160, H256, U256};
 use rlp::Rlp;
 
 use crate::{
-    crypto::{Hash, TransactionPublicKey, TransactionSignature},
+    crypto::Hash,
     message::Block,
     node::Node,
-    state::{Address, Transaction},
+    state::{Address, SignedTransaction, SigningInfo, Transaction},
 };
 
 use super::{
@@ -253,15 +252,24 @@ pub(super) fn get_transaction_inner(
     hash: Hash,
     node: &MutexGuard<Node>,
 ) -> Result<Option<EthTransaction>> {
-    let Some(transaction) = node.get_transaction_by_hash(hash) else { return Ok(None); };
+    let Some(signed_transaction) = node.get_transaction_by_hash(hash) else { return Ok(None); };
     // TODO: Return error if receipt or block does not exist.
     let Some(receipt) = node.get_transaction_receipt(hash) else { return Ok(None); };
     let Some(block) = node.get_block_by_hash(receipt.block_hash) else { return Ok(None); };
 
+    let transaction = signed_transaction.transaction;
+    let (v, r, s) = match signed_transaction.signing_info {
+        SigningInfo::Eth {
+            v,
+            r,
+            s,
+            chain_id: _,
+        } => (v, r, s),
+    };
     let transaction = EthTransaction {
         block_hash: H256(block.hash().0),
         block_number: block.view(),
-        from: transaction.addr_from().0,
+        from: signed_transaction.from_addr.0,
         gas: 0,
         gas_price: transaction.gas_price,
         hash: H256(hash.0),
@@ -271,9 +279,9 @@ pub(super) fn get_transaction_inner(
         to: (transaction.to_addr != Address::DEPLOY_CONTRACT).then_some(transaction.to_addr.0),
         transaction_index: block.transactions.iter().position(|t| *t == hash).unwrap() as u64,
         value: transaction.amount,
-        v: 0,
-        r: [0; 32],
-        s: [0; 32],
+        v,
+        r,
+        s,
     };
 
     Ok(Some(transaction))
@@ -283,7 +291,7 @@ pub(super) fn get_transaction_receipt_inner(
     hash: Hash,
     node: &MutexGuard<Node>,
 ) -> Result<Option<EthTransactionReceipt>> {
-    let Some(transaction) = node.get_transaction_by_hash(hash) else { return Ok(None); };
+    let Some(signed_transaction) = node.get_transaction_by_hash(hash) else { return Ok(None); };
     // TODO: Return error if receipt or block does not exist.
     let Some(receipt) = node.get_transaction_receipt(hash) else { return Ok(None); };
     let Some(block) = node.get_block_by_hash(receipt.block_hash) else { return Ok(None); };
@@ -318,12 +326,13 @@ pub(super) fn get_transaction_receipt_inner(
         })
         .collect();
 
+    let transaction = signed_transaction.transaction;
     let receipt = EthTransactionReceipt {
         transaction_hash,
         transaction_index,
         block_hash,
         block_number,
-        from: transaction.addr_from().0,
+        from: signed_transaction.from_addr.0,
         to: transaction.to_addr.0,
         cumulative_gas_used: 0,
         effective_gas_price: 0,
@@ -363,11 +372,11 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
 }
 
 /// Decode a transaction from its RLP-encoded form.
-fn transaction_from_rlp(bytes: &[u8], chain_id: u64) -> Result<Transaction> {
+fn transaction_from_rlp(bytes: &[u8], chain_id: u64) -> Result<SignedTransaction> {
     let rlp = Rlp::new(bytes);
     let nonce = rlp.val_at(0)?;
     let gas_price = rlp.val_at(1)?;
-    let gas_limit: u64 = rlp.val_at(2)?;
+    let gas_limit = rlp.val_at(2)?;
     let to_addr = rlp.val_at::<Vec<u8>>(3)?;
     let amount = rlp.val_at(4)?;
     let payload = rlp.val_at(5)?;
@@ -375,42 +384,18 @@ fn transaction_from_rlp(bytes: &[u8], chain_id: u64) -> Result<Transaction> {
     let r = left_pad_arr(&rlp.val_at::<Vec<_>>(7)?)?;
     let s = left_pad_arr(&rlp.val_at::<Vec<_>>(8)?)?;
 
-    let use_eip155 = v >= (chain_id * 2) + 35;
+    let signing_info = SigningInfo::Eth { v, r, s, chain_id };
 
-    let unsigned_transaction = Transaction {
+    let transaction = Transaction {
         nonce,
         gas_price,
         gas_limit,
-        signature: None,
-        public_key: TransactionPublicKey::Ecdsa(
-            // dummy temp signature to fill the object
-            *SigningKey::from_slice(&[1_u8; 32]).unwrap().verifying_key(),
-            use_eip155,
-        ),
         to_addr: Address::from_slice(&to_addr),
         amount,
         payload,
-        chain_id,
     };
 
-    let recovery_id = if use_eip155 {
-        v - ((chain_id * 2) + 35)
-    } else {
-        v - 27
-    };
-    let hash = unsigned_transaction.signing_hash();
-    let recovery_id = RecoveryId::from_byte(recovery_id.try_into()?)
-        .ok_or_else(|| anyhow!("invalid recovery id: {recovery_id}"))?;
-    let signature = Signature::from_scalars(r, s)?;
-
-    let verifying_key =
-        VerifyingKey::recover_from_prehash(hash.as_bytes(), &signature, recovery_id)?;
-
-    Ok(Transaction {
-        signature: Some(TransactionSignature::Ecdsa(signature)),
-        public_key: TransactionPublicKey::Ecdsa(verifying_key, use_eip155),
-        ..unsigned_transaction
-    })
+    SignedTransaction::new(transaction, signing_info)
 }
 
 fn left_pad_arr<const N: usize>(v: &[u8]) -> Result<[u8; N]> {
@@ -446,29 +431,30 @@ mod tests {
     fn test_transaction_from_rlp() {
         // From https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example
         let transaction = hex::decode("f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83").unwrap();
-        let transaction = transaction_from_rlp(&transaction, 1).unwrap();
-        assert_eq!(transaction.nonce, 9);
-        assert_eq!(transaction.gas_price, 20 * 10u128.pow(9));
-        assert_eq!(transaction.gas_limit, 21000u64);
+        let signed_tx = transaction_from_rlp(&transaction, 1).unwrap();
+        let tx = &signed_tx.transaction;
+        assert_eq!(tx.nonce, 9);
+        assert_eq!(tx.gas_price, 20 * 10u128.pow(9));
+        assert_eq!(tx.gas_limit, 21000u64);
         assert_eq!(
-            transaction.to_addr,
+            tx.to_addr,
             Address(
                 "0x3535353535353535353535353535353535353535"
                     .parse::<H160>()
                     .unwrap()
             )
         );
-        assert_eq!(transaction.amount, 10u128.pow(18));
-        assert_eq!(transaction.payload, Vec::<u8>::new());
+        assert_eq!(tx.amount, 10u128.pow(18));
+        assert_eq!(tx.payload, Vec::<u8>::new());
         assert_eq!(
-            transaction.addr_from(),
+            signed_tx.from_addr,
             Address(
                 "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F"
                     .parse::<H160>()
                     .unwrap()
             )
         );
-        assert!(transaction.verify().is_ok());
+        assert!(signed_tx.verify().is_ok());
     }
 
     #[test]

--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -299,7 +299,7 @@ pub struct EthTransaction {
     #[serde(serialize_with = "hex")]
     pub value: u128,
     #[serde(serialize_with = "hex")]
-    pub v: u8,
+    pub v: u64,
     #[serde(serialize_with = "hex")]
     pub r: [u8; 32],
     #[serde(serialize_with = "hex")]

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -18,7 +18,7 @@ use crate::{
         AggregateQc, BitSlice, BitVec, Block, BlockHeader, NewView, Proposal, QuorumCertificate,
         Vote,
     },
-    state::{Address, State, Transaction, TransactionReceipt},
+    state::{Address, SignedTransaction, State, TransactionReceipt},
 };
 
 #[derive(Debug)]
@@ -52,10 +52,10 @@ pub struct Consensus {
     /// Peers that have appeared between the last view and this one. They will be added to the committee before the next view.
     pending_peers: Vec<(PeerId, NodePublicKey)>,
     /// Transactions that have been broadcasted by the network, but not yet executed. Transactions will be removed from this map once they are executed.
-    new_transactions: BTreeMap<Hash, Transaction>,
+    new_transactions: BTreeMap<Hash, SignedTransaction>,
     /// Transactions that have been executed and included in a block, and the blocks the are
     /// included in.
-    transactions: BTreeMap<Hash, Transaction>,
+    transactions: BTreeMap<Hash, SignedTransaction>,
     transaction_receipts: BTreeMap<Hash, TransactionReceipt>,
     /// The account store.
     state: State,
@@ -246,7 +246,7 @@ impl Consensus {
 
     pub fn apply_transaction(
         &mut self,
-        txn: Transaction,
+        txn: SignedTransaction,
         current_block: BlockHeader,
     ) -> Result<Option<TransactionApplyResult>> {
         let hash = txn.hash();
@@ -262,8 +262,12 @@ impl Consensus {
         if let Entry::Vacant(entry) = self.transactions.entry(hash) {
             let mut listener = TouchedAddressEventListener::default();
             let result = evm::tracing::using(&mut listener, || {
-                self.state
-                    .apply_transaction(txn.clone(), self.config.eth_chain_id, current_block)
+                self.state.apply_transaction(
+                    txn.transaction.clone(),
+                    txn.from_addr,
+                    self.config.eth_chain_id,
+                    current_block,
+                )
             })?;
             entry.insert(txn);
             for address in listener.touched {
@@ -285,7 +289,11 @@ impl Consensus {
             .unwrap_or_default()
     }
 
-    pub fn vote(&mut self, _: PeerId, vote: Vote) -> Result<Option<(Block, Vec<Transaction>)>> {
+    pub fn vote(
+        &mut self,
+        _: PeerId,
+        vote: Vote,
+    ) -> Result<Option<(Block, Vec<SignedTransaction>)>> {
         let Ok(block) = self.get_block(&vote.block_hash) else { return Ok(None); }; // TODO: Is this the right response when we recieve a vote for a block we don't know about?
         let block_hash = block.hash();
         let block_view = block.view();
@@ -481,14 +489,14 @@ impl Consensus {
         Ok(None)
     }
 
-    pub fn new_transaction(&mut self, txn: Transaction) -> Result<()> {
+    pub fn new_transaction(&mut self, txn: SignedTransaction) -> Result<()> {
         txn.verify()?; // sanity check
         self.new_transactions.insert(txn.hash(), txn);
 
         Ok(())
     }
 
-    pub fn get_transaction_by_hash(&self, hash: Hash) -> Option<Transaction> {
+    pub fn get_transaction_by_hash(&self, hash: Hash) -> Option<SignedTransaction> {
         Some(self.transactions.get(&hash)?.clone())
     }
 

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -236,11 +236,12 @@ impl State {
     pub fn apply_transaction(
         &mut self,
         txn: Transaction,
+        from_addr: Address,
         chain_id: u64,
         current_block: BlockHeader,
     ) -> Result<TransactionApplyResult> {
         self.apply_transaction_inner(
-            txn.addr_from(),
+            from_addr,
             txn.to_addr,
             txn.gas_price,
             100000000000000, // Workaround until gas is implemented.

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     crypto::{Hash, NodePublicKey, NodeSignature, SecretKey},
-    state::Transaction,
+    state::SignedTransaction,
 };
 
 pub type BitVec = bitvec::vec::BitVec<u8, Msb0>;
@@ -19,11 +19,11 @@ pub struct Proposal {
     pub header: BlockHeader,
     pub qc: QuorumCertificate,
     pub agg: Option<AggregateQc>,
-    pub transactions: Vec<Transaction>,
+    pub transactions: Vec<SignedTransaction>,
 }
 
 impl Proposal {
-    pub fn into_parts(self) -> (Block, Vec<Transaction>) {
+    pub fn into_parts(self) -> (Block, Vec<SignedTransaction>) {
         (
             Block {
                 header: self.header,
@@ -109,7 +109,7 @@ pub enum Message {
     NewView(NewView),
     BlockRequest(BlockRequest),
     BlockResponse(BlockResponse),
-    NewTransaction(Transaction),
+    NewTransaction(SignedTransaction),
     RequestResponse,
 }
 

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -1,4 +1,11 @@
+use generic_array::{
+    sequence::Split,
+    typenum::{U12, U20},
+    GenericArray,
+};
+use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 use rlp::RlpStream;
+use sha3::{Digest, Keccak256};
 use std::{
     borrow::Cow,
     collections::{hash_map::DefaultHasher, BTreeMap},
@@ -10,10 +17,7 @@ use anyhow::{anyhow, Result};
 use primitive_types::{H160, H256, U256};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    contracts,
-    crypto::{self, TransactionPublicKey, TransactionSignature},
-};
+use crate::{contracts, crypto};
 
 #[derive(Debug, Clone, Default, Hash)]
 pub struct State {
@@ -123,72 +127,124 @@ pub struct Account {
     pub storage: BTreeMap<H256, H256>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignedTransaction {
+    pub transaction: Transaction,
+    /// The from address is inferred from the signing info.
+    pub from_addr: Address,
+    pub signing_info: SigningInfo,
+}
+
+impl SignedTransaction {
+    pub fn new(transaction: Transaction, signing_info: SigningInfo) -> Result<Self> {
+        let from_addr = verify(&transaction, &signing_info)?;
+        Ok(SignedTransaction {
+            transaction,
+            from_addr,
+            signing_info,
+        })
+    }
+
+    pub fn hash(&self) -> crypto::Hash {
+        let txn = &self.transaction;
+        match self.signing_info {
+            SigningInfo::Eth { v, r, s, chain_id } => {
+                let use_eip155 = v >= (chain_id * 2) + 35;
+                let mut rlp = RlpStream::new_list(if use_eip155 { 9 } else { 6 });
+                rlp.append(&txn.nonce)
+                    .append(&txn.gas_price)
+                    .append(&txn.gas_limit)
+                    .append(&txn.to_addr.as_bytes().to_vec())
+                    .append(&txn.amount)
+                    .append(&txn.payload);
+                if use_eip155 {
+                    rlp.append(&v).append(&r.as_slice()).append(&s.as_slice());
+                };
+
+                crypto::Hash(Keccak256::digest(rlp.out()).into())
+            }
+        }
+    }
+
+    pub fn verify(&self) -> Result<()> {
+        let from_addr = verify(&self.transaction, &self.signing_info)?;
+        if from_addr != self.from_addr {
+            return Err(anyhow!("inconsistent from address"));
+        }
+
+        Ok(())
+    }
+}
+
+fn verify(txn: &Transaction, signing_info: &SigningInfo) -> Result<Address> {
+    match signing_info {
+        SigningInfo::Eth { v, r, s, chain_id } => {
+            let use_eip155 = *v >= (*chain_id * 2) + 35;
+            let mut rlp = RlpStream::new_list(if use_eip155 { 9 } else { 6 });
+            rlp.append(&txn.nonce)
+                .append(&txn.gas_price)
+                .append(&txn.gas_limit)
+                .append(&txn.to_addr.as_bytes().to_vec())
+                .append(&txn.amount)
+                .append(&txn.payload);
+            if use_eip155 {
+                rlp.append(chain_id).append(&0u8).append(&0u8);
+            };
+            let prehash = Keccak256::digest(rlp.out());
+            let recovery_id = if use_eip155 {
+                v - ((chain_id * 2) + 35)
+            } else {
+                v - 27
+            };
+            let recovery_id = RecoveryId::from_byte(recovery_id.try_into()?)
+                .ok_or_else(|| anyhow!("invalid recovery id: {recovery_id}"))?;
+            let signature = Signature::from_scalars(*r, *s)?;
+
+            let verifying_key =
+                VerifyingKey::recover_from_prehash(&prehash, &signature, recovery_id)?;
+
+            // Remove the first byte before hashing - The first byte specifies the encoding tag.
+            let hashed = Keccak256::digest(&verifying_key.to_encoded_point(false).as_bytes()[1..]);
+            let (_, bytes): (GenericArray<u8, U12>, GenericArray<u8, U20>) = hashed.split();
+            let from_addr = Address::from_bytes(bytes.into());
+
+            Ok(from_addr)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SigningInfo {
+    Eth {
+        v: u64,
+        r: [u8; 32],
+        s: [u8; 32],
+        chain_id: u64,
+    },
+}
+
+impl SigningInfo {
+    pub fn hash(&self) -> crypto::Hash {
+        match self {
+            SigningInfo::Eth {
+                v,
+                r,
+                s,
+                chain_id: _,
+            } => crypto::Hash::compute(&[&v.to_be_bytes(), r.as_slice(), s.as_slice()]),
+        }
+    }
+}
+
 /// A transaction body, broadcast before execution and then persisted as part of a block after the transaction is executed.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Transaction {
     pub nonce: u64,
     pub gas_price: u128,
     pub gas_limit: u64,
-    // TODO: rework how unsigned/partially signed transactions are handled, e.g. in tests
-    pub signature: Option<TransactionSignature>,
-    pub public_key: TransactionPublicKey,
     pub to_addr: Address,
     pub amount: u128,
     pub payload: Vec<u8>,
-    pub chain_id: u64,
-}
-
-impl Transaction {
-    pub fn hash(&self) -> crypto::Hash {
-        crypto::Hash::compute(&[
-            &self.nonce.to_be_bytes(),
-            &self.gas_price.to_be_bytes(),
-            &self.gas_limit.to_be_bytes(),
-            &self.addr_from().as_bytes(),
-            &self.to_addr.as_bytes(),
-            &self.amount.to_be_bytes(),
-            &self.payload,
-        ])
-    }
-
-    /// The digest that is to be used for signing and verification.
-    ///
-    /// - If the `public_key` of the transaction is ECDSA, this follows Ethereum standard.
-    /// The second parameter then distinguishes between EIP155 or legacy signatures.
-    ///
-    /// - ...presumably Zilliqa compatibility is TBA.
-    pub fn signing_hash(&self) -> crypto::Hash {
-        match self.public_key {
-            TransactionPublicKey::Ecdsa(_, use_eip155) => {
-                let mut rlp = RlpStream::new_list(match use_eip155 {
-                    true => 9,
-                    false => 6,
-                });
-                rlp.append(&self.nonce)
-                    .append(&self.gas_price)
-                    .append(&self.gas_limit)
-                    .append(&self.to_addr.as_bytes().to_vec())
-                    .append(&self.amount)
-                    .append(&self.payload);
-                if use_eip155 {
-                    rlp.append(&self.chain_id).append(&0u8).append(&0u8);
-                };
-                crypto::Hash::compute(&[&rlp.out()])
-            }
-        }
-    }
-
-    pub fn addr_from(&self) -> Address {
-        self.public_key.into_addr()
-    }
-
-    pub fn verify(&self) -> Result<()> {
-        if let Some(sig) = self.signature {
-            self.public_key.verify(self.signing_hash().as_bytes(), sig)
-        } else {
-            Err(anyhow!("Transaction is unsigned"))
-        }
-    }
 }
 
 /// A transaction receipt stores data about the execution of a transaction.


### PR DESCRIPTION
We make the existing `Transaction` unsigned and add a new wrapper type - `SignedTransaction` which includes a `Transaction` and a `SigningInfo`. This allows us to represent both signed and unsigned transactions at any point in our system.

There is some duplication of data in `SignedTransaction` - The `from_addr` is a pure function of the `signing_info`, but we choose to store it anyway to avoid having to repeat the expensive address recovery process.

We also change the way we generate transaction signatures to match Ethereum's and update a test case to check this.