### PR TITLE
Clean up build profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,8 @@ members = [
 # Makes flamegraphs more readable.
 # https://doc.rust-lang.org/cargo/reference/manifest.html#the-profile-sections
 debug = true
+lto = "thin"
 
 [profile.release-stripped]
 inherits = "release"
-lto = "thin"
-debug = false
-
-[profile.release-lto]
-inherits = "release"
-# Enable "thin" LTO to reduce both the compilation time and the binary size.
-# See: https://doc.rust-lang.org/cargo/reference/profiles.html#lto
-lto = "thin"
+strip = true


### PR DESCRIPTION
Ensure the `release-stripped` profile actually strips and remove the unused `release-lto` profile for now. We can always bring it back later if needed (though more likely we'll just enable LTO on the existing release profiles).