### PR TITLE
Simplify address type

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -80,8 +80,8 @@ fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 
     let ret = node.lock().unwrap().call_contract(
         block_number,
-        Address(call_params.from),
-        call_params.to.map(Address),
+        call_params.from,
+        call_params.to,
         call_params.data.clone(),
         U256::from(call_params.value),
         false,
@@ -130,7 +130,7 @@ fn get_balance(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     Ok(node
         .lock()
         .unwrap()
-        .get_native_balance(Address(address), block_number)?
+        .get_native_balance(address, block_number)?
         .to_hex())
 }
 
@@ -143,7 +143,7 @@ fn get_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     Ok(node
         .lock()
         .unwrap()
-        .get_account(Address(address), block_number)?
+        .get_account(address, block_number)?
         .code
         .to_hex())
 }
@@ -159,10 +159,10 @@ fn get_storage_at(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     position.to_big_endian(&mut position_bytes);
     let position = H256::from_slice(&position_bytes);
 
-    let value =
-        node.lock()
-            .unwrap()
-            .get_account_storage(Address(address), position, block_number)?;
+    let value = node
+        .lock()
+        .unwrap()
+        .get_account_storage(address, position, block_number)?;
 
     Ok(value.to_hex())
 }
@@ -177,7 +177,7 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
         "get_transaction_count resp: {:?}",
         node.lock()
             .unwrap()
-            .get_account(Address(address), block_number)?
+            .get_account(address, block_number)?
             .nonce
             .to_hex()
     );
@@ -185,7 +185,7 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
     Ok(node
         .lock()
         .unwrap()
-        .get_account(Address(address), block_number)?
+        .get_account(address, block_number)?
         .nonce
         .to_hex())
 }
