### PR TITLE
Split message channels

### DIFF
--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -121,14 +121,6 @@ pub struct BlockResponse {
     pub block: Block,
 }
 
-// #[allow(clippy::large_enum_variant)] // Pending refactor once join_network is merged
-/// TODO: #397, refactor these two out into separate, unrelated structs
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Message {
-    External(ExternalMessage),
-    Internal(InternalMessage),
-}
-
 /// A message intended to be sent over the network as part of p2p communication.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExternalMessage {
@@ -146,17 +138,7 @@ pub enum ExternalMessage {
 /// but not sent over the network.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum InternalMessage {
-    AddPeer(NodePublicKey),
     LaunchShard(u64),
-}
-
-impl Message {
-    pub fn name(&self) -> &'static str {
-        match self {
-            Self::External(m) => m.name(),
-            Self::Internal(m) => m.name(),
-        }
-    }
 }
 
 impl ExternalMessage {
@@ -177,7 +159,6 @@ impl ExternalMessage {
 impl InternalMessage {
     pub fn name(&self) -> &'static str {
         match self {
-            InternalMessage::AddPeer(_) => "AddPeer",
             InternalMessage::LaunchShard(_) => "LaunchShard",
         }
     }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1,6 +1,7 @@
+use crate::p2p_node::LocalMessageTuple;
 use crate::{
     cfg::NodeConfig,
-    message::{BlockNumber, InternalMessage, Message},
+    message::{BlockNumber, InternalMessage},
     p2p_node::OutboundMessageTuple,
     state::{SignedTransaction, TransactionReceipt},
 };
@@ -27,20 +28,25 @@ pub struct MessageSender {
     our_shard: u64,
     our_peer_id: PeerId,
     outbound_channel: UnboundedSender<OutboundMessageTuple>,
+    local_channel: UnboundedSender<LocalMessageTuple>,
 }
 
 impl MessageSender {
     /// Send message to the p2p/coordinator thread
     pub fn send_message_to_coordinator(&self, message: InternalMessage) -> Result<()> {
-        self.outbound_channel
-            .send((None, self.our_shard, Message::Internal(message)))?;
+        self.local_channel
+            .send((self.our_shard, self.our_shard, message))?;
         Ok(())
     }
 
     /// Send a message to a locally running shard node
-    pub fn send_message_to_shard(&self, shard: u64, message: InternalMessage) -> Result<()> {
-        self.outbound_channel
-            .send((None, shard, Message::Internal(message)))?;
+    pub fn send_message_to_shard(
+        &self,
+        destination_shard: u64,
+        message: InternalMessage,
+    ) -> Result<()> {
+        self.local_channel
+            .send((self.our_shard, destination_shard, message))?;
         Ok(())
     }
 
@@ -53,14 +59,14 @@ impl MessageSender {
             peer
         );
         self.outbound_channel
-            .send((Some(peer), self.our_shard, Message::External(message)))?;
+            .send((Some(peer), self.our_shard, message))?;
         Ok(())
     }
 
     /// Broadcast to the entire network of this shard
     pub fn broadcast_external_message(&self, message: ExternalMessage) -> Result<()> {
         self.outbound_channel
-            .send((None, self.our_shard, Message::External(message)))?;
+            .send((None, self.our_shard, message))?;
         Ok(())
     }
 }
@@ -93,6 +99,7 @@ impl Node {
         config: NodeConfig,
         secret_key: SecretKey,
         message_sender_channel: UnboundedSender<OutboundMessageTuple>,
+        local_sender_channel: UnboundedSender<LocalMessageTuple>,
         reset_timeout: UnboundedSender<()>,
     ) -> Result<Node> {
         let peer_id = secret_key.to_libp2p_keypair().public().to_peer_id();
@@ -100,6 +107,7 @@ impl Node {
             our_shard: config.eth_chain_id,
             our_peer_id: peer_id,
             outbound_channel: message_sender_channel,
+            local_channel: local_sender_channel,
         };
         let node = Node {
             config: config.clone(),
@@ -112,55 +120,47 @@ impl Node {
     }
 
     // TODO: Multithreading - `&mut self` -> `&self`
-    pub fn handle_message(&mut self, from: PeerId, message: Message) -> Result<()> {
+    pub fn handle_network_message(&mut self, from: PeerId, message: ExternalMessage) -> Result<()> {
         let to = self.peer_id;
         let message_name = message.name();
         tracing::debug!(%from, %to, %message_name, "handling message");
         match message {
-            Message::External(external_message) => match external_message {
-                ExternalMessage::Proposal(m) => {
-                    if let Some((leader, vote)) = self.consensus.proposal(m)? {
-                        self.reset_timeout.send(())?;
-                        self.message_sender
-                            .send_external_message(leader, ExternalMessage::Vote(vote))?;
-                    }
+            ExternalMessage::Proposal(m) => {
+                if let Some((leader, vote)) = self.consensus.proposal(m)? {
+                    self.reset_timeout.send(())?;
+                    self.message_sender
+                        .send_external_message(leader, ExternalMessage::Vote(vote))?;
                 }
-                ExternalMessage::Vote(m) => {
-                    if let Some((block, transactions)) = self.consensus.vote(m)? {
-                        self.message_sender.broadcast_external_message(
-                            ExternalMessage::Proposal(Proposal::from_parts(block, transactions)),
-                        )?;
-                    }
+            }
+            ExternalMessage::Vote(m) => {
+                if let Some((block, transactions)) = self.consensus.vote(m)? {
+                    self.message_sender
+                        .broadcast_external_message(ExternalMessage::Proposal(
+                            Proposal::from_parts(block, transactions),
+                        ))?;
                 }
-                ExternalMessage::NewView(m) => {
-                    if let Some(block) = self.consensus.new_view(from, *m)? {
-                        self.message_sender.broadcast_external_message(
-                            ExternalMessage::Proposal(Proposal::from_parts(block, vec![])),
-                        )?;
-                    }
+            }
+            ExternalMessage::NewView(m) => {
+                if let Some(block) = self.consensus.new_view(from, *m)? {
+                    self.message_sender
+                        .broadcast_external_message(ExternalMessage::Proposal(
+                            Proposal::from_parts(block, vec![]),
+                        ))?;
                 }
-                ExternalMessage::BlockRequest(m) => {
-                    self.handle_block_request(from, m)?;
-                }
-                ExternalMessage::BlockResponse(m) => {
-                    self.handle_block_response(from, m)?;
-                }
-                ExternalMessage::RequestResponse => {}
-                ExternalMessage::NewTransaction(t) => {
-                    self.consensus.new_transaction(t)?;
-                }
-                ExternalMessage::JoinCommittee(public_key) => {
-                    self.add_peer(from, public_key)?;
-                }
-            },
-            Message::Internal(internal_message) => match internal_message {
-                InternalMessage::AddPeer(public_key) => {
-                    self.add_peer(from, public_key)?;
-                }
-                InternalMessage::LaunchShard(_) => {
-                    warn!("LaunchShard messages should not be passed to the node.");
-                }
-            },
+            }
+            ExternalMessage::BlockRequest(m) => {
+                self.handle_block_request(from, m)?;
+            }
+            ExternalMessage::BlockResponse(m) => {
+                self.handle_block_response(from, m)?;
+            }
+            ExternalMessage::RequestResponse => {}
+            ExternalMessage::NewTransaction(t) => {
+                self.consensus.new_transaction(t)?;
+            }
+            ExternalMessage::JoinCommittee(public_key) => {
+                self.add_peer(from, public_key)?;
+            }
         }
 
         Ok(())

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -1,3 +1,4 @@
+use crate::p2p_node::LocalMessageTuple;
 use crate::{health::HealthLayer, message::ExternalMessage};
 use jsonrpsee::RpcModule;
 use std::{
@@ -12,7 +13,7 @@ use anyhow::{anyhow, Result};
 use http::{header, Method};
 use libp2p::{futures::StreamExt, PeerId};
 
-use crate::message::Message;
+use crate::message::InternalMessage;
 use node::Node;
 use std::time::Duration;
 use tokio::{
@@ -28,9 +29,19 @@ pub struct NodeLauncher {
     pub node: Arc<Mutex<Node>>,
     pub config: NodeConfig,
     pub rpc_module: RpcModule<Arc<Mutex<Node>>>,
-    pub inbound_message_sender: UnboundedSender<(PeerId, Message)>,
-    pub inbound_message_receiver: UnboundedReceiverStream<(PeerId, Message)>,
+    /// The following three message streams are used for networked messages.
+    /// The sender is provided to the p2p coordinator, to forward messages to the node.
+    pub inbound_message_sender: UnboundedSender<(PeerId, ExternalMessage)>,
+    /// The corresponding receiver is handled here, forwarding messages to the node struct.
+    pub inbound_message_receiver: UnboundedReceiverStream<(PeerId, ExternalMessage)>,
+    /// This sender is provided to the node's MessageSender, to send messages back to the network.
     outbound_message_sender: UnboundedSender<OutboundMessageTuple>,
+    /// The following three message streams are used for local messages.
+    /// The sender is provided to the p2p coordinator, to forward cross-shard messages to the node.
+    pub local_inbound_message_sender: UnboundedSender<(u64, InternalMessage)>,
+    /// The corresponding receiver is handled here, forwarding messages to the node struct.
+    pub local_inbound_message_receiver: UnboundedReceiverStream<(u64, InternalMessage)>,
+
     pub reset_timeout_receiver: UnboundedReceiverStream<()>,
     secret_key: SecretKey,
     node_launched: bool,
@@ -42,9 +53,14 @@ impl NodeLauncher {
         secret_key: SecretKey,
         config: NodeConfig,
         outbound_message_sender: UnboundedSender<OutboundMessageTuple>,
+        local_outbound_message_sender: UnboundedSender<LocalMessageTuple>,
     ) -> Result<Self> {
         let (inbound_message_sender, inbound_message_receiver) = mpsc::unbounded_channel();
         let inbound_message_receiver = UnboundedReceiverStream::new(inbound_message_receiver);
+        let (local_inbound_message_sender, local_inbound_message_receiver) =
+            mpsc::unbounded_channel();
+        let local_inbound_message_receiver =
+            UnboundedReceiverStream::new(local_inbound_message_receiver);
         let (reset_timeout_sender, reset_timeout_receiver) = mpsc::unbounded_channel();
         let reset_timeout_receiver = UnboundedReceiverStream::new(reset_timeout_receiver);
 
@@ -52,6 +68,7 @@ impl NodeLauncher {
             config.clone(),
             secret_key,
             outbound_message_sender.clone(),
+            local_outbound_message_sender.clone(),
             reset_timeout_sender.clone(),
         )?;
         let node = Arc::new(Mutex::new(node));
@@ -89,8 +106,10 @@ impl NodeLauncher {
             rpc_module,
             inbound_message_sender,
             inbound_message_receiver,
-            reset_timeout_receiver,
             outbound_message_sender,
+            reset_timeout_receiver,
+            local_inbound_message_sender,
+            local_inbound_message_receiver,
             node_launched: false,
             consensus_timeout: config.consensus.consensus_timeout,
             secret_key,
@@ -98,11 +117,15 @@ impl NodeLauncher {
         })
     }
 
-    pub fn message_sender(&self) -> UnboundedSender<(PeerId, Message)> {
+    pub fn message_input(&self) -> UnboundedSender<(PeerId, ExternalMessage)> {
         self.inbound_message_sender.clone()
     }
 
-    pub async fn start_p2p_node(&mut self) -> Result<()> {
+    pub fn local_message_input(&self) -> UnboundedSender<(u64, InternalMessage)> {
+        self.local_inbound_message_sender.clone()
+    }
+
+    pub async fn start_shard_node(&mut self) -> Result<()> {
         if self.node_launched {
             return Err(anyhow!("Node already running!"));
         }
@@ -116,15 +139,19 @@ impl NodeLauncher {
 
         loop {
             select! {
+                _message = self.local_inbound_message_receiver.next() => {
+                    let (_source, _message) = _message.expect("message stream should be infinite");
+                    todo!("Local messages will need to be handled once cross-shard messaging is implemented");
+                }
                 message = self.inbound_message_receiver.next() => {
                     let (source, message) = message.expect("message stream should be infinite");
-                    self.node.lock().unwrap().handle_message(source, message).unwrap();
+                    self.node.lock().unwrap().handle_network_message(source, message).unwrap();
                 },
                 () = &mut sleep => {
                     trace!("timeout elapsed");
 
                     if !joined {
-                        self.outbound_message_sender.send((None, self.config.eth_chain_id, Message::External(ExternalMessage::JoinCommittee(self.secret_key.node_public_key())))).unwrap();
+                        self.outbound_message_sender.send((None, self.config.eth_chain_id, ExternalMessage::JoinCommittee(self.secret_key.node_public_key()))).unwrap();
                         joined = true;
                     } else {
                         self.node.lock().unwrap().handle_timeout().unwrap();

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -34,7 +34,7 @@ use tokio::{
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::{debug, error, info, warn};
 
-use crate::message::{ExternalMessage, InternalMessage, Message};
+use crate::message::{ExternalMessage, InternalMessage};
 
 #[derive(NetworkBehaviour)]
 struct Behaviour {
@@ -45,27 +45,42 @@ struct Behaviour {
     kademlia: Kademlia<MemoryStore>,
 }
 
+/// Messages circulating over the p2p network.
 /// (destination, shard_id, message)
-pub type OutboundMessageTuple = (Option<PeerId>, u64, Message);
+pub type OutboundMessageTuple = (Option<PeerId>, u64, ExternalMessage);
+
+/// Messages passed between local shard nodes.
+/// (source_shard, destination_shard, message)
+pub type LocalMessageTuple = (u64, u64, InternalMessage);
+
+struct NodeInputChannels {
+    external: UnboundedSender<(PeerId, ExternalMessage)>,
+    internal: UnboundedSender<(u64, InternalMessage)>,
+}
 
 pub struct P2pNode {
-    shard_nodes: HashMap<TopicHash, UnboundedSender<(PeerId, Message)>>,
+    shard_nodes: HashMap<TopicHash, NodeInputChannels>,
     shard_threads: JoinSet<Result<()>>,
     secret_key: SecretKey,
     config: Config,
     peer_id: PeerId,
     swarm: Swarm<Behaviour>,
-    /// Shard nodes get a copy of a handle to this sender, to propagate messages to the p2p network.
+    /// Shard nodes get a copy of these senders to propagate messages.
     outbound_message_sender: UnboundedSender<OutboundMessageTuple>,
-    /// The p2p node keeps a handle to this receiver, to obtain messages from shards and propagate
-    /// them to the p2p network.
+    local_message_sender: UnboundedSender<LocalMessageTuple>,
+    /// The p2p node keeps a handle to these receivers, to obtain messages from shards and propagate
+    /// them as necessary.
     outbound_message_receiver: UnboundedReceiverStream<OutboundMessageTuple>,
+    local_message_receiver: UnboundedReceiverStream<LocalMessageTuple>,
 }
 
 impl P2pNode {
     pub fn new(secret_key: SecretKey, config: Config) -> Result<Self> {
         let (outbound_message_sender, outbound_message_receiver) = mpsc::unbounded_channel();
         let outbound_message_receiver = UnboundedReceiverStream::new(outbound_message_receiver);
+
+        let (local_message_sender, local_message_receiver) = mpsc::unbounded_channel();
+        let local_message_receiver = UnboundedReceiverStream::new(local_message_receiver);
 
         let key_pair = secret_key.to_libp2p_keypair();
         let peer_id = PeerId::from(key_pair.public());
@@ -110,7 +125,9 @@ impl P2pNode {
             swarm,
             shard_threads: JoinSet::new(),
             outbound_message_sender,
+            local_message_sender,
             outbound_message_receiver,
+            local_message_receiver,
         })
     }
 
@@ -142,29 +159,63 @@ impl P2pNode {
             self.secret_key,
             config,
             self.outbound_message_sender.clone(),
+            self.local_message_sender.clone(),
         )
         .await?;
-        self.shard_nodes.insert(topic.hash(), node.message_sender());
+        self.shard_nodes.insert(
+            topic.hash(),
+            NodeInputChannels {
+                external: node.message_input(),
+                internal: node.local_message_input(),
+            },
+        );
         self.shard_threads
-            .spawn(async move { node.start_p2p_node().await });
+            .spawn(async move { node.start_shard_node().await });
         self.swarm.behaviour_mut().gossipsub.subscribe(&topic)?;
         Ok(())
     }
 
-    fn forward_message_to_node(
+    fn forward_external_message_to_node(
         &self,
         topic_hash: &TopicHash,
         source: PeerId,
-        message: Message,
+        message: ExternalMessage,
     ) -> Result<()> {
         match self.shard_nodes.get(topic_hash) {
-            Some(inbound_message_sender) => inbound_message_sender.send((source, message))?,
+            Some(inbound_message_sender) => {
+                inbound_message_sender.external.send((source, message))?
+            }
             None => warn!(
                 ?topic_hash,
                 ?source,
                 ?message,
                 "Message received for unknown shard/topic"
             ),
+        };
+        Ok(())
+    }
+
+    // Method will be used once cross-shard messaging is implemented.
+    #[allow(dead_code)]
+    fn forward_local_message_to_shard(
+        &self,
+        topic_hash: &TopicHash,
+        source_shard: u64,
+        message: InternalMessage,
+    ) -> Result<()> {
+        match self.shard_nodes.get(topic_hash) {
+            Some(inbound_message_sender) => inbound_message_sender
+                .internal
+                .send((source_shard, message))?,
+            None => {
+                // TODO (tentative): perhaps in the future this could auto-spawn a light shard node?
+                warn!(
+                    ?topic_hash,
+                    ?source_shard,
+                    ?message,
+                    "Message received for unknown shard/topic"
+                )
+            }
         };
         Ok(())
     }
@@ -221,18 +272,11 @@ impl P2pNode {
                         }, ..
                     })) => {
                         let source = source.expect("message should have a source");
-                        let message = serde_json::from_slice::<Message>(&data).unwrap();
+                        let message = serde_json::from_slice::<ExternalMessage>(&data).unwrap();
                         let message_type = message.name();
                         let to = self.peer_id;
-                        match message {
-                            Message::Internal(_) => {
-                                warn!(%source, message_type, "Internal message received over the network!");
-                            }
-                            Message::External(m) => {
-                                debug!(%source, %to, message_type, "broadcast recieved");
-                                self.forward_message_to_node(&topic_hash, source, Message::External(m))?;
-                            }
-                        }
+                        debug!(%source, %to, message_type, "broadcast recieved");
+                        self.forward_external_message_to_node(&topic_hash, source, message)?;
                     }
 
                     SwarmEvent::Behaviour(BehaviourEvent::RequestResponse(request_response::Event::Message { message, peer: source })) => {
@@ -243,7 +287,7 @@ impl P2pNode {
                                 let message_type = external_message.name();
                                 debug!(%source, %to, message_type, "message received");
                                 let topic = Self::shard_id_to_topic(shard_id);
-                                self.forward_message_to_node(&topic.hash(), source, Message::External(external_message))?;
+                                self.forward_external_message_to_node(&topic.hash(), source, external_message)?;
                                 let _ = self.swarm.behaviour_mut().request_response.send_response(channel, (shard_id, ExternalMessage::RequestResponse));
                             }
                             request_response::Message::Response {..} => {}
@@ -251,6 +295,20 @@ impl P2pNode {
                     }
 
                     _ => {},
+                },
+                message = self.local_message_receiver.next() => {
+                    let (_source, _destination, message) = message.expect("message stream should be infinite");
+                    match message {
+                        InternalMessage::LaunchShard(shard_id) => {
+                            let shard_config = self.config.nodes
+                                .iter()
+                                .find(|shard_config| shard_config.eth_chain_id == shard_id)
+                                .cloned()
+                                .unwrap_or_else(
+                                    || Self::generate_child_config(self.config.nodes.first().unwrap(), shard_id));
+                            self.add_shard_node(shard_config.clone()).await?;
+                        },
+                    }
                 },
                 message = self.outbound_message_receiver.next() => {
                     let (dest, shard_id, message) = message.expect("message stream should be infinite");
@@ -266,44 +324,26 @@ impl P2pNode {
                         continue;
                     }
 
-                    match message {
-                        Message::Internal(internal_message) => match internal_message {
-                            InternalMessage::LaunchShard(shard_id) => {
-                                let shard_config = self.config.nodes
-                                    .iter()
-                                    .find(|shard_config| shard_config.eth_chain_id == shard_id)
-                                    .cloned()
-                                    .unwrap_or_else(
-                                        || Self::generate_child_config(self.config.nodes.first().unwrap(), shard_id));
-                                self.add_shard_node(shard_config.clone()).await?;
-                            },
-                            _ => {
-                                warn!(?message_type, "Unexpected internal message in outbound message queue");
+                    match dest {
+                        Some(dest) => {
+                            debug!(%from, %dest, message_type, "sending direct message");
+                            if from == dest {
+                                self.forward_external_message_to_node(&topic.hash(), from, message)?;
+                            } else {
+                                let _ = self.swarm.behaviour_mut().request_response.send_request(&dest, (shard_id, message));
                             }
-                        }
-                        Message::External(external_message) => {
-                            match dest {
-                                Some(dest) => {
-                                    debug!(%from, %dest, message_type, "sending direct message");
-                                    if from == dest {
-                                        self.forward_message_to_node(&topic.hash(), from, Message::External(external_message))?;
-                                    } else {
-                                        let _ = self.swarm.behaviour_mut().request_response.send_request(&dest, (shard_id, external_message));
-                                    }
-                                },
-                                None => {
-                                    debug!(%from, message_type, "broadcasting");
-                                    match self.swarm.behaviour_mut().gossipsub.publish(topic.hash(), data)  {
-                                        Ok(_) => {},
-                                        Err(e) => {
-                                            error!(%e, "failed to publish message");
-                                        }
-                                    }
-                                    // Also broadcast the message to ourselves.
-                                    self.forward_message_to_node(&topic.hash(), from, Message::External(external_message))?;
-                                },
+                        },
+                        None => {
+                            debug!(%from, message_type, "broadcasting");
+                            match self.swarm.behaviour_mut().gossipsub.publish(topic.hash(), data)  {
+                                Ok(_) => {},
+                                Err(e) => {
+                                    error!(%e, "failed to publish message");
+                                }
                             }
-                        }
+                            // Also broadcast the message to ourselves.
+                            self.forward_external_message_to_node(&topic.hash(), from, message)?;
+                        },
                     }
                 },
                 Some(res) = self.shard_threads.join_next() => {

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -85,7 +85,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
     // As this is very painful to debug, should only ever be relevant for tests like these, and CI
     // should run enough samples to still have decent test coverage, we simply skip the rest of the
     // test if this happens.
-    let Ok((newnode, _)) = result else {
+    let Ok((newnode, _, _)) = result else {
         warn!(
             "Failed to release database lock. Skipping test, with seed {}.",
             network.seed


### PR DESCRIPTION
Separates the `InternalMessage` and `ExternalMessage` structs to be sent through different channels, and removes the combined Message enum.

The purpose of this is to improve the type safety of sending messages around. `InternalMessage` is intended for messages within the same running process - from a shard thread to the p2p coordinator process, or (in the future) between shard threads for cross-shard messaging. `ExternalMessage` meanwhile is the type for actual p2p messages which are sent over the network.
Without this PR, both types go through the same tokio `channel`s, and all channels accept a common `Message` type that encapsulates both of the above. This means that while we can handle messages in a type-safe manner with pattern matching, the actual communication channel does not enforce any safety.

This change splits the channels, so one dedicated `unbounded_channel()` is typed to only route `ExternalMessage`s and another is typed only for `InternalMessage`s. Each gets correspondibly separate handling in the message loop of `p2p_node`. This ensures conceptual separation, allows the functions to handle the different messages to be separate and avoids having to nest match statement in every place a message is being handled.

The tradeoff for ensuring cleanly separated channels for each type is of course that we have to hold more senders and receivers at each end. This adds a bit more boilerplate - the most significant place for this is in the test scaffolding, where I actually re-create a joint enum and redirect both types of messages into the same channel for processing in the `tick()` loop. This turned out to be more bothersome than I initially expected, so I think there's a genuine tradeoff in readability and complexity here, where simply having a union enum and a single channel for everything in the first place avoids it - so I'm not entirely convinced this is worth merging after all. Opening PR for discussion, though.