### PR TITLE
Add health check endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6210,6 +6210,7 @@ dependencies = [
  "generic-array",
  "hex",
  "http",
+ "hyper",
  "itertools 0.11.0",
  "jsonrpsee",
  "k256",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -64,6 +64,7 @@ tower-http = { version = "0.4.1", features = ["cors"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 zilliqa-macros = { path = "../zilliqa-macros" }
+hyper = "0.14.27"
 
 [dev-dependencies]
 async-trait = "0.1.73"

--- a/zilliqa/src/health.rs
+++ b/zilliqa/src/health.rs
@@ -1,0 +1,61 @@
+use std::{error::Error, pin::Pin};
+
+use futures::Future;
+use http::{Method, Request, Response, StatusCode};
+use hyper::Body;
+use tower::{layer::Layer, Service};
+
+/// [Layer] that responds to `GET /health` calls with a 200 status code.
+pub struct HealthLayer;
+
+impl<S> Layer<S> for HealthLayer {
+    type Service = HealthRequest<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HealthRequest { inner }
+    }
+}
+
+pub struct HealthRequest<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for HealthRequest<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>>,
+    S::Response: 'static,
+    S::Error: Into<Box<dyn Error + Send + Sync>> + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = Box<dyn Error + Send + Sync + 'static>;
+    type Future =
+        Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send + 'static>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(Into::into)
+    }
+
+    fn call(&mut self, req: Request<Body>) -> Self::Future {
+        if req.uri() == "/health" && req.method() == Method::GET {
+            let response = hyper::Response::builder()
+                .status(StatusCode::OK)
+                .body(Body::empty())
+                .unwrap();
+            let res_fut = async move { Ok(response) };
+
+            Box::pin(res_fut)
+        } else {
+            let fut = self.inner.call(req);
+            let res_fut = async move {
+                let res = fut.await.map_err(|err| err.into())?;
+                Ok(res)
+            };
+
+            Box::pin(res_fut)
+        }
+    }
+}

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -7,6 +7,7 @@ pub mod crypto;
 mod db;
 mod evm_backend;
 mod exec;
+mod health;
 pub mod message;
 pub mod networking;
 pub mod node;

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -12,6 +12,7 @@ use crate::{
     api,
     cfg::Config,
     crypto::SecretKey,
+    health::HealthLayer,
     networking::{request_response, MessageCodec, MessageProtocol, ProtocolSupport},
     node,
 };
@@ -137,7 +138,7 @@ impl NodeLauncher {
             .allow_methods(Method::POST)
             .allow_origin(Any)
             .allow_headers([header::CONTENT_TYPE]);
-        let middleware = tower::ServiceBuilder::new().layer(cors);
+        let middleware = tower::ServiceBuilder::new().layer(HealthLayer).layer(cors);
         let port = self.node.lock().unwrap().config.json_rpc_port;
         let server = jsonrpsee::server::ServerBuilder::new()
             .set_middleware(middleware)


### PR DESCRIPTION
The JSON-RPC port will respond to requests to `GET /health` with an empty 200 response.