### PR TITLE
Make transactions' `to_addr` optional

### DIFF
--- a/zilliqa/src/api/types.rs
+++ b/zilliqa/src/api/types.rs
@@ -328,8 +328,8 @@ pub struct EthTransactionReceipt {
     pub block_number: u64,
     #[serde(serialize_with = "hex")]
     pub from: H160,
-    #[serde(serialize_with = "hex")]
-    pub to: H160,
+    #[serde(serialize_with = "option_hex")]
+    pub to: Option<H160>,
     #[serde(serialize_with = "hex")]
     pub cumulative_gas_used: u64,
     #[serde(serialize_with = "hex")]
@@ -423,11 +423,7 @@ fn bool_as_int<S: Serializer>(b: &bool, serializer: S) -> Result<S::Ok, S::Error
 pub struct CallParams {
     #[serde(default)]
     pub from: H160,
-    // The documentation states that the `to` field is required, but some clients (notably Ethers.js) omit it for
-    // contract creations, where the `to` address is zero. Therefore, we default to the zero address if `to` is
-    // omitted.
-    #[serde(default)]
-    pub to: H160,
+    pub to: Option<H160>,
     #[serde(deserialize_with = "deserialize_data")]
     pub data: Vec<u8>,
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -137,8 +137,8 @@ impl Node {
 
     pub fn call_contract(
         &self,
-        caller: Address,
-        contract: Address,
+        from_addr: Address,
+        to_addr: Option<Address>,
         data: Vec<u8>,
     ) -> Result<Vec<u8>> {
         let current_block = self
@@ -146,8 +146,8 @@ impl Node {
             .ok_or_else(|| anyhow!("no blocks"))?
             .header;
         self.consensus.state().call_contract(
-            caller,
-            contract,
+            from_addr,
+            to_addr,
             data,
             self.config.eth_chain_id,
             current_block,

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -204,8 +204,7 @@ impl State {
 pub struct Address(pub H160);
 
 impl Address {
-    /// Address of the contract which allows you to deploy other contracts.
-    pub const DEPLOY_CONTRACT: Address = Address(H160::zero());
+    pub const ZERO: Address = Address(H160::zero());
 
     /// Address of the native token ERC-20 contract.
     pub const NATIVE_TOKEN: Address = Address(H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0ZIL"));
@@ -277,7 +276,11 @@ impl SignedTransaction {
                 rlp.append(&txn.nonce)
                     .append(&txn.gas_price)
                     .append(&txn.gas_limit)
-                    .append(&txn.to_addr.as_bytes().to_vec())
+                    .append(
+                        &txn.to_addr
+                            .map(|a| a.as_bytes().to_vec())
+                            .unwrap_or_default(),
+                    )
                     .append(&txn.amount)
                     .append(&txn.payload);
                 if use_eip155 {
@@ -320,7 +323,11 @@ fn verify(txn: &Transaction, signing_info: &SigningInfo) -> Result<Address> {
             rlp.append(&txn.nonce)
                 .append(&txn.gas_price)
                 .append(&txn.gas_limit)
-                .append(&txn.to_addr.as_bytes().to_vec())
+                .append(
+                    &txn.to_addr
+                        .map(|a| a.as_bytes().to_vec())
+                        .unwrap_or_default(),
+                )
                 .append(&txn.amount)
                 .append(&txn.payload);
             if use_eip155 {
@@ -365,7 +372,7 @@ pub struct Transaction {
     pub nonce: u64,
     pub gas_price: u128,
     pub gas_limit: u64,
-    pub to_addr: Address,
+    pub to_addr: Option<Address>,
     pub amount: u128,
     pub payload: Vec<u8>,
 }

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -163,4 +163,5 @@ async fn send_transaction(mut network: Network<'_>) {
         .unwrap();
 
     assert_eq!(receipt.to.unwrap(), to);
+    assert_eq!(receipt.from, wallet.address());
 }


### PR DESCRIPTION
Instead of representing contract creations with the zero address, we instead make the to address optional and represent creations with a to address of `None`.

This is in fact how Ethereum works if you dig deep enough into the yellow paper, though all the non-normative documentation is quite confused on the subject.

Specifically, equation (20) in section 4.2 of the
[yellow paper](https://ethereum.github.io/yellowpaper/paper.pdf) states that `T_t` (the to address of a transaction) "is either a 20-byte address hash or, in the case of being a contract-creation transaction (and thus formally equal to the empty set), it is the RLP empty byte sequence and thus the member of `B_0`.

This is important in practice, because a transaction with a to address of `Some(0x0)` has a different hash (and thus signature) than one with a to address of `None`. Previously, this would cause our public key recovery to fail with one of these two encodings, because we unified them.