### PR TITLE
Avoid requesting blocks we won't accept anyway

### DIFF
--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -89,6 +89,13 @@ impl BlockStore {
     }
 
     pub fn request_blocks(&mut self, peer: Option<PeerId>, number: u64) -> Result<()> {
+        // If the request is higher than our head, lower it to our head, as we don't store
+        // loose blocks
+        let number = std::cmp::min(number, self.db.get_highest_block_number().unwrap().unwrap());
+        let number = std::cmp::max(number, 1); // avoid requesting genesis unnceccessarily
+
+        trace!("Requesting blocks from {}", number);
+
         let request =
             ExternalMessage::BlockBatchRequest(BlockBatchRequest(BlockRef::Number(number)));
 


### PR DESCRIPTION
At certain points, it becomes apparent to the node it is lagging (proposal received with a parent hash it does not know of). At this point, it triggers a request for blocks. If the proposal it recieved was far ahead of its own head, this can cause wasted compute (and wasted time in test framework) as it immediately discards the response due to it being 'loose'.

to avoid this, make sure the block you are asking for is not higher than your head.