### PR TITLE
Reduce log level of "added block" message

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -9,7 +9,7 @@ use anyhow::{anyhow, Result};
 use bitvec::bitvec;
 use itertools::Itertools;
 use libp2p::PeerId;
-use tracing::{debug, info, trace};
+use tracing::{debug, trace};
 
 use crate::{
     cfg::Config,
@@ -621,7 +621,7 @@ impl Consensus {
 
     pub fn add_block(&mut self, block: Block) {
         let hash = block.hash();
-        info!(?hash, ?block.header.view, "added block");
+        debug!(?hash, ?block.header.view, "added block");
         self.blocks.insert(hash, block);
     }
 


### PR DESCRIPTION
This ensures that the logs are quiet while the system is undisturbed in the default configuration.