### PR TITLE
FIX: Solc Shanghai Version check

### DIFF
--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -528,7 +528,7 @@ async fn deploy_contract(
     if let Ok(version) = sc.version() {
         if version.cmp(&SHANGHAI_SOLC).is_lt() {
             panic!(
-                "Solc Version {} required, currently set {}",
+                "solc version {} required, currently set {}",
                 SHANGHAI_SOLC, version
             );
         }


### PR DESCRIPTION
Provides a better error requiring Solc version 0.8.20 running on the host system