### PR TITLE
Remove ignore for `RUSTSEC-2022-0004` advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,3 +1,0 @@
-[advisories]
-ignore = ["RUSTSEC-2022-0004"]
-


### PR DESCRIPTION
We resolved the issue in 188cf199a5e0c22a21c2b7b71869f88dfe60d477.