### PR TITLE
Remove unnecessary `RequestResponse` message

### DIFF
--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -110,7 +110,6 @@ pub enum Message {
     BlockRequest(BlockRequest),
     BlockResponse(BlockResponse),
     NewTransaction(SignedTransaction),
-    RequestResponse,
 }
 
 impl Message {
@@ -122,7 +121,6 @@ impl Message {
             Message::BlockRequest(_) => "BlockRequest",
             Message::BlockResponse(_) => "BlockResponse",
             Message::NewTransaction(_) => "NewTransaction",
-            Message::RequestResponse => "RequestResponse",
         }
     }
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -92,7 +92,6 @@ impl Node {
             Message::BlockResponse(m) => {
                 self.handle_block_response(source, m)?;
             }
-            Message::RequestResponse => {}
             Message::NewTransaction(t) => {
                 self.consensus.new_transaction(t)?;
             }

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -267,12 +267,10 @@ impl NodeLauncher {
 
                     SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(request_response::Event::Message { message, peer })) => {
                                 match message {
-                                    request_response::Message::Request {request, channel, ..} => {
+                                    request_response::Message::Request { request, .. } => {
                                         debug!(%peer, "direct message received");
 
                                         self.node.lock().unwrap().handle_message(peer, request).unwrap();
-
-                                        let _ = swarm.behaviour_mut().request_response.send_response(channel, Message::RequestResponse);
                                     }
                                     request_response::Message::Response {..} => {}
                                 }


### PR DESCRIPTION
If my understanding is correct, this was just used as a placeholder response to all point-to-point requests but didn't actually do anything or carry any value.