### PR TITLE
Make consensus committee mutable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1479,7 +1479,7 @@ dependencies = [
  "serde",
  "serde_json",
  "syn 2.0.26",
- "toml 0.7.6",
+ "toml",
  "walkdir",
 ]
 
@@ -2781,6 +2781,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
+ "serde",
  "smallvec",
  "thiserror",
  "unsigned-varint",
@@ -2828,6 +2829,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "regex",
+ "serde",
  "sha2 0.10.7",
  "smallvec",
  "unsigned-varint",
@@ -2868,6 +2870,7 @@ dependencies = [
  "multihash",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.7",
  "thiserror",
  "zeroize",
@@ -2893,6 +2896,7 @@ dependencies = [
  "log",
  "quick-protobuf",
  "rand 0.8.5",
+ "serde",
  "sha2 0.10.7",
  "smallvec",
  "thiserror",
@@ -3262,6 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd59dcc2bbe70baabeac52cd22ae52c55eefe6c38ff11a9439f16a350a939f2"
 dependencies = [
  "core2",
+ "serde",
  "unsigned-varint",
 ]
 
@@ -3976,12 +3981,12 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "1.1.3"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror",
- "toml 0.5.11",
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -5272,15 +5277,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
@@ -6106,6 +6102,7 @@ dependencies = [
  "futures",
  "rand_core 0.6.4",
  "serde",
+ "tempfile",
  "tokio",
  "tokio-stream",
  "zilliqa",
@@ -6170,7 +6167,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "toml 0.7.6",
+ "toml",
  "tower",
  "tower-http",
  "tracing",

--- a/infra/config.toml
+++ b/infra/config.toml
@@ -1,1 +1,3 @@
 otlp_collector_endpoint = "http://otel-collector:4317"
+consensus_timeout = { secs = 5, nanos = 0 }
+genesis_committee = [ ["b27aebb3b54effd7af87c4a064a711554ee0f3f5abf56ca910b46422f2b21603bc383d42eb3b927c4c3b0b8381ca30a3", "12D3KooWESMZ2ttSxDwjfnNe23sHCqsJf6sNEKwgHkdgtCHDsbWU"] ]

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -25,6 +25,7 @@ eyre = "0.6.8"
 futures = "0.3.28"
 rand_core = "0.6.4"
 serde = { version="1.0.171", features = [ "derive" ] }
+tempfile = "3.6.0"
 tokio = { version = "1.29.1", features = ["macros", "rt-multi-thread", "sync", "io-std", "io-util", "process"] }
 tokio-stream = "0.1.14"
 zilliqa = { path = "../zilliqa" }

--- a/z2/src/collector.rs
+++ b/z2/src/collector.rs
@@ -1,8 +1,9 @@
 use crate::runner;
 use eyre::Result;
 use futures::future::JoinAll;
-use std::vec::Vec;
+use std::{path::Path, vec::Vec};
 use tokio::sync::mpsc;
+use zilliqa::crypto::SecretKey;
 
 pub struct Collector {
     pub runners: Vec<runner::Process>,
@@ -11,14 +12,14 @@ pub struct Collector {
 }
 
 impl Collector {
-    pub async fn new(keys: &Vec<String>) -> Result<Collector> {
+    pub async fn new(keys: &Vec<SecretKey>, config_file: &Path) -> Result<Collector> {
         let mut runners = Vec::new();
         let (tx, mut rx) = mpsc::channel(32);
         let nr = keys.len();
         // Fire everything up.
         let mut do_rpc = true;
         for (i, key) in keys.iter().enumerate() {
-            runners.push(runner::Process::spawn(i, key, do_rpc, &tx).await?);
+            runners.push(runner::Process::spawn(i, &key.to_hex(), config_file, do_rpc, &tx).await?);
             do_rpc = false; // only launch RPC server in first node. TODO: better config on nodes
         }
         let reader = tokio::spawn(async move {

--- a/z2/src/runner.rs
+++ b/z2/src/runner.rs
@@ -1,5 +1,6 @@
 use eyre::Result;
 use futures::future::JoinAll;
+use std::path::Path;
 use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
@@ -29,6 +30,7 @@ impl Process {
     pub async fn spawn(
         index: usize,
         key: &str,
+        config_file: &Path,
         rpc: bool,
         channel: &mpsc::Sender<Message>,
     ) -> Result<Process> {
@@ -37,6 +39,8 @@ impl Process {
         if !rpc {
             cmd.arg("--no-jsonrpc");
         }
+        cmd.arg("--config-file");
+        cmd.arg(config_file);
         cmd.stdout(Stdio::piped());
         let mut child = cmd
             .spawn()

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -1,37 +1,56 @@
 use crate::collector;
 use eyre::{eyre, Result};
+use std::io::Write;
+use tempfile::NamedTempFile;
 /// This module should eventually generate configuration files
 /// For now, it just generates secret keys (which should be different each run, or we will become dependent on their values)
-use zilliqa::crypto;
+use zilliqa::crypto::SecretKey;
 
 pub struct Setup {
     /// How many nodes should we start?
     pub how_many: u32,
-    /// Secret keys for the nodes (we deliberately elect not to know too much about them)
-    pub secret_keys: Vec<String>,
+    /// Secret keys for the nodes
+    pub secret_keys: Vec<SecretKey>,
     /// The collector, if one is running
     pub collector: Option<collector::Collector>,
+    config_file: NamedTempFile,
 }
 
 impl Setup {
     pub fn new(how_many: u32) -> Result<Self> {
         // Generate some keys
-        let mut secret_keys: Vec<String> = Vec::new();
+        let mut secret_keys = Vec::new();
         for i in 0..how_many {
-            let key = generate_secret_key_hex()?;
-            println!("[#{i}] = {key}");
+            let key = generate_secret_key()?;
+            println!("[#{i}] = {}", key.to_hex());
             secret_keys.push(key);
         }
+
+        let first_key = secret_keys[0].node_public_key().to_string();
+        let first_peer_id = secret_keys[0]
+            .to_libp2p_keypair()
+            .public()
+            .to_peer_id()
+            .to_string();
+
+        let mut config_file = NamedTempFile::new()?;
+        write!(
+            config_file,
+            r#"genesis_committee = [ [ "{first_key}", "{first_peer_id}" ] ]"#
+        )?;
+
         Ok(Self {
             how_many,
             secret_keys,
             collector: None,
+            config_file,
         })
     }
 
     pub async fn run(&mut self) -> Result<()> {
         // Generate a collector
-        self.collector = Some(collector::Collector::new(&self.secret_keys).await?);
+        self.collector =
+            Some(collector::Collector::new(&self.secret_keys, self.config_file.path()).await?);
         if let Some(mut c) = self.collector.take() {
             c.complete().await?;
         }
@@ -39,9 +58,6 @@ impl Setup {
     }
 }
 
-pub fn generate_secret_key_hex() -> Result<String> {
-    crypto::SecretKey::new()
-        .map_err(|err| eyre!(Box::new(err)))?
-        .to_hex()
-        .map_err(|err| eyre!(Box::new(err)))
+pub fn generate_secret_key() -> Result<SecretKey> {
+    SecretKey::new().map_err(|err| eyre!(Box::new(err)))
 }

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -39,7 +39,7 @@ http = "0.2.9"
 itertools = "0.11.0"
 jsonrpsee = { version = "0.18.2", features = ["server"] }
 k256 = {version = "0.13.1", features = ["serde", "pem"] }
-libp2p = { version = "0.52.1", features = ["gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "yamux"] }
+libp2p = { version = "0.52.1", features = ["gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux"] }
 once_cell = "1.18.0"
 # TODO: Use open telemetry "0.20.0" when released
 opentelemetry = { git = "https://github.com/open-telemetry/opentelemetry-rust", rev = "ecf0dda5686dc45470ae02993a4748c289c407de", features = ["metrics", "rt-tokio"] }

--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -1,0 +1,82 @@
+use std::collections::BTreeMap;
+
+use libp2p::PeerId;
+use tokio::sync::mpsc::UnboundedSender;
+use tracing::trace;
+
+use crate::{
+    crypto::Hash,
+    message::{Block, BlockRef, BlockRequest, Message},
+};
+
+/// Stores and manages the node's list of blocks. Also responsible for making requests for new blocks. In the future,
+/// this may become more complex with retries, batching, snapshots, etc.
+#[derive(Debug)]
+pub struct BlockStore {
+    view_to_block_hash: BTreeMap<u64, Hash>,
+    blocks: BTreeMap<Hash, Block>,
+    message_sender: UnboundedSender<(Option<PeerId>, Message)>,
+}
+
+impl BlockStore {
+    pub fn new(message_sender: UnboundedSender<(Option<PeerId>, Message)>) -> Self {
+        BlockStore {
+            view_to_block_hash: BTreeMap::new(),
+            blocks: BTreeMap::new(),
+            message_sender,
+        }
+    }
+
+    pub fn contains_block(&self, hash: Hash) -> bool {
+        self.blocks.contains_key(&hash)
+    }
+
+    pub fn get_block(&self, hash: Hash) -> Option<&Block> {
+        self.blocks.get(&hash)
+    }
+
+    pub fn get_block_by_view(&self, view: u64) -> Option<&Block> {
+        self.view_to_block_hash
+            .get(&view)
+            .and_then(|hash| self.get_block(*hash))
+    }
+
+    pub fn request_block_by_view(&self, view: u64) {
+        trace!("Request block with view {view}");
+        if let Some(hash) = self.view_to_block_hash.get(&view) {
+            trace!("I know the hash, its {hash}");
+            self.request_block(*hash);
+        } else {
+            trace!("I don't know the hash");
+            self.message_sender
+                .send((
+                    None,
+                    Message::BlockRequest(BlockRequest(BlockRef::View(view))),
+                ))
+                .unwrap();
+        }
+        trace!(
+            "Block views I know: {:?}",
+            self.view_to_block_hash.keys().collect::<Vec<_>>()
+        );
+    }
+
+    pub fn request_block(&self, hash: Hash) {
+        if !self.blocks.contains_key(&hash) {
+            self.message_sender
+                .send((
+                    None,
+                    Message::BlockRequest(BlockRequest(BlockRef::Hash(hash))),
+                ))
+                .unwrap();
+        } else {
+            trace!("Already got the block with hash {hash}");
+        }
+    }
+
+    pub fn process_block(&mut self, block: Block) {
+        trace!(view = block.view(), hash = ?block.hash(), "insert block");
+        self.view_to_block_hash.insert(block.view(), block.hash());
+        self.blocks.insert(block.hash(), block);
+    }
+}

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
-use libp2p::Multiaddr;
+use libp2p::{Multiaddr, PeerId};
 use serde::Deserialize;
+
+use crate::crypto::NodePublicKey;
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -20,6 +22,7 @@ pub struct Config {
     /// The address of another node to dial when this node starts. To join the network, a node must know about at least
     /// one other existing node in the network.
     pub bootstrap_address: Option<Multiaddr>,
+    pub genesis_committee: Vec<(NodePublicKey, PeerId)>,
 }
 
 impl Default for Config {
@@ -32,6 +35,7 @@ impl Default for Config {
             allowed_timestamp_skew: Duration::from_secs(10),
             consensus_timeout: Duration::from_secs(5),
             bootstrap_address: None,
+            genesis_committee: vec![],
         }
     }
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1,22 +1,28 @@
-use eth_trie::MemoryDB;
-use primitive_types::H256;
-use std::collections::{btree_map::Entry, BTreeMap};
-use std::sync::Arc;
-
 use anyhow::{anyhow, Result};
 use bitvec::bitvec;
-use itertools::Itertools;
+use eth_trie::MemoryDB;
 use libp2p::PeerId;
+use primitive_types::H256;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    error::Error,
+    fmt::Display,
+};
+use tokio::sync::mpsc::UnboundedSender;
 use tracing::{debug, trace};
 
+use crate::message::Message;
 use crate::{
+    block_store::BlockStore,
     cfg::Config,
     crypto::{verify_messages, Hash, NodePublicKey, NodeSignature, SecretKey},
     exec::TouchedAddressEventListener,
     exec::TransactionApplyResult,
     message::{
-        AggregateQc, BitSlice, BitVec, Block, BlockHeader, NewView, Proposal, QuorumCertificate,
-        Vote,
+        AggregateQc, BitSlice, BitVec, Block, BlockHeader, BlockRef, NewView, Proposal,
+        QuorumCertificate, Vote,
     },
     state::{Address, SignedTransaction, State, TransactionReceipt},
     time::SystemTime,
@@ -31,7 +37,7 @@ struct NewViewVote {
     qcs: Vec<QuorumCertificate>,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub struct Validator {
     pub public_key: NodePublicKey,
     pub peer_id: PeerId,
@@ -39,19 +45,28 @@ pub struct Validator {
 }
 
 #[derive(Debug)]
+struct MissingBlockError(BlockRef);
+
+impl Display for MissingBlockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "missing block: {:?}", self.0)
+    }
+}
+
+impl Error for MissingBlockError {}
+
+#[derive(Debug)]
 pub struct Consensus {
     secret_key: SecretKey,
     config: Config,
-    committee: Vec<Validator>,
-    blocks: BTreeMap<Hash, Block>,
-    votes: BTreeMap<Hash, (Vec<NodeSignature>, BitVec, u128)>,
+    block_store: BlockStore,
+    votes: BTreeMap<Hash, (Vec<NodeSignature>, BitVec, u128, bool)>,
     new_views: BTreeMap<u64, NewViewVote>,
-    high_qc: Option<QuorumCertificate>, // none before we receive the first proposal
+    high_qc: QuorumCertificate,
     view: u64,
-    /// The latest finalized block.
-    finalized: Hash,
+    finalized_view: u64,
     /// Peers that have appeared between the last view and this one. They will be added to the committee before the next view.
-    pending_peers: Vec<(PeerId, NodePublicKey)>,
+    pending_peers: Vec<Validator>,
     /// Transactions that have been broadcasted by the network, but not yet executed. Transactions will be removed from this map once they are executed.
     new_transactions: BTreeMap<Hash, SignedTransaction>,
     /// Transactions that have been executed and included in a block, and the blocks the are
@@ -63,158 +78,166 @@ pub struct Consensus {
     /// An index of address to a list of transaction hashes, for which this address appeared somewhere in the
     /// transaction trace. The list of transations is ordered by execution order.
     touched_address_index: BTreeMap<Address, Vec<Hash>>,
+    //buffered_vote: Option<Vote>,
+    //buffered_proposal: Option<Proposal>,
 }
 
 impl Consensus {
-    pub fn new(secret_key: SecretKey, config: Config, database: MemoryDB) -> Result<Self> {
-        let validator = Validator {
-            public_key: secret_key.node_public_key(),
-            peer_id: secret_key.to_libp2p_keypair().public().to_peer_id(),
-            weight: 100,
-        };
-
-        Ok(Consensus {
+    pub fn new(
+        secret_key: SecretKey,
+        config: Config,
+        database: MemoryDB,
+        message_sender: UnboundedSender<(Option<PeerId>, Message)>,
+    ) -> Result<Self> {
+        let mut consensus = Consensus {
             secret_key,
-            config,
-            committee: vec![validator],
-            blocks: BTreeMap::new(),
+            config: config.clone(),
+            block_store: BlockStore::new(message_sender),
             votes: BTreeMap::new(),
             new_views: BTreeMap::new(),
-            high_qc: None,
-            view: 0,
-            finalized: Hash::ZERO,
+            high_qc: QuorumCertificate::genesis(),
+            view: 1,
+            finalized_view: 0,
             pending_peers: Vec::new(),
             new_transactions: BTreeMap::new(),
             transactions: BTreeMap::new(),
             transaction_receipts: BTreeMap::new(),
             state: State::new(Arc::new(database))?,
             touched_address_index: BTreeMap::new(),
-        })
+        };
+
+        let genesis_committee = config
+            .genesis_committee
+            .into_iter()
+            .map(|(public_key, peer_id)| Validator {
+                public_key,
+                peer_id,
+                weight: 100,
+            })
+            .collect();
+        let genesis_state_root_hash = consensus.state.root_hash()?;
+        consensus.add_block(Block::genesis(genesis_committee, genesis_state_root_hash));
+
+        Ok(consensus)
     }
 
-    fn update_view(&mut self, view: u64) {
-        self.view = view;
-        let pending_peers = self.pending_peers.drain(..);
-
-        for (peer_id, public_key) in pending_peers {
-            if self
-                .committee
-                .iter()
-                .filter(|v| v.peer_id == peer_id)
-                .count()
-                > 0
-            {
-                continue;
-            }
-
-            let validator = Validator {
-                peer_id,
-                public_key,
-                weight: 100, // Arbitrary weight
-            };
-            self.committee.push(validator);
+    fn committee(&self) -> Result<&[Validator]> {
+        if let Ok(block) = self.get_block_by_view(self.view.saturating_sub(1)) {
+            Ok(&block.committee)
+        } else {
+            Ok(&[])
         }
-        // We always keep the committee sorted by the peer ID to give a stable ordering across the network.
-        self.committee.sort_unstable_by_key(|v| v.peer_id);
     }
 
     pub fn add_peer(
         &mut self,
-        peer: PeerId,
+        peer_id: PeerId,
         public_key: NodePublicKey,
-    ) -> Result<Option<(PeerId, Vote)>> {
-        if self.pending_peers.contains(&(peer, public_key)) {
+    ) -> Result<Option<(Option<PeerId>, Message)>> {
+        if self.pending_peers.contains(&Validator {
+            peer_id,
+            public_key,
+            weight: 100,
+        }) {
             return Ok(None);
         }
 
-        debug!(%peer, "added pending peer");
+        if self
+            .committee()?
+            .iter()
+            .filter(|v| v.peer_id == peer_id)
+            .count()
+            > 0
+        {
+            return Ok(None);
+        }
 
-        self.pending_peers.push((peer, public_key));
+        self.pending_peers.push(Validator {
+            peer_id,
+            public_key,
+            weight: 100,
+        });
 
-        // Before we have at least 3 other nodes (not including ourselves) there is no point trying to propose blocks,
-        // because the supermajority condition is impossible to achieve.
-        if self.pending_peers.len() >= 3 && self.view == 0 {
-            let genesis = Block::genesis(self.committee.len(), self.state.root_hash()?);
-            self.high_qc = Some(genesis.qc.clone());
-            self.add_block(genesis.clone());
-            self.update_view(1);
-            let vote = self.vote_from_block(&genesis);
-            let leader = self.get_leader(self.view).peer_id;
-            return Ok(Some((leader, vote)));
+        debug!(%peer_id, "added pending peer");
+
+        if self.view == 1 {
+            let me = self.secret_key.to_libp2p_keypair().public().to_peer_id();
+            let genesis = self.get_block_by_view(0)?;
+            // If we're in the genesis committee, vote again.
+            // TODO: Make this work for genesis committee with multiple participants?
+            if genesis.committee.iter().any(|v| v.peer_id == me) {
+                trace!("voting for genesis block");
+                let leader = self.get_leader(self.view)?;
+                let vote = self.vote_from_block(genesis);
+                return Ok(Some((Some(leader.peer_id), Message::Vote(vote))));
+            }
         }
 
         Ok(None)
     }
 
-    pub fn timeout(&mut self) -> Result<Option<(PeerId, NewView)>> {
-        if self.view == 0 {
-            return Ok(None);
+    fn download_blocks_up_to(&mut self, to: u64) {
+        for view in (self.view + 1)..to {
+            self.view = view;
+            self.block_store.request_block_by_view(view);
         }
+        self.view = to + 1;
+    }
 
-        self.update_view(self.view + 1);
+    pub fn timeout(&mut self) -> Result<(PeerId, NewView)> {
+        self.view += 1;
 
-        if let Some(high_qc) = &self.high_qc {
-            let new_view = NewView::new(self.secret_key, high_qc.clone(), self.view, self.index());
-            return Ok(Some((self.get_leader(self.view).peer_id, new_view)));
-        }
-
-        Ok(None)
+        let leader = self.get_leader(self.view)?.peer_id;
+        let new_view = NewView::new(
+            self.secret_key,
+            self.high_qc.clone(),
+            self.view,
+            self.secret_key.node_public_key(),
+        );
+        Ok((leader, new_view))
     }
 
     pub fn proposal(&mut self, proposal: Proposal) -> Result<Option<(PeerId, Vote)>> {
         let (block, transactions) = proposal.into_parts();
+        trace!(block_view = block.view(), "handling block proposal");
 
-        // derive the sender from the proposal's view
-        let sender = self.get_leader(block.view());
-        // verify the sender's signature on the proposal
-        block.verify(sender.public_key)?;
-        // in the future check if we already have another block with the same view as proposal, which means that the sender equivocates; also figure out who voted for both of these blocks and thus equivocated
-        // check if the co-signers of the proposal's qc represent the supermajority
-        self.check_quorum_in_bits(&block.qc.cosigned)?;
-
-        // FIXME: Sane validation of genesis blocks
-        let proposal_view = block.view();
-        if proposal_view > 2 {
-            // verify the block qc's signature
-            self.verify_qc_signature(&block.qc)?;
+        if self.block_store.contains_block(block.hash()) {
+            trace!("ignoring block proposal, block store contains this block already");
+            return Ok(None);
         }
 
-        if let Some(agg) = &block.agg {
-            // check if the signers of the proposal's agg represent the supermajority
-            self.check_quorum_in_indices(&agg.signers)?;
+        match self.check_block(&block) {
+            Ok(()) => {}
+            Err(e) => {
+                if let Some(e) = e.downcast_ref::<MissingBlockError>() {
+                    trace!(?e, "missing block");
+                    match e.0 {
+                        BlockRef::Hash(hash) => self.block_store.request_block(hash),
+                        BlockRef::View(view) => self.block_store.request_block_by_view(view),
+                    }
 
-            // verify the block aggregate qc's signature
-            self.batch_verify_agg_signature(agg)?;
+                    self.add_block(block);
+
+                    return Ok(None);
+                } else {
+                    return Err(e);
+                }
+            }
         }
-
-        let parent = self.get_block(&block.parent_hash())?;
-        let parent_header = parent.header;
-
-        // This block's timestamp must be greater than or equal to the parent block's timestamp.
-        if block.timestamp() < parent.timestamp() {
-            return Err(anyhow!("timestamp decreased from parent"));
-        }
-
-        // This block's timestamp must be at most `self.allowed_timestamp_skew` away from the current time. Note this
-        // can be either forwards or backwards in time.
-        let difference = block
-            .timestamp()
-            .elapsed()
-            .unwrap_or_else(|err| err.duration());
-        if difference > self.config.allowed_timestamp_skew {
-            return Err(anyhow!(
-                "timestamp difference greater than allowed skew: {difference:?}"
-            ));
-        }
-
-        // retrieve the highest among the aggregated qcs and check if it equals the block's qc
-        let proposal_high_qc = self.get_high_qc_from_block(&block)?;
 
         self.add_block(block.clone());
-        self.update_high_qc_and_view(block.agg.is_some(), proposal_high_qc.clone())?;
+        self.update_high_qc_and_view(block.agg.is_some(), block.qc.clone())?;
 
         let proposal_view = block.view();
+        let parent = self.get_block(&block.parent_hash())?;
+        let parent_header = parent.header;
+        let next_leader = block.committee[proposal_view as usize % block.committee.len()].peer_id;
+
+        // If the proposed block is safe, vote for it and advance to the next round.
+        trace!("checking whether block is safe");
         if self.check_safe_block(&block) {
+            trace!("block is safe");
+
             for txn in &transactions {
                 if let Some(result) = self.apply_transaction(txn.clone(), parent_header)? {
                     let receipt = TransactionReceipt {
@@ -233,14 +256,24 @@ impl Consensus {
                     self.state.root_hash()
                 ));
             }
-            // TODO: Download blocks up to `proposal_view - 1`.
-            self.update_view(proposal_view + 1);
-            let leader = self.get_leader(self.view).peer_id;
-            trace!(proposal_view, "voting for block");
-            let vote = self.vote_from_block(&block);
+            self.download_blocks_up_to(proposal_view.saturating_sub(1));
+            self.view = proposal_view + 1;
 
-            Ok(Some((leader, vote)))
+            if !block
+                .committee
+                .iter()
+                .any(|v| v.peer_id == self.secret_key.to_libp2p_keypair().public().to_peer_id())
+            {
+                trace!("can't vote for block proposal, we aren't in the committee");
+                Ok(None)
+            } else {
+                trace!(proposal_view, "voting for block");
+                let vote = self.vote_from_block(&block);
+
+                Ok(Some((next_leader, vote)))
+            }
         } else {
+            trace!("block is not safe");
             Ok(None)
         }
     }
@@ -251,6 +284,7 @@ impl Consensus {
         current_block: BlockHeader,
     ) -> Result<Option<TransactionApplyResult>> {
         let hash = txn.hash();
+        trace!(?hash, "executing transaction");
 
         // If we have the transaction in the mempool, remove it.
         self.new_transactions.remove(&hash);
@@ -266,6 +300,7 @@ impl Consensus {
                 self.state
                     .apply_transaction(txn.clone(), self.config.eth_chain_id, current_block)
             })?;
+            trace!(?hash, "tranasction applied to state");
 
             entry.insert(txn);
             for address in listener.touched {
@@ -287,45 +322,58 @@ impl Consensus {
             .unwrap_or_default()
     }
 
-    pub fn vote(
-        &mut self,
-        _: PeerId,
-        vote: Vote,
-    ) -> Result<Option<(Block, Vec<SignedTransaction>)>> {
+    pub fn vote(&mut self, vote: Vote) -> Result<Option<(Block, Vec<SignedTransaction>)>> {
         let Ok(block) = self.get_block(&vote.block_hash) else { return Ok(None); }; // TODO: Is this the right response when we recieve a vote for a block we don't know about?
         let block_hash = block.hash();
         let block_view = block.view();
-        trace!(block_view, self.view, "handling vote");
+        trace!(block_view, self.view, %block_hash, "handling vote");
+
         // if we are not the leader of the round in which the vote counts
-        if self.get_leader(block_view + 1).public_key != self.secret_key.node_public_key() {
+        if block.committee[block_view as usize % block.committee.len()].public_key
+            != self.secret_key.node_public_key()
+        {
             trace!(vote_view = block_view + 1, "skipping vote, not the leader");
             return Ok(None);
         }
         // if the vote is too old and does not count anymore
         if block_view + 1 < self.view {
+            trace!("vote is too old");
             return Ok(None);
         }
-        // verify the sender's signature on block_hash
-        let sender = self.get_member(vote.index);
-        vote.verify(sender.public_key)?;
 
-        let (mut signatures, mut cosigned, mut cosigned_weight) =
-            self.votes.remove(&block_hash).unwrap_or_else(|| {
+        // verify the sender's signature on block_hash
+        let (index, &sender) = block // TODO: Is this the right committee?
+            .committee
+            .iter()
+            .enumerate()
+            .find(|(_, v)| v.public_key == vote.public_key)
+            .unwrap();
+        vote.verify()?;
+
+        let committee_size = block.committee.len();
+        let (mut signatures, mut cosigned, mut cosigned_weight, mut supermajority_reached) =
+            self.votes.get(&block_hash).cloned().unwrap_or_else(|| {
                 (
                     Vec::new(),
-                    bitvec![u8, bitvec::order::Msb0; 0; self.committee.len()],
+                    bitvec![u8, bitvec::order::Msb0; 0; committee_size],
                     0,
+                    false,
                 )
             });
 
+        if supermajority_reached {
+            trace!("supermajority already reached in this round");
+            return Ok(None);
+        }
+
         let mut supermajority = false;
         // if the vote is new, store it
-        if !cosigned[vote.index as usize] {
+        if !cosigned[index] {
             signatures.push(vote.signature);
-            cosigned.set(vote.index as usize, true);
+            cosigned.set(index, true);
             cosigned_weight += sender.weight;
 
-            supermajority = cosigned_weight * 3 > self.committee_weight() * 2;
+            supermajority = cosigned_weight * 3 > self.committee_weight(&block.committee)? * 2;
             trace!(
                 cosigned_weight,
                 supermajority,
@@ -333,72 +381,94 @@ impl Consensus {
                 vote_view = block_view + 1,
                 "storing vote"
             );
-            // if we are already in the round in which the vote counts and have reached supermajority
-            if block_view + 1 == self.view && supermajority {
-                let qc = self.qc_from_bits(block_hash, &signatures, cosigned.clone());
-                let parent_hash = qc.block_hash;
-                let parent = self.get_block(&parent_hash)?;
-                let parent_header = parent.header;
+            if supermajority {
+                self.block_store.request_block_by_view(block_view);
+                self.download_blocks_up_to(block_view);
 
-                let applied_transactions: Vec<_> =
-                    self.new_transactions.values().cloned().collect();
-                let applied_transactions: Vec<_> = applied_transactions
-                    .into_iter()
-                    .filter_map(|tx| {
-                        let result = self.apply_transaction(tx.clone(), parent_header);
-                        result
-                            .transpose()
-                            .map(|r| r.map(|r| (tx.clone(), r.success, r.contract_address, r.logs)))
-                    })
-                    .collect::<Result<_>>()?;
-                let applied_transaction_hashes: Vec<_> = applied_transactions
-                    .iter()
-                    .map(|(tx, _, _, _)| tx.hash())
-                    .collect();
+                // if we are already in the round in which the vote counts and have reached supermajority
+                if block_view + 1 == self.view {
+                    let qc = self.qc_from_bits(block_hash, &signatures, cosigned.clone());
+                    let parent_hash = qc.block_hash;
+                    let parent = self.get_block(&parent_hash)?;
+                    let parent_header = parent.header;
 
-                let proposal = Block::from_qc(
-                    self.secret_key,
-                    self.view,
-                    qc,
-                    parent_hash,
-                    self.state.root_hash()?,
-                    applied_transaction_hashes,
-                    SystemTime::max(SystemTime::now(), parent_header.timestamp),
-                );
+                    let applied_transactions: Vec<_> =
+                        self.new_transactions.values().cloned().collect();
+                    let applied_transactions: Vec<_> = applied_transactions
+                        .into_iter()
+                        .filter_map(|tx| {
+                            let result = self.apply_transaction(tx.clone(), parent_header);
+                            result.transpose().map(|r| {
+                                r.map(|r| (tx.clone(), r.success, r.contract_address, r.logs))
+                            })
+                        })
+                        .collect::<Result<_>>()?;
+                    let applied_transaction_hashes: Vec<_> = applied_transactions
+                        .iter()
+                        .map(|(tx, _, _, _)| tx.hash())
+                        .collect();
 
-                let applied_transactions: Vec<_> = applied_transactions
-                    .into_iter()
-                    .map(|(tx, success, contract_address, logs)| {
-                        self.transactions.insert(tx.hash(), tx.clone());
-                        let receipt = TransactionReceipt {
-                            block_hash: proposal.hash(),
-                            success,
-                            contract_address,
-                            logs,
-                        };
-                        self.transaction_receipts.insert(tx.hash(), receipt);
-                        tx
-                    })
-                    .collect();
+                    let proposal = Block::from_qc(
+                        self.secret_key,
+                        self.view,
+                        qc,
+                        parent_hash,
+                        self.state.root_hash()?,
+                        applied_transaction_hashes,
+                        SystemTime::max(SystemTime::now(), parent_header.timestamp),
+                        self.get_next_committee()?,
+                    );
 
-                // as a future improvement, process the proposal before broadcasting it
-                trace!("vote successful");
-                return Ok(Some((proposal, applied_transactions)));
-                // we don't want to keep the collected votes if we proposed a new block
-                // we should remove the collected votes if we couldn't reach supermajority within the view
+                    let applied_transactions: Vec<_> = applied_transactions
+                        .into_iter()
+                        .map(|(tx, success, contract_address, logs)| {
+                            self.transactions.insert(tx.hash(), tx.clone());
+                            let receipt = TransactionReceipt {
+                                block_hash: proposal.hash(),
+                                success,
+                                contract_address,
+                                logs,
+                            };
+                            self.transaction_receipts.insert(tx.hash(), receipt);
+                            tx
+                        })
+                        .collect();
+
+                    supermajority_reached = true;
+                    self.votes.insert(
+                        block_hash,
+                        (signatures, cosigned, cosigned_weight, supermajority_reached),
+                    );
+                    // as a future improvement, process the proposal before broadcasting it
+                    trace!(proposal_hash = ?proposal.hash(), "vote successful");
+                    return Ok(Some((proposal, applied_transactions)));
+                    // we don't want to keep the collected votes if we proposed a new block
+                    // we should remove the collected votes if we couldn't reach supermajority within the view
+                }
             }
         }
         if !supermajority {
-            self.votes
-                .insert(block_hash, (signatures, cosigned, cosigned_weight));
+            self.votes.insert(
+                block_hash,
+                (signatures, cosigned, cosigned_weight, supermajority_reached),
+            );
         }
 
         Ok(None)
     }
 
+    fn get_next_committee(&mut self) -> Result<Vec<Validator>> {
+        let committee = self.committee()?.to_vec();
+        let joiners = self
+            .pending_peers
+            .drain(..)
+            .filter(|v1| !committee.iter().any(|v2| v1.peer_id == v2.peer_id));
+        Ok(committee.iter().cloned().chain(joiners).collect())
+    }
+
     pub fn new_view(&mut self, _: PeerId, new_view: NewView) -> Result<Option<Block>> {
         // if we are not the leader of the round in which the vote counts
-        if self.get_leader(new_view.view).public_key != self.secret_key.node_public_key() {
+        if self.get_leader(new_view.view)?.public_key != self.secret_key.node_public_key() {
             trace!(new_view.view, "skipping new view, not the leader");
             return Ok(None);
         }
@@ -407,12 +477,21 @@ impl Consensus {
             return Ok(None);
         }
         // verify the sender's signature on the block hash
-        let sender = self.get_member(new_view.index);
+        let Some((index, sender)) = self
+            .committee()?
+            .iter()
+            .enumerate()
+            .find(|(_, v)| v.public_key == new_view.public_key) else {
+                debug!("ignoring new view from unknown node (buffer?)");
+                return Ok(None);
+            };
+        let sender = *sender;
         new_view.verify(sender.public_key)?;
 
         // check if the sender's qc is higher than our high_qc or even higher than our view
         self.update_high_qc_and_view(false, new_view.qc.clone())?;
 
+        let committee_size = self.committee()?.len();
         let NewViewVote {
             mut signatures,
             mut signers,
@@ -425,20 +504,21 @@ impl Consensus {
             .unwrap_or_else(|| NewViewVote {
                 signatures: Vec::new(),
                 signers: Vec::new(),
-                cosigned: bitvec![u8, bitvec::order::Msb0; 0; self.committee.len()],
+                cosigned: bitvec![u8, bitvec::order::Msb0; 0; committee_size],
                 cosigned_weight: 0,
                 qcs: Vec::new(),
             });
 
         let mut supermajority = false;
-        // if the vote is new, stores it
-        if !cosigned[new_view.index as usize] {
+        // if the vote is new, store it
+        if !cosigned[index] {
             signatures.push(new_view.signature);
-            signers.push(new_view.index);
-            cosigned.set(new_view.index as usize, true);
+            signers.push(index as u16);
+            cosigned.set(index, true);
             cosigned_weight += sender.weight;
             qcs.push(new_view.qc);
-            supermajority = cosigned_weight * 3 > self.committee_weight() * 2;
+            // TODO: New views broken
+            supermajority = cosigned_weight * 3 > self.committee_weight(&[])? * 2;
             let num_signers = signers.len();
             trace!(
                 num_signers,
@@ -448,28 +528,33 @@ impl Consensus {
                 new_view.view,
                 "storing vote for new view"
             );
-            // if we are already in the round in which the vote counts and have reached supermajority
-            if new_view.view == self.view && supermajority {
-                // todo: the aggregate qc is an aggregated signature on the qcs, view and validator index which can be batch verified
-                let agg =
-                    self.aggregate_qc_from_indexes(new_view.view, qcs, &signatures, signers)?;
-                let high_qc = self.get_highest_from_agg(&agg)?;
-                let parent_hash = high_qc.block_hash;
-                let state_root = self.state.root_hash()?;
-                let parent = self.get_block(&parent_hash)?;
-                let proposal = Block::from_agg(
-                    self.secret_key,
-                    self.view,
-                    high_qc.clone(),
-                    agg,
-                    parent_hash,
-                    state_root,
-                    SystemTime::max(SystemTime::now(), parent.timestamp()),
-                );
-                // as a future improvement, process the proposal before broadcasting it
-                return Ok(Some(proposal));
-                // we don't want to keep the collected votes if we proposed a new block
-                // we should remove the collected votes if we couldn't reach supermajority within the view
+            if supermajority {
+                self.download_blocks_up_to(new_view.view - 1);
+
+                // if we are already in the round in which the vote counts and have reached supermajority
+                if new_view.view == self.view {
+                    // todo: the aggregate qc is an aggregated signature on the qcs, view and validator index which can be batch verified
+                    let agg =
+                        self.aggregate_qc_from_indexes(new_view.view, qcs, &signatures, signers)?;
+                    let high_qc = self.get_highest_from_agg(&agg)?;
+                    let parent_hash = high_qc.block_hash;
+                    let state_root_hash = self.state.root_hash()?;
+                    let parent = self.get_block(&parent_hash)?;
+                    let proposal = Block::from_agg(
+                        self.secret_key,
+                        self.view,
+                        high_qc.clone(),
+                        agg,
+                        parent_hash,
+                        state_root_hash,
+                        SystemTime::max(SystemTime::now(), parent.timestamp()),
+                        self.get_next_committee()?,
+                    );
+                    // as a future improvement, process the proposal before broadcasting it
+                    return Ok(Some(proposal));
+                    // we don't want to keep the collected votes if we proposed a new block
+                    // we should remove the collected votes if we couldn't reach supermajority within the view
+                }
             }
         }
         if !supermajority {
@@ -508,24 +593,25 @@ impl Consensus {
         from_agg: bool,
         new_high_qc: QuorumCertificate,
     ) -> Result<()> {
-        let Some(new_high_qc_block) = self.blocks.get(&new_high_qc.block_hash) else {
+        let Some(new_high_qc_block) = self.block_store.get_block(new_high_qc.block_hash) else {
             // We don't set high_qc to a qc if we don't have its block.
             return Ok(());
         };
-        match &self.high_qc {
-            None => {
-                self.high_qc = Some(new_high_qc);
-            }
-            Some(high_qc) => {
-                let current_high_qc_view = self.get_block(&high_qc.block_hash)?.view();
-                // If `from_agg` then we always release the lock because the supermajority has a different high_qc.
-                if from_agg || new_high_qc_block.view() > current_high_qc_view {
-                    self.high_qc = Some(new_high_qc);
-                }
+
+        let new_high_qc_block_view = new_high_qc_block.view();
+
+        if self.high_qc.block_hash == Hash::ZERO {
+            self.high_qc = new_high_qc;
+        } else {
+            let current_high_qc_view = self.get_block(&self.high_qc.block_hash)?.view();
+            // If `from_agg` then we always release the lock because the supermajority has a different high_qc.
+            if from_agg || new_high_qc_block_view > current_high_qc_view {
+                self.high_qc = new_high_qc;
             }
         }
-        // TODO: Download the missing blocks
-        self.update_view(new_high_qc_block.view());
+
+        self.download_blocks_up_to(new_high_qc_block_view);
+
         Ok(())
     }
 
@@ -566,11 +652,11 @@ impl Consensus {
         while current.view() > ancestor.view() {
             current = self.get_block(&current.parent_hash())?;
         }
-        Ok(current.hash() == ancestor.hash())
+        Ok(current.view() == 0 || current.hash() == ancestor.hash())
     }
 
     fn check_safe_block(&mut self, proposal: &Block) -> bool {
-        let Ok(qc_block) = self.get_block(&proposal.qc.block_hash) else { return false; };
+        let Ok(qc_block) = self.get_block(&proposal.qc.block_hash) else { trace!("could not get qc for block: {}", proposal.qc.block_hash); return false; };
         // We don't vote on blocks older than our view
         let not_outdated = proposal.view() >= self.view;
         match proposal.agg {
@@ -581,13 +667,30 @@ impl Consensus {
                     self.check_and_commit(block_hash);
                     not_outdated
                 }
-                Ok(false) | Err(_) => false,
+                Ok(false) => {
+                    trace!("block does not extend from parent");
+                    false
+                }
+                Err(e) => {
+                    trace!(?e, "error checking block extension");
+                    false
+                }
             },
             None => {
-                if proposal.view() == qc_block.view() + 1 {
+                if proposal.view() == 0 || proposal.view() == qc_block.view() + 1 {
                     self.check_and_commit(proposal.hash());
+
+                    if !not_outdated {
+                        trace!("proposal is outdated: {} < {}", proposal.view(), self.view);
+                    }
+
                     not_outdated
                 } else {
+                    trace!(
+                        "block does not extend from parent, {} != {} + 1",
+                        proposal.view(),
+                        qc_block.view()
+                    );
                     false
                 }
             }
@@ -595,37 +698,142 @@ impl Consensus {
     }
 
     fn check_and_commit(&mut self, proposal_hash: Hash) {
-        let Ok(proposal) = self.get_block(&proposal_hash) else { return; };
-        let Ok(prev_1) = self.get_block(&proposal.qc.block_hash) else { return; };
-        let Ok(prev_2) = self.get_block(&prev_1.qc.block_hash) else { return; };
+        let Ok(proposal) = self.get_block(&proposal_hash) else { trace!("block not found: {proposal_hash}"); return; };
+        let Ok(prev_1) = self.get_block(&proposal.qc.block_hash) else { trace!("parent not found: {}", proposal.qc.block_hash); return; };
+        let Ok(prev_2) = self.get_block(&prev_1.qc.block_hash) else { trace!("grandparent not found: {}", prev_1.qc.block_hash); return; };
 
-        if prev_1.view() == prev_2.view() + 1 {
+        if prev_1.view() == 0 || prev_1.view() == prev_2.view() + 1 {
             let committed_block = prev_2;
-            let Ok(finalized_block) = self.get_block(&self.finalized) else { return; };
+            let finalized_block = self.get_block_by_view(self.finalized_view).unwrap();
             let mut current = committed_block;
             // commit blocks back to the last finalized block
-            while current.view() > finalized_block.view() {
+            while current.view() > self.finalized_view {
                 let Ok(new) = self.get_block(&current.parent_hash()) else { return; };
                 current = new;
             }
-            if current.hash() == self.finalized {
-                self.finalized = committed_block.hash();
+            if current.hash() == finalized_block.hash() {
+                self.finalized_view = committed_block.view();
                 // discard blocks that can't be committed anymore
             }
+        } else {
+            trace!(
+                "parent does not extend from grandparent {} != {} + 1",
+                prev_1.view(),
+                prev_2.view()
+            );
         }
     }
 
-    pub fn add_block(&mut self, block: Block) {
+    /// Check the validity of a block
+    fn check_block(&mut self, block: &Block) -> Result<()> {
+        block.verify_hash()?;
+
+        if block.view() == 0 {
+            return Ok(());
+        }
+
+        // TODO: Handle missing block error here - Happens if we join the network late, our finalized_view is still 0. We need to get the genesis block!
+        let finalized_block = self.get_block_by_view(self.finalized_view)?;
+        if block.view() < finalized_block.view() {
+            return Err(anyhow!(
+                "block is too old: view is {} but we have finalized {}",
+                block.view(),
+                finalized_block.view()
+            ));
+        }
+
+        let parent = self.get_block(&block.parent_hash())?;
+
+        // Derive the proposer from the block's view
+        let proposer = parent.committee[parent.view() as usize % parent.committee.len()];
+        trace!("I think the block proposer is: {}", proposer.peer_id);
+        // Verify the proposer's signature on the block
+        proposer
+            .public_key
+            .verify(block.hash().as_bytes(), block.signature())?;
+        // Check if the co-signers of the block's QC represent the supermajority.
+        self.check_quorum_in_bits(block.view(), &block.qc.cosigned)?;
+        // Verify the block's QC signature
+        self.verify_qc_signature(&block.qc)?;
+        if let Some(agg) = &block.agg {
+            // Check if the signers of the block's aggregate QC represent the supermajority
+            self.check_quorum_in_indices(block.view(), &agg.signers)?;
+            // Verify the aggregate QC's signature
+            self.batch_verify_agg_signature(agg)?;
+        }
+
+        // Retrieve the highest among the aggregated QCs and check if it equals the block's QC.
+        let block_high_qc = self.get_high_qc_from_block(block)?;
+        let block_high_qc_block = self.get_block(&block_high_qc.block_hash)?;
+        // Prevent the creation of forks from the already committed chain
+        if block_high_qc_block.view() < finalized_block.view() {
+            return Err(anyhow!("invalid block"));
+        }
+
+        // This block's timestamp must be greater than or equal to the parent block's timestamp.
+        if block.timestamp() < parent.timestamp() {
+            return Err(anyhow!("timestamp decreased from parent"));
+        }
+
+        // This block's timestamp must be at most `self.allowed_timestamp_skew` away from the current time. Note this
+        // can be either forwards or backwards in time.
+        let difference = block
+            .timestamp()
+            .elapsed()
+            .unwrap_or_else(|err| err.duration());
+        if difference > self.config.allowed_timestamp_skew {
+            return Err(anyhow!(
+                "timestamp difference greater than allowed skew: {difference:?}"
+            ));
+        }
+
+        if !self.block_extends_from(block, finalized_block)? {
+            return Err(anyhow!("invalid block"));
+        }
+
+        Ok(())
+    }
+
+    // Checks for the validity of a block and adds it to our block store if valid.
+    pub fn receive_block(&mut self, block: Block) -> Result<()> {
+        if self.block_store.contains_block(block.hash()) {
+            return Ok(());
+        }
+
+        match self.check_block(&block) {
+            Ok(()) => {
+                self.update_high_qc_and_view(block.agg.is_some(), block.qc.clone())?;
+                self.add_block(block);
+            }
+            Err(e) => {
+                // TODO: Downcasting is a bit ugly here - We should probably have an error enum instead.
+                if let Some(e) = e.downcast_ref::<MissingBlockError>() {
+                    // We don't call `update_high_qc_and_view` here because the block might be a fork of the finalized chain
+                    self.add_block(block);
+                    match e.0 {
+                        BlockRef::Hash(hash) => self.block_store.request_block(hash),
+                        BlockRef::View(view) => self.block_store.request_block_by_view(view),
+                    }
+                } else {
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn add_block(&mut self, block: Block) {
         let hash = block.hash();
         debug!(?hash, ?block.header.view, "added block");
-        self.blocks.insert(hash, block);
+        self.block_store.process_block(block);
     }
 
     fn vote_from_block(&self, block: &Block) -> Vote {
         Vote {
             block_hash: block.hash(),
             signature: self.secret_key.sign(block.hash().as_bytes()),
-            index: self.index(),
+            public_key: self.secret_key.node_public_key(),
         }
     }
 
@@ -642,14 +850,21 @@ impl Consensus {
     }
 
     pub fn get_block(&self, key: &Hash) -> Result<&Block> {
-        self.blocks
-            .get(key)
-            .ok_or_else(|| anyhow!("block not found: {key:?}"))
+        Ok(self
+            .block_store
+            .get_block(*key)
+            .ok_or(MissingBlockError(BlockRef::Hash(*key)))?)
     }
 
-    pub fn get_block_by_view(&self, view: u64) -> Option<&Block> {
-        // TODO: Inefficient - Use an index.
-        self.blocks.values().find(|b| b.view() == view)
+    pub fn get_block_by_view(&self, view: u64) -> Result<&Block> {
+        //if view == 0 {
+        //    return Ok(&EMPTY_GENESIS);
+        //}
+
+        Ok(self
+            .block_store
+            .get_block_by_view(view)
+            .ok_or(MissingBlockError(BlockRef::View(view)))?)
     }
 
     pub fn view(&self) -> u64 {
@@ -661,7 +876,7 @@ impl Consensus {
     }
 
     pub fn state_at(&self, view: u64) -> Option<State> {
-        let root_hash = self.get_block_by_view(view)?.state_root_hash();
+        let root_hash = self.get_block_by_view(view).ok()?.state_root_hash();
         Some(self.state.at_root(H256(root_hash.0)))
     }
 
@@ -714,63 +929,50 @@ impl Consensus {
             .collect();
         let messages: Vec<_> = messages.iter().map(|m| m.as_slice()).collect();
 
+        let committee = self.committee()?;
         let public_keys: Vec<_> = agg
             .signers
             .iter()
-            .map(|i| self.committee[*i as usize].public_key)
+            .map(|i| committee[*i as usize].public_key)
             .collect();
 
         verify_messages(agg.signature, &messages, &public_keys)
     }
 
-    fn get_leader(&self, view: u64) -> Validator {
+    fn get_leader(&self, view: u64) -> Result<Validator> {
         // currently it's a simple round robin but later
         // we will select the leader based on the weights
-        self.committee[(view % (self.committee.len() as u64)) as usize]
+        let block = self.get_block_by_view(view - 1)?;
+        Ok(block.committee[view as usize % block.committee.len()])
     }
 
-    fn get_member(&self, index: u16) -> Validator {
-        self.committee[index as usize]
+    fn committee_weight(&self, committee: &[Validator]) -> Result<u128> {
+        Ok(committee.iter().map(|v| v.weight).sum())
     }
 
-    fn committee_weight(&self) -> u128 {
-        self.committee.iter().map(|v| v.weight).sum()
-    }
-
-    fn check_quorum_in_bits(&self, cosigned: &BitSlice) -> Result<()> {
-        let cosigned_sum: u128 = self
-            .committee
+    fn check_quorum_in_bits(&self, view: u64, cosigned: &BitSlice) -> Result<()> {
+        let committee = &self.get_block_by_view(view - 1)?.committee;
+        let cosigned_sum: u128 = committee
             .iter()
             .enumerate()
             .map(|(i, v)| if cosigned[i] { v.weight } else { 0 })
             .sum();
 
-        if cosigned_sum * 3 <= self.committee_weight() * 2 {
+        if cosigned_sum * 3 <= self.committee_weight(committee)? * 2 {
             return Err(anyhow!("no quorum"));
         }
 
         Ok(())
     }
 
-    fn check_quorum_in_indices(&self, signers: &[u16]) -> Result<()> {
-        let signed_sum: u128 = signers
-            .iter()
-            .map(|i| self.committee[*i as usize].weight)
-            .sum();
+    fn check_quorum_in_indices(&self, view: u64, signers: &[u16]) -> Result<()> {
+        let committee = &self.get_block_by_view(view - 1)?.committee;
+        let signed_sum: u128 = signers.iter().map(|i| committee[*i as usize].weight).sum();
 
-        if signed_sum * 3 <= self.committee_weight() * 2 {
+        if signed_sum * 3 <= self.committee_weight(committee)? * 2 {
             return Err(anyhow!("no quorum"));
         }
 
         Ok(())
-    }
-
-    /// My own index within the committee.
-    fn index(&self) -> u16 {
-        self.committee
-            .iter()
-            .find_position(|v| v.public_key == self.secret_key.node_public_key())
-            .expect("node should be in committee")
-            .0 as u16
     }
 }

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -101,7 +101,7 @@ impl serde::Serialize for NodePublicKey {
     where
         S: serde::Serializer,
     {
-        self.as_bytes().serialize(serializer)
+        hex::encode(self.as_bytes()).serialize(serializer)
     }
 }
 
@@ -110,7 +110,8 @@ impl<'de> Deserialize<'de> for NodePublicKey {
     where
         D: serde::Deserializer<'de>,
     {
-        let bytes = <Vec<u8>>::deserialize(deserializer)?;
+        let s = <String>::deserialize(deserializer)?;
+        let bytes = hex::decode(s).unwrap();
         NodePublicKey::from_bytes(&bytes)
             .map_err(|_| de::Error::invalid_value(Unexpected::Bytes(&bytes), &"a public key"))
     }
@@ -209,12 +210,12 @@ impl SecretKey {
         k256::ecdsa::SigningKey::from_bytes(&self.bytes.into()).unwrap()
     }
 
-    pub fn as_bytes(&self) -> Result<Vec<u8>> {
-        Ok(self.bytes.to_vec())
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.bytes.to_vec()
     }
 
-    pub fn to_hex(&self) -> Result<String> {
-        Ok(hex::encode(self.bytes))
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.bytes)
     }
 
     pub fn sign(&self, message: &[u8]) -> NodeSignature {

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+mod block_store;
 pub mod cfg;
 pub mod consensus;
 mod contracts;

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bitvec::{bitvec, order::Msb0};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
 use crate::{
+    consensus::Validator,
     crypto::{Hash, NodePublicKey, NodeSignature, SecretKey},
     state::SignedTransaction,
     time::SystemTime,
@@ -19,16 +20,27 @@ pub struct Proposal {
     pub header: BlockHeader,
     pub qc: QuorumCertificate,
     pub agg: Option<AggregateQc>,
+    pub committee: Vec<Validator>,
     pub transactions: Vec<SignedTransaction>,
 }
 
 impl Proposal {
+    pub fn from_parts(block: Block, transactions: Vec<SignedTransaction>) -> Self {
+        Proposal {
+            header: block.header,
+            qc: block.qc,
+            agg: block.agg,
+            committee: block.committee,
+            transactions,
+        }
+    }
     pub fn into_parts(self) -> (Block, Vec<SignedTransaction>) {
         (
             Block {
                 header: self.header,
                 qc: self.qc,
                 agg: self.agg,
+                committee: self.committee,
                 transactions: self.transactions.iter().map(|txn| txn.hash()).collect(),
             },
             self.transactions,
@@ -41,20 +53,21 @@ pub struct Vote {
     /// A signature on the block_hash.
     pub signature: NodeSignature,
     pub block_hash: Hash,
-    pub index: u16,
+    pub public_key: NodePublicKey,
 }
 
 impl Vote {
-    pub fn new(secret_key: SecretKey, block_hash: Hash, index: u16) -> Self {
+    pub fn new(secret_key: SecretKey, block_hash: Hash, public_key: NodePublicKey) -> Self {
         Vote {
             signature: secret_key.sign(block_hash.as_bytes()),
             block_hash,
-            index,
+            public_key,
         }
     }
 
-    pub fn verify(&self, public_key: NodePublicKey) -> Result<()> {
-        public_key.verify(self.block_hash.as_bytes(), self.signature)
+    pub fn verify(&self) -> Result<()> {
+        self.public_key
+            .verify(self.block_hash.as_bytes(), self.signature)
     }
 }
 
@@ -64,28 +77,33 @@ pub struct NewView {
     pub signature: NodeSignature,
     pub qc: QuorumCertificate,
     pub view: u64,
-    pub index: u16,
+    pub public_key: NodePublicKey,
 }
 
 impl NewView {
-    pub fn new(secret_key: SecretKey, qc: QuorumCertificate, view: u64, index: u16) -> Self {
+    pub fn new(
+        secret_key: SecretKey,
+        qc: QuorumCertificate,
+        view: u64,
+        public_key: NodePublicKey,
+    ) -> Self {
         let mut bytes = Vec::new();
         bytes.extend_from_slice(qc.compute_hash().as_bytes());
-        bytes.extend_from_slice(&index.to_be_bytes());
+        bytes.extend_from_slice(&public_key.as_bytes());
         bytes.extend_from_slice(&view.to_be_bytes());
 
         NewView {
             signature: secret_key.sign(&bytes),
             qc,
             view,
-            index,
+            public_key,
         }
     }
 
     pub fn verify(&self, public_key: NodePublicKey) -> Result<()> {
         let mut message = Vec::new();
         message.extend_from_slice(self.qc.compute_hash().as_bytes());
-        message.extend_from_slice(&self.index.to_be_bytes());
+        message.extend_from_slice(&self.public_key.as_bytes());
         message.extend_from_slice(&self.view.to_be_bytes());
 
         public_key.verify(&message, self.signature)
@@ -93,9 +111,7 @@ impl NewView {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BlockRequest {
-    pub hash: Hash,
-}
+pub struct BlockRequest(pub BlockRef);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockResponse {
@@ -111,6 +127,7 @@ pub enum Message {
     BlockResponse(BlockResponse),
     NewTransaction(SignedTransaction),
     RequestResponse,
+    JoinCommittee(NodePublicKey),
 }
 
 impl Message {
@@ -123,6 +140,7 @@ impl Message {
             Message::BlockResponse(_) => "BlockResponse",
             Message::NewTransaction(_) => "NewTransaction",
             Message::RequestResponse => "RequestResponse",
+            Message::JoinCommittee(_) => "JoinCommittee",
         }
     }
 }
@@ -136,19 +154,19 @@ pub struct QuorumCertificate {
 }
 
 impl QuorumCertificate {
-    pub fn genesis(committee_size: usize) -> Self {
-        Self {
-            signature: NodeSignature::identity(),
-            cosigned: bitvec![u8, bitvec::order::Msb0; 1; committee_size],
-            block_hash: Hash::ZERO,
-        }
-    }
-
     pub fn new(signatures: &[NodeSignature], cosigned: BitVec, block_hash: Hash) -> Self {
         QuorumCertificate {
             signature: NodeSignature::aggregate(signatures).unwrap(),
             cosigned,
             block_hash,
+        }
+    }
+
+    pub fn genesis() -> Self {
+        QuorumCertificate {
+            signature: NodeSignature::identity(),
+            cosigned: bitvec![u8, bitvec::order::Msb0; 1; 1024],
+            block_hash: Hash::ZERO,
         }
     }
 
@@ -189,6 +207,12 @@ impl AggregateQc {
             .as_bytes(),
         ])
     }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub enum BlockRef {
+    Hash(Hash),
+    View(u64),
 }
 
 /// The [Copy]-able subset of a block.
@@ -237,27 +261,91 @@ pub struct Block {
     /// this is not `None`, `qc` will contain a clone of the highest QC within this [AggregateQc];
     pub agg: Option<AggregateQc>,
     pub transactions: Vec<Hash>,
+    /// The consensus committee for this block.
+    pub committee: Vec<Validator>,
 }
 
 impl Block {
-    pub fn genesis(committee_size: usize, state_root_hash: Hash) -> Block {
-        let qc = QuorumCertificate::genesis(committee_size);
+    pub fn genesis(committee: Vec<Validator>, state_root_hash: Hash) -> Block {
+        let view = 0u64;
+        let qc = QuorumCertificate {
+            signature: NodeSignature::identity(),
+            cosigned: bitvec![u8, bitvec::order::Msb0; 1; 0],
+            block_hash: Hash::ZERO,
+        };
         let parent_hash = Hash::ZERO;
+        let timestamp = SystemTime::UNIX_EPOCH;
+
+        // FIXME: Just concatenating the keys is dumb.
+        let committee_keys: Vec<_> = committee
+            .iter()
+            .flat_map(|v| v.public_key.as_bytes())
+            .collect();
+
+        let digest = Hash::compute([
+            &view.to_be_bytes(),
+            qc.compute_hash().as_bytes(),
+            // hash of agg missing here intentionally
+            parent_hash.as_bytes(),
+            state_root_hash.as_bytes(),
+            &committee_keys,
+        ]);
+
         Block {
             header: BlockHeader {
-                view: 0,
-                hash: Hash::ZERO,
+                view,
+                hash: digest,
                 parent_hash,
                 signature: NodeSignature::identity(),
                 state_root_hash,
-                timestamp: SystemTime::UNIX_EPOCH,
+                timestamp,
             },
-            qc,
+            qc: QuorumCertificate {
+                signature: NodeSignature::identity(),
+                cosigned: bitvec![u8, bitvec::order::Msb0; 1; 0],
+                block_hash: Hash::ZERO,
+            },
             agg: None,
             transactions: vec![],
+            committee,
         }
     }
 
+    pub fn verify_hash(&self) -> Result<()> {
+        // FIXME: Just concatenating the keys is dumb.
+        let committee_keys: Vec<_> = self
+            .committee
+            .iter()
+            .flat_map(|v| v.public_key.as_bytes())
+            .collect();
+
+        let computed_hash = if let Some(agg) = &self.agg {
+            Hash::compute([
+                &self.view().to_be_bytes(),
+                self.qc.compute_hash().as_bytes(),
+                agg.compute_hash().as_bytes(),
+                self.parent_hash().as_bytes(),
+                self.state_root_hash().as_bytes(),
+                &committee_keys,
+            ])
+        } else {
+            Hash::compute([
+                &self.view().to_be_bytes(),
+                self.qc.compute_hash().as_bytes(),
+                self.parent_hash().as_bytes(),
+                self.state_root_hash().as_bytes(),
+                &committee_keys,
+            ])
+        };
+
+        if computed_hash != self.hash() {
+            return Err(anyhow!("invalid hash"));
+        }
+
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
     pub fn from_qc(
         secret_key: SecretKey,
         view: u64,
@@ -266,13 +354,21 @@ impl Block {
         state_root_hash: Hash,
         transactions: Vec<Hash>,
         timestamp: SystemTime,
+        committee: Vec<Validator>,
     ) -> Block {
+        // FIXME: Just concatenating the keys is dumb.
+        let committee_keys: Vec<_> = committee
+            .iter()
+            .flat_map(|v| v.public_key.as_bytes())
+            .collect();
+
         let digest = Hash::compute([
             &view.to_be_bytes(),
             qc.compute_hash().as_bytes(),
             // hash of agg missing here intentionally
             parent_hash.as_bytes(),
             state_root_hash.as_bytes(),
+            &committee_keys,
         ]);
         let signature = secret_key.sign(digest.as_bytes());
         Block {
@@ -287,9 +383,11 @@ impl Block {
             qc,
             agg: None,
             transactions,
+            committee,
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn from_agg(
         secret_key: SecretKey,
         view: u64,
@@ -298,13 +396,21 @@ impl Block {
         parent_hash: Hash,
         state_root_hash: Hash,
         timestamp: SystemTime,
+        committee: Vec<Validator>,
     ) -> Block {
+        // FIXME: Just concatenating the keys is dumb.
+        let committee_keys: Vec<_> = committee
+            .iter()
+            .flat_map(|v| v.public_key.as_bytes())
+            .collect();
+
         let digest = Hash::compute([
             &view.to_be_bytes(),
             qc.compute_hash().as_bytes(),
             agg.compute_hash().as_bytes(),
             parent_hash.as_bytes(),
             state_root_hash.as_bytes(),
+            &committee_keys,
         ]);
         let signature = secret_key.sign(digest.as_bytes());
         Block {
@@ -319,6 +425,7 @@ impl Block {
             qc,
             agg: Some(agg),
             transactions: vec![],
+            committee,
         }
     }
 

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -9,4 +9,14 @@ async fn block_production(mut network: Network<'_>) {
         )
         .await
         .unwrap();
+
+    let index = network.add_node();
+
+    network
+        .run_until(
+            |n| n.node_at(index).get_latest_block().map_or(0, |b| b.view()) >= 10,
+            500,
+        )
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
**TODO:**
- [x] Figure out why node 4 manages to join the network, despite only having downloaded 2/10 blocks (e.g. see seed `5356104854894035144`). It appears there are at least 2 bugs: 1. the node proposes blocks despite not knowing the parent, 2. other nodes don't complain about this.
- [ ] Documentation on new message type and how the committee is structured and changed.
- [x] Some real testing rather than just using the test suite.