### PR TITLE
Specify workspace resolver in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members = [
  "zilliqa",


### PR DESCRIPTION
This silences the warning about non-explicit resolvers whenever we build.