### PR TITLE
Fix missing node error from an empty trie

### DIFF
--- a/eth-trie.rs/src/trie.rs
+++ b/eth-trie.rs/src/trie.rs
@@ -411,6 +411,7 @@ where
         let partial = &path.offset(path_index);
         match source_node {
             Node::Empty => Ok(None),
+            Node::Hash(hash_node) if hash_node.hash == KECCAK_NULL_RLP => Ok(None),
             Node::Leaf(leaf) => {
                 if &leaf.key == partial {
                     Ok(Some(leaf.value.clone()))


### PR DESCRIPTION
`Node::Empty` and `Node::Hash(keccak(rlp::NULL_RLP))` are equivalent, so treat them the same when trying to obtain a value from the node.