### PR TITLE
Revert "Remove unnecessary `RequestResponse` message (#248)"

### DIFF
--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -110,6 +110,7 @@ pub enum Message {
     BlockRequest(BlockRequest),
     BlockResponse(BlockResponse),
     NewTransaction(SignedTransaction),
+    RequestResponse,
 }
 
 impl Message {
@@ -121,6 +122,7 @@ impl Message {
             Message::BlockRequest(_) => "BlockRequest",
             Message::BlockResponse(_) => "BlockResponse",
             Message::NewTransaction(_) => "NewTransaction",
+            Message::RequestResponse => "RequestResponse",
         }
     }
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -92,6 +92,7 @@ impl Node {
             Message::BlockResponse(m) => {
                 self.handle_block_response(source, m)?;
             }
+            Message::RequestResponse => {}
             Message::NewTransaction(t) => {
                 self.consensus.new_transaction(t)?;
             }

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -267,10 +267,12 @@ impl NodeLauncher {
 
                     SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(request_response::Event::Message { message, peer })) => {
                                 match message {
-                                    request_response::Message::Request { request, .. } => {
+                                    request_response::Message::Request {request, channel, ..} => {
                                         debug!(%peer, "direct message received");
 
                                         self.node.lock().unwrap().handle_message(peer, request).unwrap();
+
+                                        let _ = swarm.behaviour_mut().request_response.send_response(channel, Message::RequestResponse);
                                     }
                                     request_response::Message::Response {..} => {}
                                 }


### PR DESCRIPTION
This reverts commit 7da640f58907d50212162ac31a91ef96846c3b2c - the chain will stall eventually since the sender blacklists nodes that do not respond.