### PR TITLE
Make `Hash::compute` more convenient

### DIFF
--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -253,10 +253,10 @@ impl Hash {
         &self.0
     }
 
-    pub fn compute(preimages: &[&[u8]]) -> Hash {
+    pub fn compute<T: AsRef<[S]>, S: AsRef<[u8]>>(preimages: T) -> Hash {
         let mut hasher = Keccak256::new();
-        for preimage in preimages {
-            hasher.update(preimage);
+        for preimage in preimages.as_ref() {
+            hasher.update(preimage.as_ref());
         }
         Self(hasher.finalize().into())
     }

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -153,7 +153,7 @@ impl QuorumCertificate {
     }
 
     pub fn compute_hash(&self) -> Hash {
-        Hash::compute(&[
+        Hash::compute([
             &self.signature.to_bytes(),
             &self.cosigned.clone().into_vec(), // FIXME: What does this do when `self.cosigned.len() % 8 != 0`?
             self.block_hash.as_bytes(),
@@ -173,7 +173,7 @@ pub struct AggregateQc {
 impl AggregateQc {
     pub fn compute_hash(&self) -> Hash {
         let hashes: Vec<_> = self.qcs.iter().map(|qc| qc.compute_hash()).collect();
-        Hash::compute(&[
+        Hash::compute([
             &self.signature.to_bytes(),
             &self
                 .signers
@@ -181,7 +181,7 @@ impl AggregateQc {
                 .flat_map(|signer| signer.to_be_bytes())
                 .collect::<Vec<_>>(),
             Hash::compute(
-                &hashes
+                hashes
                     .iter()
                     .map(|hash| hash.as_bytes())
                     .collect::<Vec<_>>(),
@@ -267,7 +267,7 @@ impl Block {
         transactions: Vec<Hash>,
         timestamp: SystemTime,
     ) -> Block {
-        let digest = Hash::compute(&[
+        let digest = Hash::compute([
             &view.to_be_bytes(),
             qc.compute_hash().as_bytes(),
             // hash of agg missing here intentionally
@@ -299,7 +299,7 @@ impl Block {
         state_root_hash: Hash,
         timestamp: SystemTime,
     ) -> Block {
-        let digest = Hash::compute(&[
+        let digest = Hash::compute([
             &view.to_be_bytes(),
             qc.compute_hash().as_bytes(),
             agg.compute_hash().as_bytes(),

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -219,7 +219,7 @@ impl State {
 
     pub fn save_account(&mut self, address: Address, account: Account) -> Result<()> {
         Ok(self.accounts.insert(
-            crypto::Hash::compute(&[&address.as_bytes()]).as_bytes(),
+            crypto::Hash::compute([address.as_bytes()]).as_bytes(),
             &bincode::serialize(&account)?,
         )?)
     }


### PR DESCRIPTION
Instead of just accepting `&[&[u8]]` we accept `AsRef<[S]>` where `S: AsRef<[u8]>`. This allows the caller to pass other similar types such as `Vec<u8>` or `Bytes`.