### PR TITLE
Implement `ots_getContractCreator`

### DIFF
--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -262,6 +262,18 @@ pub struct OtterscanTransactions {
     pub last_page: bool,
 }
 
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OtterscanContractCreator {
+    /// The tx hash of the transaction which created the contract.
+    pub hash: H256,
+    /// The address who directly created the contract. Note that for simple transactions that directly deploy a
+    /// contract this corresponds to the EOA in the from field of the transaction. For deployer contracts, i.e., the
+    /// contract is created as a result of a method call, this corresponds to the address of the contract who created
+    /// it.
+    pub creator: H160,
+}
+
 /// A transaction object, returned by the Ethereum API.
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -96,7 +96,7 @@ impl NodeLauncher {
             secret_key,
             message_sender.clone(),
             reset_timeout_sender.clone(),
-            MemoryDB::default(),
+            MemoryDB::new(false),
         )?;
         let node = Arc::new(Mutex::new(node));
 

--- a/zilliqa/tests/it/contracts/ContractCreator.sol
+++ b/zilliqa/tests/it/contracts/ContractCreator.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+contract CreateMe {}
+
+contract Creator {
+    // Emit the created address as an event, so we can see it in the receipt.
+    event Created(address indexed addr);
+
+    CreateMe created;
+
+    function create() external {
+        created = new CreateMe();
+        emit Created(address(created));
+    }
+}

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -1,8 +1,6 @@
 use ethabi::ethereum_types::U64;
 use ethers::abi::FunctionExt;
-use ethers::solc::EvmVersion;
 use ethers::{
-    prelude::{CompilerInput, DeploymentTxFactory},
     providers::{Middleware, Provider},
     types::{transaction::eip2718::TypedTransaction, BlockId, BlockNumber, TransactionRequest},
     utils::keccak256,

--- a/zilliqa/tests/it/ots.rs
+++ b/zilliqa/tests/it/ots.rs
@@ -1,0 +1,73 @@
+use ethabi::RawLog;
+use ethers::{providers::Middleware, types::TransactionRequest};
+use primitive_types::{H160, H256};
+use serde::{Deserialize, Serialize};
+
+use crate::{deploy_contract, Network};
+
+#[zilliqa_macros::test]
+async fn get_contract_creator(mut network: Network<'_>) {
+    let wallet = network.random_wallet();
+
+    let (hash, abi) = deploy_contract!("contracts/ContractCreator.sol", "Creator", wallet, network);
+
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let contract_address = receipt.contract_address.unwrap();
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct ContractCreator {
+        hash: H256,
+        creator: H160,
+    }
+
+    // First verify the creator of the `Creator` contract is correct. This should be the same as the `from` address in
+    // the receipt.
+    let response: ContractCreator = wallet
+        .provider()
+        .request("ots_getContractCreator", [contract_address])
+        .await
+        .unwrap();
+    assert_eq!(response.hash, hash);
+    assert_eq!(response.creator, receipt.from);
+
+    // Now call the `Creator` contract to deploy the `CreateMe` contract.
+    let call_tx = TransactionRequest::new()
+        .to(contract_address)
+        .data(abi.function("create").unwrap().encode_input(&[]).unwrap());
+
+    let hash = wallet
+        .send_transaction(call_tx, None)
+        .await
+        .unwrap()
+        .tx_hash();
+
+    network
+        .run_until_async(
+            || async {
+                wallet
+                    .get_transaction_receipt(hash)
+                    .await
+                    .unwrap()
+                    .is_some()
+            },
+            50,
+        )
+        .await
+        .unwrap();
+
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let log = receipt.logs[0].clone();
+    let log: RawLog = (log.topics, log.data.to_vec()).into();
+    let log = abi.event("Created").unwrap().parse_log_whole(log).unwrap();
+
+    let created_address = log.params[0].value.clone().into_address().unwrap();
+
+    // Verify the creator of the `CreateMe` contract is the `Creator` contract.
+    let response: ContractCreator = wallet
+        .provider()
+        .request("ots_getContractCreator", [created_address])
+        .await
+        .unwrap();
+    assert_eq!(response.hash, hash);
+    assert_eq!(response.creator, contract_address);
+}


### PR DESCRIPTION
This API requires doing some time travel and transaction replays. If contracts were not able to create contracts themselves, this would be simpler, because the contract creator would always be the `from_addr` of the creation transaction. However, this is not the case so we need to replay transactions with a custom event listener to work out which account created a contract.

