### PR TITLE
Randomise order of message delivery in tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # Run a decent number of samples for our randomized
+  ZQ_TEST_SAMPLES: 100
 
 jobs:
   check:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -888,7 +888,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1437,7 +1437,7 @@ checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1821,7 +1821,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.22",
  "toml 0.7.4",
  "walkdir",
 ]
@@ -1839,7 +1839,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -1865,7 +1865,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "syn 2.0.18",
+ "syn 2.0.22",
  "tempfile",
  "thiserror",
  "tiny-keccak",
@@ -2248,7 +2248,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -3499,6 +3499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffbee8634e0d45d258acb448e7eaab3fce7a0a467395d4d9f228e3c1f01fb2e4"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3823,7 +3832,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -4281,7 +4290,7 @@ checksum = "39407670928234ebc5e6e580247dd567ad73a3578460c5990f9503df207e8f07"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -4420,7 +4429,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b69d39aab54d069e7f2fe8cb970493e7834601ca2d8c65fd7bbd183578080d1"
 dependencies = [
  "proc-macro2",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -4486,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.59"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]
@@ -4762,6 +4771,15 @@ dependencies = [
  "aho-corasick 1.0.1",
  "memchr",
  "regex-syntax 0.7.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -5204,7 +5222,7 @@ checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5543,9 +5561,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.18"
+version = "2.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
+checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5648,7 +5666,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5759,7 +5777,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5930,7 +5948,7 @@ checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -5970,10 +5988,14 @@ version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -6301,7 +6323,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-shared",
 ]
 
@@ -6335,7 +6357,7 @@ checksum = "e128beba882dd1eb6200e1dc92ae6c5dbaa4311aa7bb211ca035779e5efc39f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6986,7 +7008,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.18",
+ "syn 2.0.22",
 ]
 
 [[package]]
@@ -7017,6 +7039,7 @@ dependencies = [
  "opentelemetry-otlp",
  "primitive-types 0.12.1",
  "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rlp",
  "serde",
@@ -7034,4 +7057,14 @@ dependencies = [
  "tracing-subscriber",
  "ureq",
  "vergen",
+ "zilliqa-macros",
+]
+
+[[package]]
+name = "zilliqa-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
  "zilliqa",
+ "zilliqa-macros",
  "z2",
  "eth-trie.rs"
 ]

--- a/zilliqa-macros/Cargo.toml
+++ b/zilliqa-macros/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zilliqa-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.63"
+quote = "1.0.28"
+syn = "2.0.22"

--- a/zilliqa-macros/src/lib.rs
+++ b/zilliqa-macros/src/lib.rs
@@ -1,0 +1,8 @@
+mod test;
+
+use proc_macro::TokenStream;
+
+#[proc_macro_attribute]
+pub fn test(args: TokenStream, item: TokenStream) -> TokenStream {
+    test::test_macro(args.into(), item.into()).into()
+}

