### PR TITLE
Add `bootstrap_address` to node configuration

### DIFF
--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use libp2p::Multiaddr;
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize)]
@@ -16,6 +17,9 @@ pub struct Config {
     pub allowed_timestamp_skew: Duration,
     /// The maximum time to wait for consensus to proceed as normal, before proposing a new view.
     pub consensus_timeout: Duration,
+    /// The address of another node to dial when this node starts. To join the network, a node must know about at least
+    /// one other existing node in the network.
+    pub bootstrap_address: Option<Multiaddr>,
 }
 
 impl Default for Config {
@@ -27,6 +31,7 @@ impl Default for Config {
             otlp_collector_endpoint: None,
             allowed_timestamp_skew: Duration::from_secs(10),
             consensus_timeout: Duration::from_secs(5),
+            bootstrap_address: None,
         }
     }
 }

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -33,7 +33,7 @@ use libp2p::{
     multiaddr::{Multiaddr, Protocol},
     multihash::Multihash,
     noise,
-    swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent},
+    swarm::{dial_opts::DialOpts, NetworkBehaviour, SwarmBuilder, SwarmEvent},
     tcp, yamux, PeerId, Transport,
 };
 
@@ -81,6 +81,7 @@ pub struct NodeLauncher {
     rpc_launched: bool,
     node_launched: bool,
     consensus_timeout: Duration,
+    bootstrap_address: Option<Multiaddr>,
 }
 
 impl NodeLauncher {
@@ -115,6 +116,7 @@ impl NodeLauncher {
             rpc_launched: false,
             node_launched: false,
             consensus_timeout: config.consensus_timeout,
+            bootstrap_address: config.bootstrap_address,
         })
     }
 
@@ -201,6 +203,14 @@ impl NodeLauncher {
         addr.push(Protocol::Tcp(p2p_port));
 
         swarm.listen_on(addr)?;
+
+        if let Some(bootstrap_address) = &self.bootstrap_address {
+            swarm.dial(
+                DialOpts::unknown_peer_id()
+                    .address(bootstrap_address.clone())
+                    .build(),
+            )?;
+        }
 
         let topic = IdentTopic::new("topic");
         swarm.behaviour_mut().gossipsub.subscribe(&topic)?;


### PR DESCRIPTION
This allows nodes to discover each other on non-local networks where mDNS is not an option.