### PR TITLE
Use default `config.toml` file if argument not provided

### DIFF
--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -15,7 +15,7 @@ use zilliqa::{cfg::Config, crypto::SecretKey};
 struct Args {
     #[arg(value_parser = SecretKey::from_hex)]
     secret_key: SecretKey,
-    #[clap(long, short, required = true, default_value = "config.toml")]
+    #[clap(long, short, default_value = "config.toml")]
     config_file: PathBuf,
 }
 


### PR DESCRIPTION
`required = true` causes the `default` to be ignored and returns an error if `--config-file` isn't passed explicitly.