### PR TITLE
Shutdown Otterscan container with `SIGKILL`

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -81,3 +81,5 @@ services:
     image: otterscan/otterscan:develop
     ports:
       - "5100:80"
+    # Fast shutdown - Don't gracefully close open connections.
+    stop_signal: SIGKILL


### PR DESCRIPTION
By default, a `SIGQUIT` is sent which tells nginx to do a graceful shutdown. On my machine this takes a noticable number of seconds. I don't think we care about being graceful for local development builds, so speed things up by immediately `SIGKILL`ing instead.