@@ -433,7 +433,7 @@ pub(super) fn get_transaction_inner(
     let transaction = eth::Transaction {
         block_hash: block.as_ref().map(|b| b.hash().0.into()),
         block_number: block.as_ref().map(|b| b.number()),
-        from: from.0,
+        from,
         gas: 0,
         gas_price,
         max_fee_per_gas,
@@ -441,7 +441,7 @@ pub(super) fn get_transaction_inner(
         hash: H256(hash.0),
         input: transaction.payload().to_vec(),
         nonce: transaction.nonce(),
-        to: transaction.to_addr().map(|a| a.0),
+        to: transaction.to_addr(),
         transaction_index: block
             .map(|b| b.transactions.iter().position(|t| *t == hash).unwrap() as u64),
         value: transaction.amount(),
@@ -449,9 +449,7 @@ pub(super) fn get_transaction_inner(
         r,
         s,
         chain_id: transaction.chain_id(),
-        access_list: transaction
-            .access_list()
-            .map(|a| a.iter().map(|(a, s)| (a.0, s.clone())).collect()),
+        access_list: transaction.access_list().map(|a| a.to_vec()),
         transaction_type: match transaction {
             Transaction::Legacy(_) => 0,
             Transaction::Eip2930(_) => 1,
@@ -520,12 +518,12 @@ pub(super) fn get_transaction_receipt_inner(
         transaction_index: transaction_index as u64,
         block_hash: H256(block.hash().0),
         block_number: block.number(),
-        from: from.0,
-        to: transaction.to_addr().map(|a| a.0),
+        from,
+        to: transaction.to_addr(),
         cumulative_gas_used: 0,
         effective_gas_price: 0,
         gas_used: 1,
-        contract_address: receipt.contract_address.map(|a| a.0),
+        contract_address: receipt.contract_address,
         logs,
         logs_bloom,
         ty: 0,
@@ -614,7 +612,7 @@ fn parse_legacy_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
         nonce,
         gas_price,
         gas_limit,
-        to_addr: (!to_addr.is_empty()).then_some(Address::from_slice(&to_addr)),
+        to_addr: (!to_addr.is_empty()).then(|| Address::from_slice(&to_addr)),
         amount,
         payload,
     };
@@ -646,13 +644,10 @@ fn parse_eip2930_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
         nonce,
         gas_price,
         gas_limit,
-        to_addr: (!to_addr.is_empty()).then_some(Address::from_slice(&to_addr)),
+        to_addr: (!to_addr.is_empty()).then(|| Address::from_slice(&to_addr)),
         amount,
         payload,
-        access_list: access_list
-            .into_iter()
-            .map(|(a, s)| (Address(a), s))
-            .collect(),
+        access_list,
     };
 
     Ok(SignedTransaction::Eip2930 { tx, sig })
@@ -684,13 +679,10 @@ fn parse_eip1559_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
         max_priority_fee_per_gas,
         max_fee_per_gas,
         gas_limit,
-        to_addr: (!to_addr.is_empty()).then_some(Address::from_slice(&to_addr)),
+        to_addr: (!to_addr.is_empty()).then(|| Address::from_slice(&to_addr)),
         amount,
         payload,
-        access_list: access_list
-            .into_iter()
-            .map(|(a, s)| (Address(a), s))
-            .collect(),
+        access_list,
     };
 
     Ok(SignedTransaction::Eip1559 { tx, sig })
@@ -752,7 +744,6 @@ mod tests {
     use crate::{
         api::eth::{left_pad_arr, parse_transaction},
         crypto::Hash,
-        state::Address,
         transaction::{EthSignature, SignedTransaction, TxLegacy, VerifiedTransaction},
     };
 
@@ -769,7 +760,7 @@ mod tests {
                     nonce: 9,
                     gas_price: 20 * 10_u128.pow(9),
                     gas_limit: 21000u64,
-                    to_addr: Some(Address("0x3535353535353535353535353535353535353535".parse().unwrap())),
+                    to_addr: Some("0x3535353535353535353535353535353535353535".parse().unwrap()),
                     amount: 10u128.pow(18),
                     payload: Vec::new(),
                 },
@@ -779,7 +770,7 @@ mod tests {
                     y_is_odd: false,
                 },
             },
-            signer: Address("0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F".parse().unwrap()),
+            signer: "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F".parse().unwrap(),
             hash: Hash::from_bytes(hex::decode("33469b22e9f636356c4160a87eb19df52b7412e8eac32a4a55ffe88ea8350788").unwrap()).unwrap(),
         };
         assert_eq!(recovered_tx, expected);

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -112,7 +112,7 @@ fn has_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
     let empty = node
         .lock()
         .unwrap()
-        .get_account(Address(address), block_number)?
+        .get_account(address, block_number)?
         .code
         .is_empty();
 
@@ -218,7 +218,7 @@ fn search_transactions_after(params: Params, node: &Arc<Mutex<Node>>) -> Result<
     let block_number: u64 = params.next()?;
     let page_size: usize = params.next()?;
 
-    search_transactions_inner(node, Address(address), block_number, page_size, false)
+    search_transactions_inner(node, address, block_number, page_size, false)
 }
 
 fn search_transactions_before(
@@ -235,7 +235,7 @@ fn search_transactions_before(
         block_number = u64::MAX;
     }
 
-    search_transactions_inner(node, Address(address), block_number, page_size, true)
+    search_transactions_inner(node, address, block_number, page_size, true)
 }
 
 fn get_internal_operations(

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -16,7 +16,6 @@ use crate::{
     message::BlockNumber,
     node::Node,
     schnorr,
-    state::Address,
     transaction::{SignedTransaction, TxZilliqa},
 };
 
@@ -96,7 +95,7 @@ fn create_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<serde_j
             nonce: transaction.nonce,
             gas_price: transaction.gas_price,
             gas_limit: transaction.gas_limit,
-            to_addr: Address(transaction.to_addr),
+            to_addr: transaction.to_addr,
             amount: transaction.amount,
             code: transaction.code,
             data: transaction.data,
@@ -116,13 +115,11 @@ fn get_balance(params: Params, node: &Arc<Mutex<Node>>) -> Result<serde_json::Va
 
     let node = node.lock().unwrap();
 
-    let balance = node.get_native_balance(Address(address), BlockNumber::Latest)?;
+    let balance = node.get_native_balance(address, BlockNumber::Latest)?;
     // We need to scale the balance from units of (10^-18) ZIL to (10^-12) ZIL. The value is truncated in this process.
     let balance = balance / U256::from(10).pow(U256::from(6));
     let balance = balance.to_string();
-    let nonce = node
-        .get_account(Address(address), BlockNumber::Latest)?
-        .nonce;
+    let nonce = node.get_account(address, BlockNumber::Latest)?.nonce;
 
     Ok(json!({"balance": balance, "nonce": nonce}))
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -3,6 +3,7 @@ use primitive_types::H256;
 
 use crate::message::{ExternalMessage, InternalMessage};
 use crate::node::MessageSender;
+use crate::state::contract_addr;
 use anyhow::{anyhow, Result};
 use bitvec::bitvec;
 use libp2p::PeerId;
@@ -729,7 +730,7 @@ impl Consensus {
         })?;
 
         for address in listener.touched {
-            self.db.add_touched_address(Address(address), hash)?;
+            self.db.add_touched_address(address, hash)?;
         }
 
         if !result.success {
@@ -1241,7 +1242,7 @@ impl Consensus {
         let logs: Result<Vec<_>, _> = receipts
             .into_iter()
             .flat_map(|receipt| receipt.logs)
-            .filter(|log| log.address == emitter.0 && log.topics[0] == event.signature())
+            .filter(|log| log.address == emitter && log.topics[0] == event.signature())
             .map(|log| {
                 event.parse_log_whole(RawLog {
                     topics: log.topics,
@@ -1449,7 +1450,7 @@ impl Consensus {
             let shard_logs = self.get_logs_in_block(
                 hash,
                 contracts::shard_registry::SHARD_ADDED_EVT.clone(),
-                Address::SHARD_CONTRACT,
+                contract_addr::SHARD_CONTRACT,
             )?;
             for log in shard_logs {
                 let Some(shard_id) = log

--- a/zilliqa/src/evm_backend.rs
+++ b/zilliqa/src/evm_backend.rs
@@ -72,8 +72,6 @@ impl<'a> EvmBackend<'a> {
         for apply in applys {
             match apply {
                 Apply::Delete { address } => {
-                    let address = Address(address);
-
                     // Insert empty slot into cache
                     self.account_storage_cached.insert(address, None);
                 }
@@ -85,8 +83,6 @@ impl<'a> EvmBackend<'a> {
                     storage,
                     reset_storage,
                 } => {
-                    let address = Address(address);
-
                     if reset_storage {
                         todo!("clear_account_storage");
                     }
@@ -123,11 +119,11 @@ impl<'a> EvmBackend<'a> {
     pub fn get_result(self) -> EvmResult {
         let mut applys: Vec<Apply> = vec![];
 
-        for (addr, item) in self.account_storage_cached.into_iter() {
+        for (address, item) in self.account_storage_cached.into_iter() {
             match item {
                 Some((acct, stor)) => {
                     applys.push(Apply::Modify {
-                        address: addr.0,
+                        address,
                         balance: U256::zero(),
                         nonce: U256::zero(),
                         code: acct.code,
@@ -139,7 +135,7 @@ impl<'a> EvmBackend<'a> {
                     });
                 }
                 None => {
-                    applys.push(Apply::Delete { address: addr.0 });
+                    applys.push(Apply::Delete { address });
                 }
             }
         }
@@ -205,13 +201,13 @@ impl<'a> Backend for EvmBackend<'a> {
         // creation of many addresses and the resulting increase in state size.
 
         // first check if the account is cleared in the cache
-        if let Some(item) = self.account_storage_cached.get(&address.into()) {
+        if let Some(item) = self.account_storage_cached.get(&address) {
             if item.is_none() {
                 return false;
             }
         }
 
-        let exists = self.state.has_account(Address(address));
+        let exists = self.state.has_account(address);
         trace!(
             "EVM request: Checking whether account {:?} exists {}",
             address,
@@ -222,13 +218,10 @@ impl<'a> Backend for EvmBackend<'a> {
 
     fn basic(&self, address: H160) -> Basic {
         // first check if the account is in the cache
-        if let Some(Some((acct, _))) = self.account_storage_cached.get(&Address(address)) {
+        if let Some(Some((acct, _))) = self.account_storage_cached.get(&address) {
             let nonce = acct.nonce;
             let basic = Basic {
-                balance: self
-                    .state
-                    .get_native_balance(Address(address), false)
-                    .unwrap(),
+                balance: self.state.get_native_balance(address, false).unwrap(),
                 nonce: nonce.into(),
             };
             trace!(
@@ -239,12 +232,9 @@ impl<'a> Backend for EvmBackend<'a> {
             return basic;
         }
 
-        let nonce = self.state.must_get_account(Address(address)).nonce;
+        let nonce = self.state.must_get_account(address).nonce;
         let basic = Basic {
-            balance: self
-                .state
-                .get_native_balance(Address(address), false)
-                .unwrap(),
+            balance: self.state.get_native_balance(address, false).unwrap(),
             nonce: nonce.into(),
         };
         trace!(
@@ -257,7 +247,7 @@ impl<'a> Backend for EvmBackend<'a> {
 
     fn code(&self, address: H160) -> Vec<u8> {
         // first check if the account is in the cache
-        if let Some(Some((acct, _))) = self.account_storage_cached.get(&Address(address)) {
+        if let Some(Some((acct, _))) = self.account_storage_cached.get(&address) {
             let code = acct.code.clone();
             trace!(
                 "EVM request: (cached) Requesting code for {:?} - answ: {:?}",
@@ -267,7 +257,7 @@ impl<'a> Backend for EvmBackend<'a> {
             return code;
         }
 
-        let code = self.state.must_get_account(Address(address)).code;
+        let code = self.state.must_get_account(address).code;
 
         trace!(
             "EVM request: Requesting code for {:?} - answ: {:?}",
@@ -279,7 +269,7 @@ impl<'a> Backend for EvmBackend<'a> {
 
     fn storage(&self, address: H160, index: H256) -> H256 {
         // first check if the account is in the cache
-        if let Some(Some((_, stor))) = self.account_storage_cached.get(&Address(address)) {
+        if let Some(Some((_, stor))) = self.account_storage_cached.get(&address) {
             if let Some(value) = stor.get(&index) {
                 trace!(
                     "EVM request: (cached) Requesting storage for {:?} at {:?} and is: {:?}",
@@ -291,7 +281,7 @@ impl<'a> Backend for EvmBackend<'a> {
             }
         }
 
-        let res = self.state.must_get_account_storage(Address(address), index);
+        let res = self.state.must_get_account_storage(address, index);
 
         trace!(
             "EVM request: Requesting storage for {:?} at {:?} and is: {:?}",

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -7,7 +7,7 @@ use std::{
 
 use evm_ds::tracing_logging::LoggingEventListener;
 
-use crate::evm_backend::EvmBackend;
+use crate::{evm_backend::EvmBackend, state::contract_addr};
 use anyhow::{anyhow, Result};
 use ethabi::Token;
 use evm_ds::{
@@ -127,13 +127,13 @@ impl State {
                     for apply in result.apply.iter_mut() {
                         match apply {
                             EvmProto::Apply::Modify { address, .. } => {
-                                if *address == evm_address.0 {
-                                    *address = override_address.0;
+                                if *address == evm_address {
+                                    *address = override_address;
                                 }
                             }
                             EvmProto::Apply::Delete { address, .. } => {
-                                if *address == evm_address.0 {
-                                    *address = override_address.0;
+                                if *address == evm_address {
+                                    *address = override_address;
                                 }
                             }
                         }
@@ -173,9 +173,9 @@ impl State {
         let context = "".to_string();
         let continuations: Arc<Mutex<EvmProto::Continuations>> = Default::default();
         let account = self
-            .get_account(to_addr.unwrap_or(Address::ZERO))
+            .get_account(to_addr.unwrap_or(Address::zero()))
             .unwrap_or_default();
-        let mut to = to_addr.unwrap_or(Address::ZERO);
+        let mut to = to_addr.unwrap_or(Address::zero());
         let mut created_contract_addr: Option<Address> = None;
 
         let mut code: Vec<u8> = account.code;
@@ -184,13 +184,13 @@ impl State {
             Arc::new(Mutex::new(LoggingEventListener::new(tracing)));
 
         // The backend is provided to the evm as a way to read accounts and state during execution
-        let mut backend = EvmBackend::new(self, U256::zero(), caller.0, chain_id, current_block);
+        let mut backend = EvmBackend::new(self, U256::zero(), caller, chain_id, current_block);
 
         // if this is none, it is contract creation
         if to_addr.is_none() {
             code = data;
             data = vec![];
-            to = Address(calculate_contract_address(from_addr.0, &backend));
+            to = calculate_contract_address(from_addr, &backend);
             created_contract_addr = Some(to);
             info!("Calculated contract address for creation: {}", to);
         }
@@ -201,12 +201,12 @@ impl State {
 
         // The first continuation in the stack is the tx itself
         continuation_stack.push(EvmProto::EvmCallArgs {
-            address: to.0,
+            address: to,
             code,
             data,
             apparent_value: amount,
             gas_limit,
-            caller: caller.0,
+            caller,
             gas_scaling_factor: 1,
             scaling_factor: None,
             estimate,
@@ -341,8 +341,8 @@ impl State {
                         call_args.node_continuation = Some(cont);
 
                         let call_data_next = call.call_data;
-                        let call_addr: Address = call.callee_address.into();
-                        let caller: Address = call.context.caller.into();
+                        let call_addr = call.callee_address;
+                        let caller = call.context.caller;
                         let value: U256 = if let Some(transfer) = call.transfer {
                             transfer.value
                         } else {
@@ -350,11 +350,11 @@ impl State {
                         };
 
                         // Fetch the code to be called from the backend
-                        let code_next = backend.code(call_addr.0);
+                        let code_next = backend.code(call_addr);
 
                         // Set up the next continuation, adjust the relevant parameters
                         let call_args_next = EvmProto::EvmCallArgs {
-                            address: call_addr.0,
+                            address: call_addr,
                             code: code_next,
                             data: call_data_next,
                             apparent_value: value,
@@ -426,7 +426,7 @@ impl State {
                             // We also need to write down the data + address of the contract we
                             // just created
                             backend.create_account(
-                                prior_node_continuation.get_address().into(),
+                                prior_node_continuation.get_address(),
                                 result.return_value.clone(),
                             );
 
@@ -458,7 +458,7 @@ impl State {
 
             continuation_stack.push(self.push_transfer(
                 from_addr,
-                Address::COLLECTED_FEES,
+                contract_addr::COLLECTED_FEES,
                 gas_deduction.into(),
                 continuations,
                 traces,
@@ -521,7 +521,7 @@ impl State {
         payload: Vec<u8>,
     ) -> Result<(EvmProto::EvmResult, Option<Address>)> {
         self.apply_transaction_inner(
-            Address::ZERO,
+            Address::zero(),
             to_addr,
             u128::MIN,
             u64::MAX,
@@ -624,7 +624,6 @@ impl State {
         for apply in applys {
             match apply {
                 EvmProto::Apply::Delete { address } => {
-                    let address = Address(address);
                     let _account = self.delete_account(address);
                 }
                 EvmProto::Apply::Modify {
@@ -635,7 +634,6 @@ impl State {
                     storage,
                     reset_storage,
                 } => {
-                    let address = Address(address);
                     let mut account = self.get_account(address).unwrap_or_default();
 
                     if !code.is_empty() {
@@ -666,12 +664,12 @@ impl State {
         // For these accounts, we hardcode the balance we return to the EVM engine as zero. Otherwise, we have an
         // infinite recursion because getting the native balance of any account requires this method to be called for
         // these two 'special' accounts.
-        if address == Address::NATIVE_TOKEN || address == Address::ZERO {
+        if address == contract_addr::NATIVE_TOKEN || address.is_zero() {
             return Ok(U256::zero());
         }
 
         let data = contracts::native_token::BALANCE_OF
-            .encode_input(&[Token::Address(address.0)])
+            .encode_input(&[Token::Address(address)])
             .unwrap();
 
         if print_enabled {
@@ -680,8 +678,8 @@ impl State {
 
         let balance = self
             .call_contract(
-                Address::ZERO,
-                Some(Address::NATIVE_TOKEN),
+                Address::zero(),
+                Some(contract_addr::NATIVE_TOKEN),
                 data,
                 // The chain ID and current block are not accessed when the native balance is read, so we just pass in some
                 // dummy values.
@@ -705,7 +703,7 @@ impl State {
             .unwrap();
 
         debug!("****** setting gas price to: {}", price);
-        let result = self.force_execute_payload(Some(Address::GAS_PRICE), data);
+        let result = self.force_execute_payload(Some(contract_addr::GAS_PRICE), data);
 
         match result {
             Ok((result, _)) => {
@@ -734,8 +732,8 @@ impl State {
 
         let gas_price = self
             .call_contract(
-                Address::ZERO,
-                Some(Address::GAS_PRICE),
+                Address::zero(),
+                Some(contract_addr::GAS_PRICE),
                 data,
                 U256::zero(),
                 // The chain ID and current block are not accessed when the native balance is read, so we just pass in some
@@ -755,7 +753,7 @@ impl State {
 
     pub fn set_native_balance(&mut self, address: Address, amount: U256) -> Result<()> {
         let data = contracts::native_token::SET_BALANCE
-            .encode_input(&[Token::Address(address.0), Token::Uint(amount)])
+            .encode_input(&[Token::Address(address), Token::Uint(amount)])
             .unwrap();
 
         debug!(
@@ -764,8 +762,8 @@ impl State {
         );
 
         let result = self.apply_transaction_inner(
-            Address::ZERO,
-            Some(Address::NATIVE_TOKEN),
+            Address::zero(),
+            Some(contract_addr::NATIVE_TOKEN),
             u128::MIN,
             u64::MAX,
             U256::zero(),
@@ -923,18 +921,18 @@ impl State {
             amount
         );
 
-        let native_token_code = self.get_account(Address::NATIVE_TOKEN).unwrap().code;
+        let native_token_code = self.get_account(contract_addr::NATIVE_TOKEN).unwrap().code;
 
         let balance_data = contracts::native_token::TRANSFER
-            .encode_input(&[Token::Address(to.0), Token::Uint(amount)])
+            .encode_input(&[Token::Address(to), Token::Uint(amount)])
             .unwrap();
 
         EvmProto::EvmCallArgs {
-            caller: from.0,
+            caller: from,
             gas_scaling_factor: 1,
             scaling_factor: None,
             estimate: false,
-            address: Address::NATIVE_TOKEN.0,
+            address: contract_addr::NATIVE_TOKEN,
             code: native_token_code,
             data: balance_data,
             apparent_value: Default::default(),

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -1,14 +1,12 @@
 use anyhow::{anyhow, Result};
-use core::fmt;
 use eth_trie::{EthTrie as PatriciaTrie, Trie};
 use ethabi::Token;
 use primitive_types::{H160, H256};
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 use std::convert::TryInto;
-use std::fmt::{Display, LowerHex};
+use std::hash::Hash;
 use std::sync::Arc;
-use std::{hash::Hash, str::FromStr};
 
 use crate::{cfg::ConsensusConfig, contracts, crypto, db::TrieStorage};
 
@@ -50,16 +48,16 @@ impl State {
                 contracts::shard_registry::BYTECODE.to_vec(),
                 &[Token::Uint(config.consensus_timeout.as_millis().into())],
             )?;
-            state.force_deploy_contract(shard_data, Some(Address::SHARD_CONTRACT))?;
+            state.force_deploy_contract(shard_data, Some(contract_addr::SHARD_CONTRACT))?;
         };
 
         let native_token_data = contracts::native_token::CONSTRUCTOR
             .encode_input(contracts::native_token::BYTECODE.to_vec(), &[])?;
-        state.force_deploy_contract(native_token_data, Some(Address::NATIVE_TOKEN))?;
+        state.force_deploy_contract(native_token_data, Some(contract_addr::NATIVE_TOKEN))?;
 
         let gas_price_data = contracts::gas_price::CONSTRUCTOR
             .encode_input(contracts::gas_price::BYTECODE.to_vec(), &[])?;
-        state.force_deploy_contract(gas_price_data, Some(Address::GAS_PRICE))?;
+        state.force_deploy_contract(gas_price_data, Some(contract_addr::GAS_PRICE))?;
 
         let _ = state.set_gas_price(default_gas_price().into());
 
@@ -222,72 +220,20 @@ impl State {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
-pub struct Address(pub H160);
+pub type Address = H160;
 
-impl fmt::Debug for Address {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.0)
-    }
-}
+pub mod contract_addr {
+    use primitive_types::H160;
 
-impl From<H160> for Address {
-    fn from(h: H160) -> Address {
-        Address(h)
-    }
-}
-
-impl Address {
-    pub const ZERO: Address = Address(H160::zero());
-    pub fn zero() -> Address {
-        Address(H160::zero())
-    }
+    use super::Address;
 
     /// Address of the native token ERC-20 contract.
-    pub const NATIVE_TOKEN: Address = Address(H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0ZIL"));
-
-    pub const SHARD_CONTRACT: Address = Address(H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0ZQSHARD"));
-
+    pub const NATIVE_TOKEN: Address = H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0ZIL");
+    pub const SHARD_CONTRACT: Address = H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0ZQSHARD");
     /// Address of the gas contract
-    pub const GAS_PRICE: Address = Address(H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0GAS"));
-
+    pub const GAS_PRICE: Address = H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0GAS");
     /// Gas fees go here
-    pub const COLLECTED_FEES: Address = Address(H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0FEE"));
-
-    pub fn is_balance_transfer(to: Address) -> bool {
-        to == Address::NATIVE_TOKEN
-    }
-
-    pub fn from_bytes(bytes: [u8; 20]) -> Address {
-        Address(bytes.into())
-    }
-
-    pub fn from_slice(bytes: &[u8]) -> Address {
-        let mut bytes = bytes.to_owned();
-        // FIXME: Awfully inefficient
-        while bytes.len() < 20 {
-            bytes.insert(0, 0);
-        }
-        Address(H160::from_slice(&bytes))
-    }
-
-    pub fn as_bytes(&self) -> [u8; 20] {
-        *self.0.as_fixed_bytes()
-    }
-}
-
-impl Display for Address {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        LowerHex::fmt(&self.0, f)
-    }
-}
-
-impl FromStr for Address {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Address(s.parse()?))
-    }
+    pub const COLLECTED_FEES: Address = H160(*b"\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0FEE");
 }
 
 #[derive(Debug, Clone, Default, Hash, Serialize, Deserialize)]

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -6,7 +6,7 @@ use ethers::{
 };
 use primitive_types::H160;
 use tracing::*;
-use zilliqa::{contracts, state::Address};
+use zilliqa::{contracts, state::contract_addr};
 
 // Test that all nodes can die and the network can restart (even if they startup at different
 // times)
@@ -209,7 +209,7 @@ async fn launch_shard(mut network: Network) {
 
     // 4. Register the shard in the shard registry on the main shard
     let tx_request = TransactionRequest::new()
-        .to(Address::SHARD_CONTRACT.0)
+        .to(contract_addr::SHARD_CONTRACT)
         .data(
             contracts::shard_registry::ADD_SHARD
                 .encode_input(&[

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -245,7 +245,7 @@ impl Network {
 
     fn genesis_accounts(genesis_key: &SigningKey) -> Vec<(Address, String)> {
         vec![(
-            Address(secret_key_to_address(genesis_key)),
+            secret_key_to_address(genesis_key),
             1_000_000_000u128
                 .checked_mul(10u128.pow(18))
                 .unwrap()


### PR DESCRIPTION
Instead of defining `Address` as a newtype of `Address(H160)`, we instead just alias `Address = H160`. This simplifies quite a bit of code and I'd argue it doesn't cost us any type safety, because we aren't using `H160` for anything other than addresses. The only thing this might make more difficult in the future is changing the width of addresses, but I'd argue that will be difficult anyway and its not worth paying the complexity cost now.