### PR TITLE
Fix potential panic when printing time

### DIFF
--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -326,10 +326,13 @@ impl fmt::Display for BlockHeader {
 // Helper function to format SystemTime as a string
 // https://stackoverflow.com/questions/45386585
 fn systemtime_strftime(timestamp: SystemTime) -> Result<String> {
-    let time_since_epoch = timestamp.elapsed()?;
+    let time_since_epoch = timestamp.elapsed()
+        .map(|d| d.as_nanos() as i128)
+        // Handle the case where `timestamp` was before unix epoch.
+        .unwrap_or_else(|e| -(e.duration().as_nanos() as i128));
     let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
     Ok(
-        OffsetDateTime::from_unix_timestamp_nanos(time_since_epoch.as_nanos() as i128)?
+        OffsetDateTime::from_unix_timestamp_nanos(time_since_epoch)?
             .format(&format)?,
     )
 }

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -326,15 +326,13 @@ impl fmt::Display for BlockHeader {
 // Helper function to format SystemTime as a string
 // https://stackoverflow.com/questions/45386585
 fn systemtime_strftime(timestamp: SystemTime) -> Result<String> {
-    let time_since_epoch = timestamp.elapsed()
+    let time_since_epoch = timestamp
+        .elapsed()
         .map(|d| d.as_nanos() as i128)
         // Handle the case where `timestamp` was before unix epoch.
         .unwrap_or_else(|e| -(e.duration().as_nanos() as i128));
     let format = format_description!("[year]-[month]-[day] [hour]:[minute]:[second]");
-    Ok(
-        OffsetDateTime::from_unix_timestamp_nanos(time_since_epoch)?
-            .format(&format)?,
-    )
+    Ok(OffsetDateTime::from_unix_timestamp_nanos(time_since_epoch)?.format(&format)?)
 }
 
 impl BlockHeader {

--- a/zilliqa/src/time.rs
+++ b/zilliqa/src/time.rs
@@ -35,7 +35,7 @@ mod time_impl {
         }
 
         pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
-            self.duration_since(SystemTime::now())
+            self.duration_since(Self::UNIX_EPOCH)
         }
 
         pub fn duration_since(&self, other: SystemTime) -> Result<Duration, SystemTimeError> {

--- a/zilliqa/src/time.rs
+++ b/zilliqa/src/time.rs
@@ -35,7 +35,7 @@ mod time_impl {
         }
 
         pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
-            self.duration_since(Self::UNIX_EPOCH)
+            SystemTime::now().duration_since(*self)
         }
 
         pub fn duration_since(&self, other: SystemTime) -> Result<Duration, SystemTimeError> {


### PR DESCRIPTION
Not sure that this is the clean way to solve the issue, but essentially, 
message.rs:
```
fn systemtime_strftime(timestamp: SystemTime) -> Result<String> {
    let time_since_epoch = timestamp.elapsed()?;
```
...
```
        pub fn elapsed(&self) -> Result<Duration, SystemTimeError> {
            self.duration_since(SystemTime::now())
        }
```

If the block timestamp is before now, then it will panic, because it can't be a duration since a time in the future. I think it should be time since epoch.

I am not even sure how this can happen in the tests - it suggests to me that something isn't right with the fake time?