--- a/zilliqa-macros/src/test.rs
+++ b/zilliqa-macros/src/test.rs
@@ -1,0 +1,66 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
+use syn::ItemFn;
+
+// Much of this code is adapted from https://github.com/tokio-rs/tokio/blob/910a1e2fcf8ebafd41c2841144c3a1037af7dc40/tokio-macros/src/lib.rs.
+
+pub(crate) fn test_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
+    let mut input: ItemFn = match syn::parse2(item.clone()) {
+        Ok(it) => it,
+        Err(e) => return token_stream_with_error(item, e),
+    };
+
+    // Take the name of the test function as written.
+    let test_name = input.sig.ident;
+    // Rename the test function to "inner". We will add it as an inner function of our actual test and call it.
+    let inner_name = Ident::new("inner", Span::call_site());
+    input.sig.ident = inner_name.clone();
+
+    quote! {
+        #[tokio::test(flavor = "multi_thread")]
+        async fn #test_name() {
+            // The original test function
+            #input
+
+            // Work out what RNG seeds to run the test with.
+            let seeds: Vec<u64> = if let Some(seed) = std::env::var_os("ZQ_TEST_RNG_SEED") {
+                vec![seed.to_str().unwrap().parse().unwrap()]
+            } else {
+                let samples: usize = std::env::var_os("ZQ_TEST_SAMPLES")
+                    .map(|s| s.to_str().unwrap().parse().unwrap())
+                    .unwrap_or(1);
+                // Generate random seeds using the thread-local RNG.
+                rand::Rng::sample_iter(rand::thread_rng(), rand::distributions::Standard).take(samples).collect()
+            };
+
+            let mut set = tokio::task::JoinSet::new();
+
+            for seed in seeds {
+                set.spawn(async move {
+                    // Set up a tracing subscriber, so we can see logs from failed test cases.
+                    let subscriber = tracing_subscriber::fmt()
+                        .with_ansi(false)
+                        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
+                    let _guard = tracing_subscriber::util::SubscriberInitExt::set_default(subscriber);
+
+                    println!("Reproduce this test run by setting ZQ_TEST_RNG_SEED={seed}");
+                    let mut rng = <rand_chacha::ChaCha8Rng as rand_core::SeedableRng>::seed_from_u64(seed);
+                    let network = crate::Network::new(&mut rng, 4);
+                    // Call the original test function
+                    #inner_name(network).await;
+                });
+            }
+
+            while let Some(result) = set.join_next().await {
+                let () = result.unwrap();
+            }
+        }
+    }
+}
+
+// If any of the steps for this macro fail, we still want to expand to an item that is as close to the expected output
+// as possible. This helps out IDEs such that completions and other related features keep working.
+fn token_stream_with_error(mut tokens: TokenStream, error: syn::Error) -> TokenStream {
+    tokens.extend(error.into_compile_error());
+    tokens
+}

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -56,10 +56,12 @@ toml = "0.7.4"
 tower = "0.4.13"
 tower-http = { version = "0.4.0", features = ["cors"] }
 tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
+zilliqa-macros = { path = "../zilliqa-macros" }
 
 [dev-dependencies]
 async-trait = "0.1.68"
 ethers = { version = "2.0.7", default-features = false, features = ["ethers-solc", "legacy"] }
+rand_chacha = "0.3.1"
 tempfile = "3.6.0"
 ureq = "2.6.2"

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -176,6 +176,11 @@ impl SecretKey {
         Self::from_bytes(&bls_temp.as_bytes())
     }
 
