### PR TITLE
fix span messages in tests

### DIFF
--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -601,7 +601,15 @@ impl Network {
                 } else {
                     self.nodes.iter().collect()
                 };
-                for (index, node) in nodes.iter().enumerate() {
+
+                for node in &nodes {
+                    // Need to recalculate index against the original vec, not the filtered one.
+                    let index = self
+                        .nodes
+                        .iter()
+                        .position(|n| n.peer_id == node.peer_id)
+                        .unwrap();
+
                     let span = tracing::span!(tracing::Level::INFO, "handle_message", index);
                     span.in_scope(|| {
                         node.inner


### PR DESCRIPTION
The comment should make it clear, but as I noted in my main forking PR, the index has to be recalculated otherwise it incorrectly appears as if the messages are all or mostly going to node 0.