### PR TITLE
Refactor transaction pool into separate data structure

### DIFF
--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -44,8 +44,6 @@ pub struct NodeConfig {
     pub eth_chain_id: u64,
     /// Consensus-specific data.
     pub consensus: ConsensusConfig,
-    /// The maximum number of times to retry out of order TXs before dropping them
-    pub tx_retries: u64,
     /// The maximum duration between a recieved block's timestamp and the current time. Defaults to 10 seconds.
     pub allowed_timestamp_skew: Duration,
     /// The location of persistence data. If not set, uses a temporary path.
@@ -61,10 +59,6 @@ pub struct ConsensusConfig {
     pub main_shard_id: Option<u64>,
     /// The maximum time to wait for consensus to proceed as normal, before proposing a new view.
     pub consensus_timeout: Duration,
-    /// The maximum number of times to retry out of order TXs before dropping them
-    pub tx_retries: u64,
-    /// The maximum number of times to retry out of order TXs before dropping them
-    pub block_tx_limit: usize,
     /// The genesis committee (public key, peer id) pairs. Only allowed to have one member at the moment
     /// Genesis data. Specifying a committee node is necessary for nodes participating in the consensus at
     /// genesis. Only the hash can be specified for nodes joining afterwards.
@@ -80,8 +74,6 @@ impl Default for ConsensusConfig {
             is_main: true,
             main_shard_id: None,
             consensus_timeout: Duration::from_secs(5),
-            block_tx_limit: 1000,
-            tx_retries: 1000,
             genesis_committee: vec![],
             genesis_hash: None,
             genesis_accounts: Vec::new(),
@@ -99,7 +91,6 @@ impl Default for NodeConfig {
             eth_chain_id: 700 + 0x8000,
             allowed_timestamp_skew: Duration::from_secs(10),
             data_dir: None,
-            tx_retries: 1000,
         }
     }
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -664,10 +664,8 @@ impl Consensus {
             )
         })?;
 
