### PR TITLE
Use task-local values for fake time

### DIFF
--- a/zilliqa-macros/src/test.rs
+++ b/zilliqa-macros/src/test.rs
@@ -56,7 +56,9 @@ pub(crate) fn test_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
                     let network = crate::Network::new(std::sync::Arc::new(std::sync::Mutex::new(rng)), 4, seed);
 
                     // Call the original test function, wrapped in `catch_unwind` so we can detect the panic.
-                    let result = futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(#inner_name(network))).await;
+                    let result = futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
+                        zilliqa::time::with_fake_time(#inner_name(network))
+                    )).await;
 
                     match result {
                         Ok(()) => {},

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -7,13 +7,12 @@ use rand::Rng;
 use serde::{Deserialize, Deserializer, Serialize};
 use sha3::{Digest, Keccak256};
 use std::{fmt, fmt::Display, fmt::Formatter, str::FromStr};
-use time::format_description;
+use time::{macros::format_description, OffsetDateTime};
 use tracing::*;
 
 use crate::{
     consensus::Validator,
     crypto::{Hash, NodePublicKey, NodeSignature, SecretKey},
-    time::OffsetDateTime,
     time::SystemTime,
     transaction::SignedTransaction,
 };
@@ -326,12 +325,13 @@ impl fmt::Display for BlockHeader {
 
 // Helper function to format SystemTime as a string
 // https://stackoverflow.com/questions/45386585
-fn systemtime_strftime<T>(dt: T) -> Result<String, time::error::Format>
-where
-    T: Into<OffsetDateTime>,
-{
-    let f = format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
-    dt.into().format(&f)
+fn systemtime_strftime(timestamp: SystemTime) -> Result<String> {
+    let time_since_epoch = timestamp.elapsed()?;
+    let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
+    Ok(
+        OffsetDateTime::from_unix_timestamp_nanos(time_since_epoch.as_nanos() as i128)?
+            .format(&format)?,
+    )
 }
 
 impl BlockHeader {

--- a/zilliqa/src/time.rs
+++ b/zilliqa/src/time.rs
@@ -6,30 +6,14 @@
 #[cfg(not(feature = "fake_time"))]
 pub type SystemTime = std::time::SystemTime;
 
-pub type OffsetDateTime = time::OffsetDateTime;
-
-impl From<time_impl::SystemTime> for OffsetDateTime {
-    fn from(time: time_impl::SystemTime) -> Self {
-        let duration = time
-            .duration_since(time_impl::SystemTime::UNIX_EPOCH)
-            .unwrap();
-        time::OffsetDateTime::from_unix_timestamp(duration.as_secs() as i64).unwrap()
-    }
-}
-
 #[cfg(feature = "fake_time")]
 pub use time_impl::*;
 
 #[cfg(feature = "fake_time")]
 mod time_impl {
+    use futures::Future;
     use serde::{Deserialize, Serialize};
-    use std::{
-        sync::{
-            atomic::{AtomicBool, Ordering},
-            Mutex, OnceLock,
-        },
-        time::Duration,
-    };
+    use std::{error::Error, fmt, sync::Mutex, time::Duration};
 
     /// A fake implementation of [std::time::SystemTime]. The value of `SystemTime::now` can be controlled with [advance_time].
     #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -39,15 +23,15 @@ mod time_impl {
         pub const UNIX_EPOCH: SystemTime = SystemTime(std::time::SystemTime::UNIX_EPOCH);
 
         pub fn now() -> Self {
-            let paused = PAUSED.load(Ordering::Acquire);
-            if paused {
-                // Time has been paused, get the fake time.
-                let current_time = *CURRENT_TIME.get_or_init(Mutex::default).lock().unwrap();
-                SystemTime(std::time::SystemTime::UNIX_EPOCH + current_time)
-            } else {
-                // Time has not been paused, use the real time.
-                SystemTime(std::time::SystemTime::now())
-            }
+            CURRENT_TIME
+                .try_with(|current_time| {
+                    let current_time = *current_time.lock().unwrap();
+                    SystemTime(std::time::SystemTime::UNIX_EPOCH + current_time)
+                })
+                .unwrap_or_else(|_| {
+                    // We are not within the scope of `with_fake_time()`, so use the real time.
+                    SystemTime(std::time::SystemTime::now())
+                })
         }
 
         pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
@@ -69,30 +53,32 @@ mod time_impl {
             self.0
         }
     }
-
-    static PAUSED: AtomicBool = AtomicBool::new(false);
-    /// Stores the duration between the currently set fake time time and the `UNIX_EPOCH`.
-    static CURRENT_TIME: OnceLock<Mutex<Duration>> = OnceLock::new();
-
-    /// Pause the fake time at the unix epoch.
-    pub fn pause_at_epoch() {
-        // Do not pause if it already paused
-        if PAUSED.load(Ordering::Acquire) {
-            return;
+    impl fmt::Display for SystemTimeError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "second time provided was later than self")
         }
-
-        PAUSED.store(true, Ordering::Release);
-        let mut current_time = CURRENT_TIME.get_or_init(Mutex::default).lock().unwrap();
-        *current_time = Duration::ZERO;
     }
 
-    /// Advance the fake time by this duration. Panics if time has not been paused with `pause_at_epoch()`.
-    pub fn advance(delta: Duration) {
-        let paused = PAUSED.load(Ordering::Acquire);
-        if !paused {
-            panic!("time is not paused");
+    impl Error for SystemTimeError {
+        fn description(&self) -> &str {
+            "other time was not earlier than self"
         }
-        let mut current_time = CURRENT_TIME.get_or_init(Mutex::default).lock().unwrap();
-        *current_time += delta;
+    }
+
+    tokio::task_local! {
+        /// Stores the duration between the currently set fake time time and the `UNIX_EPOCH`.
+        static CURRENT_TIME: Mutex<Duration>;
+    }
+
+    pub fn with_fake_time<F: Future>(f: F) -> impl Future<Output = F::Output> {
+        CURRENT_TIME.scope(Mutex::new(Duration::ZERO), f)
+    }
+
+    /// Advance the fake time by this duration. Panics if not called within the scope of `with_fake_time()`.
+    pub fn advance(delta: Duration) {
+        CURRENT_TIME.with(|current_time| {
+            let mut current_time = current_time.lock().unwrap();
+            *current_time += delta;
+        });
     }
 }

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -193,9 +193,6 @@ struct Network {
 
 impl Network {
     pub fn new(rng: Arc<Mutex<ChaCha8Rng>>, nodes: usize, seed: u64) -> Network {
-        // Make sure first thing is to pause system time
-        zilliqa::time::pause_at_epoch();
-
         let mut keys: Vec<_> = (0..nodes)
             .map(|_| SecretKey::new_from_rng(rng.lock().unwrap().deref_mut()).unwrap())
             .collect();


### PR DESCRIPTION
This means each test instance gets its own independent and deterministic value of fake time.