### PR TITLE
Use GCP-hosted runners for CI tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,12 +15,12 @@ env:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, gcp]
     steps:
-    - name: Clear some disk space
-      run: sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL /home/runner/work/_temp/
+    - name: Install Rust
+      run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Install dependencies
-      run: sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && sudo apt install -y protobuf-compiler solc
+      run: sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && sudo apt install -y protobuf-compiler solc build-essential
     - uses: actions/checkout@v4
       with:
         submodules: recursive


### PR DESCRIPTION
We're replacing the AWS-hosted runners with ones in GCP. On AWS, we saw spurious and unexplained SIGKILLs - I started 12 jobs on the GCP runners and didn't see the SIGKILL, so the issue might be fixed here.