-        // If the transaction succeeded, tell the transaction pool that the sender's nonce has been incremented.
-        if result.success {
-            self.transaction_pool.update_nonce(&txn);
-        }
+        // Tell the transaction pool that the sender's nonce has been incremented.
+        self.transaction_pool.update_nonce(&txn);
 
         for address in listener.touched {
             self.db.add_touched_address(address, hash)?;

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -12,6 +12,7 @@ pub mod message;
 pub mod node;
 pub mod node_launcher;
 pub mod p2p_node;
+mod pool;
 pub mod schnorr;
 pub mod state;
 pub mod time;

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -1,0 +1,212 @@
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BinaryHeap},
+};
+
+use crate::{crypto::Hash, state::Address, transaction::VerifiedTransaction};
+
+/// A pool that manages uncommitted transactions.
+///
+/// It provides transactions to the chain via [`TransactionPool::best_transaction`].
+#[derive(Debug, Default)]
+pub struct TransactionPool {
+    /// All transactions in the pool, indexed by (sender, nonce). These transactions are all valid, or might become
+    /// valid at some point in the future.
+    transactions: BTreeMap<(Address, u64), VerifiedTransaction>,
+    /// Indices into `transactions`, sorted by gas price. This contains indices of transactions which are immediately
+    /// executable, because they have a nonce equal to the account's nonce.
+    ready: BinaryHeap<ReadyItem>,
+    /// A map of transaction hash to index into `transactions`. Used for querying transactions from the pool by their
+    /// hash.
+    hash_to_index: BTreeMap<Hash, (Address, u64)>,
+}
+
+/// A wrapper for (gas price, sender, nonce), stored in the `ready` heap of [TransactionPool].
+/// The [PartialEq], [PartialOrd] and [Ord] implementations only consider the gas price.
+#[derive(Debug)]
+struct ReadyItem {
+    gas_price: u128,
+    from_addr: Address,
+    nonce: u64,
+}
+
+impl PartialEq for ReadyItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.gas_price == other.gas_price
+    }
+}
+
+impl Eq for ReadyItem {}
+
+impl PartialOrd for ReadyItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ReadyItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.gas_price.cmp(&other.gas_price)
+    }
+}
+
+impl From<&VerifiedTransaction> for ReadyItem {
+    fn from(txn: &VerifiedTransaction) -> Self {
+        ReadyItem {
+            gas_price: txn.tx.gas_price(),
+            from_addr: txn.signer,
+            nonce: txn.tx.nonce(),
+        }
+    }
+}
+
+impl TransactionPool {
+    /// Pop a *ready* transaction out of the pool, maximising the gas price.
+    ///
+    /// Ready means that the transaction has a nonce equal to the sender's current nonce or it has a nonce that is
+    /// consecutive with a previously returned transaction, from the same sender.
+    pub fn best_transaction(&mut self) -> Option<VerifiedTransaction> {
+        loop {
+            let Some(ReadyItem {
+                from_addr, nonce, ..
+            }) = self.ready.pop()
+            else {
+                return None;
+            };
+            let Some(transaction) = self.transactions.remove(&(from_addr, nonce)) else {
+                // A transaction might have been ready, but then we learnt that the sender's nonce increased, making it
+                // invalid. In this case, we will have removed the transaction from `transactions` in `update_nonce`.
+                // We loop until we find a transaction that hasn't been made invalid.
+                continue;
+            };
+            self.hash_to_index.remove(&transaction.hash);
+
+            if let Some(next_txn) = self.transactions.get(&(from_addr, nonce + 1)) {
+                self.ready.push(next_txn.into());
+            }
+
+            return Some(transaction);
+        }
+    }
+
+    pub fn insert_transaction(&mut self, transaction: VerifiedTransaction, account_nonce: u64) {
+        if transaction.tx.nonce() < account_nonce {
+            // This transaction is permanently invalid, so there is nothing to do.
+            return;
+        }
+
+        if transaction.tx.nonce() == account_nonce {
+            self.ready.push((&transaction).into());
+        }
+
+        self.hash_to_index.insert(
+            transaction.hash,
+            (transaction.signer, transaction.tx.nonce()),
+        );
+        self.transactions
+            .insert((transaction.signer, transaction.tx.nonce()), transaction);
+    }
+
+    pub fn get_transaction(&self, hash: Hash) -> Option<&VerifiedTransaction> {
+        let Some((addr, nonce)) = self.hash_to_index.get(&hash) else {
+            return None;
+        };
+
+        self.transactions.get(&(*addr, *nonce))
+    }
+
+    pub fn update_nonce(&mut self, address: Address, nonce: u64) {
+        // Remove a transaction from this sender with the previous nonce, if it exists.
+        self.transactions.remove(&(address, nonce - 1));
+
+        if let Some(next_txn) = self.transactions.get(&(address, nonce)) {
+            self.ready.push(next_txn.into());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TransactionPool;
+    use crate::{
+        crypto::Hash,
+        state::Address,
+        transaction::{EthSignature, SignedTransaction, TxLegacy, VerifiedTransaction},
+    };
+
+    fn transaction(from_addr: Address, nonce: u64, gas_price: u128) -> VerifiedTransaction {
+        VerifiedTransaction {
+            tx: SignedTransaction::Legacy {
+                tx: TxLegacy {
+                    chain_id: Some(0),
+                    nonce,
+                    gas_price,
+                    gas_limit: 0,
+                    to_addr: None,
+                    amount: 0,
+                    payload: vec![],
+                },
+                sig: EthSignature {
+                    r: [0; 32],
+                    s: [0; 32],
+                    y_is_odd: false,
+                },
+            },
+            signer: from_addr,
+            hash: Hash::ZERO,
+        }
+    }
+
+    #[test]
+    fn nonces_returned_in_order() {
+        let mut pool = TransactionPool::default();
+        let from = "0x0000000000000000000000000000000000001234"
+            .parse()
+            .unwrap();
+
+        pool.insert_transaction(transaction(from, 1, 1), 0);
+        pool.insert_transaction(transaction(from, 2, 2), 0);
+        pool.insert_transaction(transaction(from, 0, 0), 0);
+
+        assert_eq!(pool.best_transaction().unwrap().tx.nonce(), 0);
+        assert_eq!(pool.best_transaction().unwrap().tx.nonce(), 1);
+        assert_eq!(pool.best_transaction().unwrap().tx.nonce(), 2);
+    }
+
+    #[test]
+    fn ordered_by_gas_price() {
+        let mut pool = TransactionPool::default();
+        let from1 = "0x0000000000000000000000000000000000000001"
+            .parse()
+            .unwrap();
+        let from2 = "0x0000000000000000000000000000000000000002"
+            .parse()
+            .unwrap();
+        let from3 = "0x0000000000000000000000000000000000000003"
+            .parse()
+            .unwrap();
+
+        pool.insert_transaction(transaction(from1, 0, 1), 0);
+        pool.insert_transaction(transaction(from2, 0, 2), 0);
+        pool.insert_transaction(transaction(from3, 0, 0), 0);
+
+        assert_eq!(pool.best_transaction().unwrap().tx.gas_price(), 2);
+        assert_eq!(pool.best_transaction().unwrap().tx.gas_price(), 1);
+        assert_eq!(pool.best_transaction().unwrap().tx.gas_price(), 0);
+    }
+
+    #[test]
+    fn update_nonce_discards_invalid_transaction() {
+        let mut pool = TransactionPool::default();
+        let from = "0x0000000000000000000000000000000000001234"
+            .parse()
+            .unwrap();
+
+        pool.insert_transaction(transaction(from, 0, 0), 0);
+        pool.insert_transaction(transaction(from, 1, 0), 0);
+
+        pool.update_nonce(from, 1);
+
+        assert_eq!(pool.best_transaction().unwrap().tx.nonce(), 1);
+    }
+}

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -114,6 +114,16 @@ impl SignedTransaction {
         }
     }
 
+    pub fn gas_price(&self) -> u128 {
+        match self {
+            SignedTransaction::Legacy { tx, .. } => tx.gas_price,
+            SignedTransaction::Eip2930 { tx, .. } => tx.gas_price,
+            // We ignore the priority fee and just use the maximum fee.
+            SignedTransaction::Eip1559 { tx, .. } => tx.max_fee_per_gas,
+            SignedTransaction::Zilliqa { tx, .. } => tx.gas_price,
+        }
+    }
+
     pub fn verify(self) -> Result<VerifiedTransaction> {
         let signer = match &self {
             SignedTransaction::Legacy { tx, sig } => {

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -883,7 +883,6 @@ async fn nonces_respected_ordered(mut network: Network) {
     assert!(wait.is_ok());
 }
 
-#[cfg(target_os = "macos")]
 #[zilliqa_macros::test]
 async fn priority_fees_tx(mut network: Network) {
     let wallet = network.genesis_wallet().await;


### PR DESCRIPTION
The mempool now lives in its own `TransactionPool` data structure. I have changed the details of the pool's implementation, but I think the high-level logic should remain the same:

* Return only valid transactions (which have a nonce equal to the sender's nonce)
* Of these, prioritise transactions with a higher gas price.

The comments in `pool.rs` should hopefully do a reasonable job at explaining the new logic and how it is implemented.