+    pub fn new_from_rng<R: rand::Rng + rand::CryptoRng>(rng: &mut R) -> Result<SecretKey> {
+        let bls = bls_signatures::PrivateKey::generate(rng);
+        Self::from_bytes(&bls.as_bytes())
+    }
+
     pub fn from_bytes(bytes: &[u8]) -> Result<SecretKey> {
         let bytes: [u8; 32] = bytes.try_into()?;
         // ensure the key is valid for all representations

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -1,12 +1,10 @@
 use crate::Network;
 
-#[tokio::test]
-async fn block_production() {
-    let mut network = Network::new(4);
-
+#[zilliqa_macros::test]
+async fn block_production(mut network: Network<'_>) {
     network
         .run_until(
-            |n| n.node(0).get_latest_block().map_or(0, |b| b.view()) >= 5,
+            |n| n.node().get_latest_block().map_or(0, |b| b.view()) >= 5,
             50,
         )
         .await

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -19,7 +19,7 @@ use ethers::{
     providers::{HttpClientError, JsonRpcClient, JsonRpcError, Provider},
     signers::{LocalWallet, Signer},
 };
-use futures::{stream::BoxStream, Future, StreamExt};
+use futures::{stream::BoxStream, Future, FutureExt, StreamExt};
 use itertools::Itertools;
 use jsonrpsee::{
     types::{Id, RequestSer, Response, ResponsePayload},
@@ -27,17 +27,20 @@ use jsonrpsee::{
 };
 use k256::ecdsa::SigningKey;
 use libp2p::PeerId;
+use rand::{seq::SliceRandom, Rng};
+use rand_chacha::ChaCha8Rng;
 use serde::{de::DeserializeOwned, Serialize};
-use tokio::sync::mpsc;
+use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use zilliqa::{cfg::Config, crypto::SecretKey, message::Message, node::Node};
 
-fn node() -> (
+fn node(
+    secret_key: SecretKey,
+    index: usize,
+) -> (
     TestNode,
     BoxStream<'static, (PeerId, Option<PeerId>, Message)>,
 ) {
-    let secret_key = SecretKey::new().unwrap();
-
     let (message_sender, message_receiver) = mpsc::unbounded_channel();
     let message_receiver = UnboundedReceiverStream::new(message_receiver);
     // Augment the `message_receiver` stream to include the sender's `PeerId`.
@@ -61,6 +64,7 @@ fn node() -> (
 
     (
         TestNode {
+            index,
             peer_id: secret_key.to_libp2p_keypair().public().to_peer_id(),
             secret_key,
             inner: node,
@@ -72,24 +76,41 @@ fn node() -> (
 
 /// A node within a test [Network].
 struct TestNode {
+    index: usize,
     secret_key: SecretKey,
     peer_id: PeerId,
     inner: Arc<Mutex<Node>>,
     rpc_module: RpcModule<Arc<Mutex<Node>>>,
 }
 
-struct Network {
+struct Network<'r> {
     // We keep `nodes` and `receivers` separate so we can independently borrow each half of this struct, while keeping
     // the borrow checker happy.
     nodes: Vec<TestNode>,
     /// A stream of messages from each node. The stream items are a tuple of (source, destination, message).
     /// If the destination is `None`, the message is a broadcast.
     receivers: Vec<BoxStream<'static, (PeerId, Option<PeerId>, Message)>>,
+    resend_message: UnboundedSender<(PeerId, Option<PeerId>, Message)>,
+    rng: &'r mut ChaCha8Rng,
 }
 
-impl Network {
-    pub fn new(nodes: usize) -> Network {
-        let (nodes, receivers): (Vec<_>, Vec<_>) = (0..nodes).map(|_| node()).unzip();
+impl<'r> Network<'r> {
+    pub fn new(rng: &mut ChaCha8Rng, nodes: usize) -> Network {
+        let mut keys: Vec<_> = (0..nodes)
+            .map(|_| SecretKey::new_from_rng(rng).unwrap())
+            .collect();
+        // Sort the keys in the same order as they will occur in the consensus committee. This means node indices line
+        // up with indices in the committee, making logs easier to read.
+        keys.sort_unstable_by_key(|key| key.to_libp2p_keypair().public().to_peer_id());
+        let (nodes, mut receivers): (Vec<_>, Vec<_>) = keys
+            .into_iter()
+            .enumerate()
+            .map(|(i, key)| node(key, i))
+            .unzip();
+
+        for node in &nodes {
+            println!("Node {}: {}", node.index, node.peer_id);
+        }
 
         nodes
             .iter()
@@ -109,28 +130,79 @@ impl Network {
                 }
             });
 
-        Network { nodes, receivers }
+        let (resend_message, receive_resend_message) =
+            mpsc::unbounded_channel::<(PeerId, Option<PeerId>, Message)>();
+        let receive_resend_message = UnboundedReceiverStream::new(receive_resend_message).boxed();
+        receivers.push(receive_resend_message);
+
+        Network {
+            nodes,
+            receivers,
+            resend_message,
+            rng,
+        }
     }
 
-    pub async fn run_for(&mut self, ticks: usize) {
-        let messages = futures::stream::select_all(&mut self.receivers);
-        let mut messages = messages.take(ticks);
-
-        while let Some((source, destination, message)) = messages.next().await {
-            // Respect the destination if it is set and only send it to one
-            for node in self.nodes.iter() {
-                if let Some(dest) = destination {
-                    if dest == node.peer_id {
-                        node.inner
-                            .lock()
-                            .unwrap()
-                            .handle_message(source, message.clone())
-                            .unwrap();
+    pub async fn tick(&mut self) {
+        // Take all the currently ready messages from the stream.
+        let mut messages = Vec::new();
+        for (_i, receiver) in self.receivers.iter_mut().enumerate() {
+            loop {
+                // Poll the receiver with `unconstrained` to ensure it won't be pre-empted. This makes sure we always
+                // get an item if it has been sent. It does not lead to starvation, because we evaluate the returned
+                // future with `.now_or_never()` which instantly returns `None` if the future is not ready.
+                match tokio::task::unconstrained(receiver.next()).now_or_never() {
+                    Some(Some(message)) => {
+                        messages.push(message);
+                    }
+                    Some(None) => {
+                        unreachable!("stream was terminated, this should be impossible");
+                    }
+                    None => {
                         break;
                     }
-                    continue;
                 }
-                // Broadcast when no destination is set
+            }
+        }
+
+        println!(
+            "{} possible messages to send ({:?})",
+            messages.len(),
+            messages
+                .iter()
+                .map(|(s, d, m)| format_message(&self.nodes, *s, *d, m))
+                .collect::<Vec<_>>()
+        );
+
+        if messages.is_empty() {
+            return;
+        }
+        // Pick a random message
+        let index = self.rng.gen_range(0..messages.len());
+        let (source, destination, message) = messages.swap_remove(index);
+        // Requeue the other messages
+        for message in messages {
+            self.resend_message.send(message).unwrap();
+        }
+
+        println!(
+            "{}",
+            format_message(&self.nodes, source, destination, &message)
+        );
+
+        if let Some(destination) = destination {
+            let node = self
+                .nodes
+                .iter()
+                .find(|n| n.peer_id == destination)
+                .unwrap();
+            node.inner
+                .lock()
+                .unwrap()
+                .handle_message(source, message)
+                .unwrap();
+        } else {
+            for node in &self.nodes {
                 node.inner
                     .lock()
                     .unwrap()
@@ -142,7 +214,7 @@ impl Network {
 
     pub async fn run_until(
         &mut self,
-        mut condition: impl FnMut(&Network) -> bool,
+        mut condition: impl FnMut(&mut Network) -> bool,
         mut timeout: usize,
     ) -> Result<()> {
         while !condition(self) {
@@ -150,7 +222,7 @@ impl Network {
                 return Err(anyhow!("condition was still false after {timeout} ticks"));
             }
 
-            self.run_for(1).await;
+            self.tick().await;
 
             timeout -= 1;
         }
@@ -160,16 +232,15 @@ impl Network {
 
     pub async fn run_until_async<Fut: Future<Output = bool>>(
         &mut self,
-        mut condition: impl FnMut(Provider<LocalRpcClient>) -> Fut,
+        mut condition: impl FnMut() -> Fut,
         mut timeout: usize,
     ) -> Result<()> {
-        let provider = self.provider(0);
-        while !condition(provider.clone()).await {
+        while !condition().await {
             if timeout == 0 {
                 return Err(anyhow!("condition was still false after {timeout} ticks"));
             }
 
-            self.run_for(1).await;
+            self.tick().await;
 
             timeout -= 1;
         }
@@ -177,32 +248,49 @@ impl Network {
         Ok(())
     }
 
-    pub fn node(&self, index: usize) -> MutexGuard<Node> {
-        self.nodes[index].inner.lock().unwrap()
+    pub fn node(&mut self) -> MutexGuard<Node> {
+        self.nodes.choose(self.rng).unwrap().inner.lock().unwrap()
     }
 
-    pub fn provider(&self, index: usize) -> Provider<LocalRpcClient> {
+    pub fn provider(&mut self) -> Provider<LocalRpcClient> {
         let client = LocalRpcClient {
             id: Arc::new(AtomicU64::new(0)),
-            rpc_module: self.nodes[index].rpc_module.clone(),
+            rpc_module: self.nodes.choose(self.rng).unwrap().rpc_module.clone(),
         };
         Provider::new(client)
     }
+
+    pub fn random_wallet(&mut self) -> SignerMiddleware<Provider<LocalRpcClient>, LocalWallet> {
+        let wallet: LocalWallet = SigningKey::random(self.rng).into();
+        let wallet = wallet.with_chain_id(0x8001u64);
+        SignerMiddleware::new(self.provider(), wallet)
+    }
 }
 
-pub fn random_wallet(
-    provider: Provider<LocalRpcClient>,
-) -> SignerMiddleware<Provider<LocalRpcClient>, LocalWallet> {
-    let wallet: LocalWallet = SigningKey::random(&mut rand::thread_rng()).into();
-    let wallet = wallet.with_chain_id(0x8001u64);
-    SignerMiddleware::new(provider, wallet)
+fn format_message(
+    nodes: &[TestNode],
+    source: PeerId,
+    destination: Option<PeerId>,
+    message: &Message,
+) -> String {
+    let source_index = nodes.iter().find(|n| n.peer_id == source).unwrap().index;
+    if let Some(destination) = destination {
+        let destination_index = nodes
+            .iter()
+            .find(|n| n.peer_id == destination)
+            .unwrap()
+            .index;
+        format!("{source_index} -> {destination_index}: {}", message.name())
+    } else {
+        format!("{source_index} -> *: {}", message.name())
+    }
 }
 
 /// A helper macro to deploy a contract. Provide the relative path containing the contract, the name of the contract, a
 /// wallet and the network. This will include the contract source in the test binary and compile the contract at
 /// runtime.
 macro_rules! deploy_contract {
-    ($path:expr, $contract:expr, $wallet:ident, $network:ident) => {{
+    ($path:expr, $contract:expr, $wallet:ident, $provider:ident, $network:ident $(,)?) => {{
         // Include the contract source directly in the binary.
         let contract_source = include_bytes!($path);
 
@@ -231,8 +319,14 @@ macro_rules! deploy_contract {
 
         $network
             .run_until_async(
-                |p| async move { p.get_transaction_receipt(hash).await.unwrap().is_some() },
-                10,
+                || async {
+                    $provider
+                        .get_transaction_receipt(hash)
+                        .await
+                        .unwrap()
+                        .is_some()
+                },
+                50,
             )
             .await
             .unwrap();
@@ -240,7 +334,7 @@ macro_rules! deploy_contract {
         hash
     }};
 }
-use deploy_contract;
+pub(crate) use deploy_contract;
 
 /// An implementation of [JsonRpcClient] which sends requests directly to an [RpcModule], without making any network
 /// calls.

--- a/zilliqa/tests/it/web3.rs
+++ b/zilliqa/tests/it/web3.rs
@@ -1,9 +1,8 @@
 use crate::Network;
 
-#[tokio::test]
-async fn sha3() {
-    let network = Network::new(4);
-    let provider = network.provider(0);
+#[zilliqa_macros::test]
+async fn sha3(mut network: Network<'_>) {
+    let provider = network.provider();
 
     // Example from https://ethereum.org/en/developers/docs/apis/json-rpc/#web3_sha3
     let result: String = provider


### PR DESCRIPTION
Instead of delivering messages in the order they arrive, we keep track of all currently pending messages and deliver a randomly decided one. The random distribution is uniform, so there is no bias towards older messages like would presumably be the case for real networks. The randomness is seeded and reproducible on any machine. If a test case fails, the seed will be printed.

The seeds for a single test are run in parallel using a Tokio `JoinSet`.

The tests are controlled by two environment variables:

- `ZQ_TEST_RNG_SEED` - If set only a single sample is run, using the specified RNG seed.
- `ZQ_TEST_SAMPLES` - Controls the number of random samples for which to run the test cases. Ignored if `ZQ_TEST_RNG_SEED` is set. Defaults to `1`, but set to `100` in CI.

I've added a custom procedual macro for our test harness to make this setup process easy for test writers.