### PR TITLE
start z2 deterministically

### DIFF
--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -42,7 +42,6 @@ impl Setup {
                 r#"
                     [[nodes]]
                     {}data_dir = "{DATADIR_PREFIX}{i}"
-                    eth_chain_id = 0x8001
                     consensus.genesis_committee = [ [ "{first_key}", "{first_peer_id}" ] ]
                     consensus.genesis_accounts = [
                         ["7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "5000000000000000000000"],

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -22,7 +22,7 @@ impl Setup {
     pub fn new(how_many: usize) -> Result<Self> {
         let mut secret_keys = Vec::new();
         for i in 0..how_many {
-            let key = generate_secret_key()?;
+            let key = generate_secret_key_from_index(i + 1)?;
             println!("[#{i}] = {}", key.to_hex());
             secret_keys.push(key);
         }
@@ -42,6 +42,7 @@ impl Setup {
                 r#"
                     [[nodes]]
                     {}data_dir = "{DATADIR_PREFIX}{i}"
+                    eth_chain_id = 0x8001
                     consensus.genesis_committee = [ [ "{first_key}", "{first_peer_id}" ] ]
                     consensus.genesis_accounts = [
                         ["7E5F4552091A69125d5DfCb7b8C2659029395Bdf", "5000000000000000000000"],
@@ -76,4 +77,13 @@ impl Setup {
 
 pub fn generate_secret_key() -> Result<SecretKey> {
     SecretKey::new().map_err(|err| eyre!(Box::new(err)))
+}
+
+pub fn generate_secret_key_from_index(index: usize) -> Result<SecretKey> {
+    assert_ne!(
+        index, 0,
+        "index must be non-zero when generating secret key"
+    );
+    let padded_key = format!("{:0>64}", index);
+    SecretKey::from_hex(&padded_key).map_err(|err| eyre!(Box::new(err)))
 }


### PR DESCRIPTION
With the consensus improvements, z2 could not restart from persistence as it gets a new set of private keys each time. This is one way to get around that (the other would be saving the private keys to disk which seems messier).