### PR TITLE
control time by task id

### DIFF
--- a/zilliqa/src/time.rs
+++ b/zilliqa/src/time.rs
@@ -8,6 +8,7 @@ pub type SystemTime = std::time::SystemTime;
 
 pub type OffsetDateTime = time::OffsetDateTime;
 
+#[cfg(feature = "fake_time")]
 impl From<time_impl::SystemTime> for OffsetDateTime {
     fn from(time: time_impl::SystemTime) -> Self {
         let duration = time
@@ -23,6 +24,7 @@ pub use time_impl::*;
 #[cfg(feature = "fake_time")]
 mod time_impl {
     use serde::{Deserialize, Serialize};
+    use std::collections::HashMap;
     use std::{
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -30,6 +32,7 @@ mod time_impl {
         },
         time::Duration,
     };
+    use tokio::task::Id;
 
     /// A fake implementation of [std::time::SystemTime]. The value of `SystemTime::now` can be controlled with [advance_time].
     #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -39,11 +42,22 @@ mod time_impl {
         pub const UNIX_EPOCH: SystemTime = SystemTime(std::time::SystemTime::UNIX_EPOCH);
 
         pub fn now() -> Self {
+            // Paused is global and not task-local
             let paused = PAUSED.load(Ordering::Acquire);
+
             if paused {
-                // Time has been paused, get the fake time.
-                let current_time = *CURRENT_TIME.get_or_init(Mutex::default).lock().unwrap();
-                SystemTime(std::time::SystemTime::UNIX_EPOCH + current_time)
+                // Time has been paused, get the fake time (init if not exist).
+                let mut current_time_map = CURRENT_TIME
+                    .get_or_init(|| Mutex::new(HashMap::new()))
+                    .lock()
+                    .unwrap();
+
+                let current_task_id = tokio::task::id();
+                let current_time = current_time_map
+                    .entry(current_task_id)
+                    .or_insert(Duration::ZERO);
+
+                SystemTime(std::time::SystemTime::UNIX_EPOCH + *current_time)
             } else {
                 // Time has not been paused, use the real time.
                 SystemTime(std::time::SystemTime::now())
@@ -72,7 +86,8 @@ mod time_impl {
 
     static PAUSED: AtomicBool = AtomicBool::new(false);
     /// Stores the duration between the currently set fake time time and the `UNIX_EPOCH`.
-    static CURRENT_TIME: OnceLock<Mutex<Duration>> = OnceLock::new();
+    /// This is on a tokio task basis, to avoid tests interfering with each other.
+    static CURRENT_TIME: OnceLock<Mutex<HashMap<Id, Duration>>> = OnceLock::new();
 
     /// Pause the fake time at the unix epoch.
     pub fn pause_at_epoch() {
@@ -82,7 +97,15 @@ mod time_impl {
         }
 
         PAUSED.store(true, Ordering::Release);
-        let mut current_time = CURRENT_TIME.get_or_init(Mutex::default).lock().unwrap();
+
+        let mut current_time_map = CURRENT_TIME
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap();
+        let current_task_id = tokio::task::id();
+        let current_time = current_time_map
+            .entry(current_task_id)
+            .or_insert(Duration::ZERO);
         *current_time = Duration::ZERO;
     }
 
@@ -92,7 +115,13 @@ mod time_impl {
         if !paused {
             panic!("time is not paused");
         }
-        let mut current_time = CURRENT_TIME.get_or_init(Mutex::default).lock().unwrap();
+
+        let mut current_time_map = CURRENT_TIME
+            .get_or_init(|| Mutex::new(HashMap::new()))
+            .lock()
+            .unwrap();
+        let current_task_id = tokio::task::id();
+        let current_time = current_time_map.get_mut(&current_task_id).unwrap();
         *current_time += delta;
     }
 }

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -545,7 +545,7 @@ impl Network {
 
         if messages.is_empty() {
             trace!("Messages were empty - advance time and trigger timeout in all nodes!");
-            zilliqa::time::advance(Duration::from_millis(500));
+            zilliqa::time::advance(Duration::from_millis(1000));
 
             for (index, node) in self.nodes.iter().enumerate() {
                 let span = tracing::span!(tracing::Level::INFO, "handle_timeout", index);


### PR DESCRIPTION
Motivation: tests were not deterministic because all tests have access to the fake time, which means sometimes a test would fail, but not when you re-used that same seed.

This solution keeps a map of task ID to fake time. It is not bulletproof since task ids can eventually be re-used, but this seems unlikely, and even more unlikely to cause an issue, as not starting at epoch zero shouldn't be a problem for any of the code.

There is an alternate solution James proposed here: https://github.com/Zilliqa/zq2/pull/563 so if @theo-zil could weigh in that would be nice :)