### PR TITLE
Remove dependency on generic-array

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6512,7 +6512,6 @@ dependencies = [
  "ethers",
  "evm_ds",
  "futures",
- "generic-array",
  "hex",
  "http",
  "hyper",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -37,7 +37,6 @@ eth_trie = {path =  "../eth-trie.rs"}
 ethabi = "18.0.0"
 evm_ds = { path = "../evm-ds" }
 futures = "0.3.28"
-generic-array = "0.14.7"
 hex = { version = "0.4.3", features = ["serde"] }
 http = "0.2.9"
 itertools = "0.11.0"

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -1,14 +1,16 @@
 use core::fmt;
 use eth_trie::{EthTrie as PatriciaTrie, Trie};
 use ethabi::Token;
-use generic_array::{
-    sequence::Split,
-    typenum::{U12, U20},
-    GenericArray,
-};
 use k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
 use rlp::RlpStream;
-use sha3::{Digest, Keccak256};
+use sha3::{
+    digest::generic_array::{
+        sequence::Split,
+        typenum::{U12, U20},
+        GenericArray,
+    },
+    Digest, Keccak256,
+};
 use sled::Tree;
 use std::convert::TryInto;
 use std::fmt::{Display, LowerHex};


### PR DESCRIPTION
Use the re-exported version from `sha3` instead to avoid problems with mismatching dependency versions.