### PR TITLE
Make genesis accounts configurable

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -4,6 +4,13 @@ p2p_port = 0
 json_rpc_port = 4201
 eth_chain_id = 0x8001
 consensus_timeout = { secs = 5, nanos = 0 }
+genesis_accounts = [
+    # Accounts with private key 0x1, 0x2, 0x3, 0x4.
+    ["7E5F4552091A69125d5DfCb7b8C2659029395Bdf", 5000000000000000000000],
+    ["2B5AD5c4795c026514f8317c7a215E218DcCD6cF", 5000000000000000000000],
+    ["6813Eb9362372EEF6200f3b1dbC3f819671cBA69", 5000000000000000000000],
+    ["1efF47bc3a10a45D4B230B5d10E37751FE6AA718", 5000000000000000000000],
+]
 
 [[nodes]]
 json_rpc_port = 4202

--- a/infra/config.toml
+++ b/infra/config.toml
@@ -1,3 +1,10 @@
 otlp_collector_endpoint = "http://otel-collector:4317"
 # This is the public key and peer ID corresponding to the first private key in `docker-compose.yaml`.
 genesis_committee = [ ["b27aebb3b54effd7af87c4a064a711554ee0f3f5abf56ca910b46422f2b21603bc383d42eb3b927c4c3b0b8381ca30a3", "12D3KooWESMZ2ttSxDwjfnNe23sHCqsJf6sNEKwgHkdgtCHDsbWU"] ]
+genesis_accounts = [
+    # Accounts with private key 0x1, 0x2, 0x3, 0x4.
+    ["7E5F4552091A69125d5DfCb7b8C2659029395Bdf", 5000000000000000000000],
+    ["2B5AD5c4795c026514f8317c7a215E218DcCD6cF", 5000000000000000000000],
+    ["6813Eb9362372EEF6200f3b1dbC3f819671cBA69", 5000000000000000000000],
+    ["1efF47bc3a10a45D4B230B5d10E37751FE6AA718", 5000000000000000000000],
+]

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 
-use crate::crypto::NodePublicKey;
+use crate::{crypto::NodePublicKey, state::Address};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(default, deny_unknown_fields)]
@@ -45,6 +45,7 @@ pub struct NodeConfig {
     /// The maximum time to wait for consensus to proceed as normal, before proposing a new view.
     pub consensus_timeout: Duration,
     pub genesis_committee: Vec<(NodePublicKey, PeerId)>,
+    pub genesis_accounts: Vec<(Address, u128)>,
 }
 
 impl Default for NodeConfig {
@@ -57,6 +58,7 @@ impl Default for NodeConfig {
             data_dir: None,
             consensus_timeout: Duration::from_secs(5),
             genesis_committee: vec![],
+            genesis_accounts: Vec::new(),
         }
     }
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -155,7 +155,7 @@ impl Consensus {
         let mut state = if let Some(latest_block) = &latest_block {
             State::new_from_root(state_trie, H256(latest_block.state_root_hash().0))
         } else {
-            State::new_genesis(state_trie)?
+            State::new_genesis(state_trie, &config.genesis_accounts)?
         };
 
         let latest_block = match latest_block {

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -5,7 +5,6 @@ use generic_array::{
     GenericArray,
 };
 use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
-use once_cell::sync::Lazy;
 use rlp::RlpStream;
 use sha3::{Digest, Keccak256};
 use sled::Tree;
@@ -16,61 +15,10 @@ use std::{hash::Hash, str::FromStr};
 
 use anyhow::{anyhow, Result};
 use evm_ds::protos::evm_proto::Log;
-use primitive_types::{H160, H256, U256};
+use primitive_types::{H160, H256};
 use serde::{Deserialize, Serialize};
 
 use crate::{contracts, crypto, db::SledDb};
-
-/// Const version of `impl From<u128> for U256`
-const fn u128_to_u256(value: u128) -> U256 {
-    let mut ret = [0; 4];
-    ret[0] = value as u64;
-    ret[1] = (value >> 64) as u64;
-    U256(ret)
-}
-
-static GENESIS: Lazy<Vec<(Address, U256)>> = Lazy::new(|| {
-    // Address with private key  0000000000000000000000000000000000000000000000000000000000000001
-    // then ...0002 etc
-    vec![
-        (
-            Address(H160(
-                hex::decode("7E5F4552091A69125d5DfCb7b8C2659029395Bdf")
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-            )),
-            u128_to_u256(5000 * 10u128.pow(18)),
-        ),
-        (
-            Address(H160(
-                hex::decode("2B5AD5c4795c026514f8317c7a215E218DcCD6cF")
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-            )),
-            u128_to_u256(5000 * 10u128.pow(18)),
-        ),
-        (
-            Address(H160(
-                hex::decode("6813Eb9362372EEF6200f3b1dbC3f819671cBA69")
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-            )),
-            u128_to_u256(5000 * 10u128.pow(18)),
-        ),
-        (
-            Address(H160(
-                hex::decode("1efF47bc3a10a45D4B230B5d10E37751FE6AA718")
-                    .unwrap()
-                    .try_into()
-                    .unwrap(),
-            )),
-            u128_to_u256(5000 * 10u128.pow(18)),
-        ),
-    ]
-});
 
 #[derive(Debug)]
 pub struct State {
@@ -79,7 +27,7 @@ pub struct State {
 }
 
 impl State {
-    pub fn new_genesis(database: Tree) -> Result<State> {
+    pub fn new_genesis(database: Tree, genesis_accounts: &[(Address, u128)]) -> Result<State> {
         let db = Arc::new(SledDb::new(database));
         let mut state = Self {
             db: db.clone(),
@@ -93,8 +41,8 @@ impl State {
 
         let _ = state.set_gas_price(default_gas_price().into());
 
-        for (address, balance) in GENESIS.iter() {
-            state.set_native_balance(*address, *balance)?;
+        for (address, balance) in genesis_accounts {
+            state.set_native_balance(*address, (*balance).into())?;
         }
 
         Ok(state)

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -1,6 +1,7 @@
 use crate::{Network, TestNode};
 use ethers::providers::Middleware;
 use ethers::types::TransactionRequest;
+use ethers::utils::secret_key_to_address;
 use primitive_types::H160;
 use tracing::*;
 use zilliqa::crypto::Hash;
@@ -75,6 +76,7 @@ async fn block_and_tx_data_persistence(mut network: Network<'_>) {
         SecretKey::new().unwrap(),
         0,
         Some(dir),
+        secret_key_to_address(&network.genesis_key),
     );
 
     // Sometimes, the dropping Arc<Node> (by dropping the TestNode above) does not actually drop


### PR DESCRIPTION
In the public devnet, we probably shouldn't put all our genesis funds in the accounts with known private keys. So, we make the genesis accounts (and amounts) configurable.