### PR TITLE
Revert state accounts reflecting evm balances

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -78,11 +78,13 @@ fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     let call_params: CallParams = params.next()?;
     let block_number: BlockNumber = params.next()?;
 
-    let return_value = node.lock().unwrap().call_contract(
+    let ret = node.lock().unwrap().call_contract(
         block_number,
         Address(call_params.from),
         call_params.to.map(Address),
         call_params.data.clone(),
+        U256::from(call_params.value),
+        false,
     )?;
 
     trace!(
@@ -91,10 +93,10 @@ fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
         call_params.from,
         call_params.to,
         call_params.data,
-        return_value.to_hex()
+        ret.return_value.to_hex()
     );
 
-    Ok(return_value.to_hex())
+    Ok(ret.return_value.to_hex())
 }
 
 fn chain_id(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -1,11 +1,10 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Result};
+use evm_ds::tracing_logging::InternalOperationOtter;
 use jsonrpsee::{types::Params, RpcModule};
 use primitive_types::{H160, H256};
 use tracing::trace;
-//use evm_ds::protos::evm_proto::InternalOperationOtter;
-use evm_ds::tracing_logging::InternalOperationOtter;
 
 use crate::{crypto::Hash, message::BlockNumber, node::Node, state::Address, time::SystemTime};
 

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -3,6 +3,9 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, Result};
 use jsonrpsee::{types::Params, RpcModule};
 use primitive_types::{H160, H256};
+use tracing::trace;
+//use evm_ds::protos::evm_proto::InternalOperationOtter;
+use evm_ds::tracing_logging::InternalOperationOtter;
 
 use crate::{crypto::Hash, message::BlockNumber, node::Node, state::Address, time::SystemTime};
 
@@ -22,6 +25,7 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
             ("ots_hasCode", has_code),
             ("ots_searchTransactionsAfter", search_transactions_after),
             ("ots_searchTransactionsBefore", search_transactions_before),
+            ("ots_getInternalOperations", get_internal_operations),
         ],
     )
 }
@@ -233,4 +237,43 @@ fn search_transactions_before(
     }
 
     search_transactions_inner(node, Address(address), block_number, page_size, true)
+}
+
+fn get_internal_operations(
+    params: Params,
+    node: &Arc<Mutex<Node>>,
+) -> Result<Vec<InternalOperationOtter>> {
+    trace!("get_internal_operations called");
+    let hash: H256 = params.one()?;
+    let hash: Hash = Hash(hash.0);
+
+    let node = node.lock().unwrap();
+
+    let tx = node.get_transaction_by_hash(hash)?;
+
+    let receipt = get_transaction_receipt_inner(hash, &node)?;
+
+    if tx.is_none() || receipt.is_none() {
+        return Err(anyhow!("transaction not yet executed: {hash}"));
+    }
+
+    let tx = tx.unwrap();
+    let receipt = receipt.unwrap();
+
+    let call_result = node.call_contract(
+        receipt.block_number.into(),
+        tx.from_addr,
+        tx.transaction.to_addr,
+        tx.transaction.payload,
+        tx.transaction.amount.into(),
+        true,
+    );
+
+    Ok(call_result
+        .unwrap()
+        .tx_trace
+        .lock()
+        .unwrap()
+        .otter_internal_tracer
+        .clone())
 }

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -216,6 +216,7 @@ pub struct CallParams {
     pub to: Option<H160>,
     #[serde(deserialize_with = "deserialize_data")]
     pub data: Vec<u8>,
+    pub value: u64,
 }
 
 /// Parameters passed to `estimate_gas`.

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -216,6 +216,7 @@ pub struct CallParams {
     pub to: Option<H160>,
     #[serde(deserialize_with = "deserialize_data")]
     pub data: Vec<u8>,
+    #[serde(default)]
     pub value: u64,
 }
 

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -497,11 +497,6 @@ impl State {
             );
         }
 
-        println!(
-            "XXXXXXXXXXXXXXX tracing is: {:?}",
-            backend_result.tx_trace.lock().unwrap()
-        );
-
         Ok((backend_result, created_contract_addr))
     }
 

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -856,6 +856,7 @@ impl State {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn call_contract(
         &self,
         from_addr: Address,

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -323,6 +323,12 @@ impl Display for BlockNumber {
     }
 }
 
+impl From<u64> for BlockNumber {
+    fn from(num: u64) -> Self {
+        Self::Number(num)
+    }
+}
+
 impl<'de> Deserialize<'de> for BlockNumber {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -6,6 +6,8 @@ use crate::{
 };
 use primitive_types::H256;
 
+use evm_ds::protos::evm_proto::{self as EvmProto};
+
 use anyhow::{anyhow, Result};
 use libp2p::PeerId;
 
@@ -231,7 +233,9 @@ impl Node {
         from_addr: Address,
         to_addr: Option<Address>,
         data: Vec<u8>,
-    ) -> Result<Vec<u8>> {
+        amount: U256,
+        tracing: bool,
+    ) -> Result<EvmProto::EvmResult> {
         let block = self
             .get_block_by_view(self.get_view(block_number))?
             .ok_or_else(|| anyhow!("block not found"))?;
@@ -244,9 +248,11 @@ impl Node {
             from_addr,
             to_addr,
             data,
+            amount,
             self.config.eth_chain_id,
             block.header,
             true,
+            tracing,
         )
     }
 


### PR DESCRIPTION
No longer rely on the TX trace, but do use it for ots_getInternalOperations (which has a corresponding test enabled in integration tests). I realised also that eth_call did not respect value which was causing the ots test to fail.