### PR TITLE
Add gas charging on revert, and gas_used tracking to receipts. Add tests for reverted transactions.

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -521,7 +521,7 @@ pub(super) fn get_transaction_receipt_inner(
         to: transaction.to_addr(),
         cumulative_gas_used: 0,
         effective_gas_price: 0,
-        gas_used: 1,
+        gas_used: receipt.gas_used,
         contract_address: receipt.contract_address,
         logs,
         logs_bloom,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -643,6 +643,7 @@ impl Consensus {
                         success: result.success,
                         contract_address: result.contract_address,
                         logs: result.logs,
+                        gas_used: result.gas_used,
                     };
                     info!(?receipt, "applied transaction {:?}", receipt);
                     block_receipts.push(receipt);

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -482,6 +482,7 @@ pub struct TransactionReceipt {
     pub block_hash: crypto::Hash,
     pub tx_hash: crypto::Hash,
     pub success: bool,
+    pub gas_used: u64,
     pub contract_address: Option<Address>,
     pub logs: Vec<Log>,
 }

--- a/zilliqa/tests/it/contracts/RevertMe.sol
+++ b/zilliqa/tests/it/contracts/RevertMe.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract RevertMe {
+  int256 public value = 0;
+
+  function revertable(bool success) public {
+      value += 1; // incur some gas cost
+      if (!success) {
+          revert("Reverting.");
+      }
+  }
+}

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Debug, ops::DerefMut};
 
 use ethabi::ethereum_types::U64;
+use ethabi::Token;
 use ethers::{
     abi::FunctionExt,
     providers::{Middleware, Provider},
@@ -684,6 +685,116 @@ async fn eth_call(mut network: Network) {
     let value = wallet.call(&tx.into(), None).await.unwrap();
 
     assert_eq!(H256::from_slice(value.as_ref()), H256::from_low_u64_be(99));
+}
+
+#[zilliqa_macros::test]
+async fn revert_transaction(mut network: Network) {
+    let wallet = network.genesis_wallet().await;
+
+    let (hash, abi) = deploy_contract(
+        "tests/it/contracts/RevertMe.sol",
+        "RevertMe",
+        &wallet,
+        &mut network,
+    )
+    .await;
+
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let contract_address = receipt.contract_address.unwrap();
+    let setter = abi.function("revertable").unwrap();
+    let getter = abi.function("value").unwrap();
+
+    // First ensure contract works
+    let success_call = TransactionRequest::new()
+        .to(contract_address)
+        .data(setter.encode_input(&[Token::Bool(true)]).unwrap());
+    let (_, receipt) = send_transaction(&mut network, success_call.into()).await;
+    assert_eq!(receipt.status.unwrap().as_u32(), 1);
+
+    // Ensure value was incremented
+    let check_call = TransactionRequest::new()
+        .to(contract_address)
+        .data(getter.selector());
+    let value = wallet.call(&check_call.clone().into(), None).await.unwrap();
+    let value = getter.decode_output(&value).unwrap()[0]
+        .clone()
+        .into_int()
+        .unwrap();
+    assert_eq!(value, 1.into());
+
+    // Next ensure revert fails correctly
+    let revert_call = TransactionRequest::new()
+        .to(contract_address)
+        .data(setter.encode_input(&[Token::Bool(false)]).unwrap())
+        .gas(10_000_000_000u64); // Pass a gas limit, otherwise estimate_gas is called and fails
+                                 // due to the revert
+    let (_, receipt) = send_transaction(&mut network, revert_call.into()).await;
+    assert_eq!(receipt.status.unwrap().as_u32(), 0);
+
+    // Ensure value was NOT incremented a second time
+    let value = wallet.call(&check_call.into(), None).await.unwrap();
+    let value = getter.decode_output(&value).unwrap()[0]
+        .clone()
+        .into_int()
+        .unwrap();
+    assert_eq!(value, 1.into());
+}
+
+#[zilliqa_macros::test]
+async fn gas_charged_on_revert(mut network: Network) {
+    const SMALL_GAS_LIMIT: u64 = 10;
+    const LARGE_GAS_LIMIT: u64 = 10_000_000_000;
+
+    let wallet = network.genesis_wallet().await;
+
+    let (hash, abi) = deploy_contract(
+        "tests/it/contracts/RevertMe.sol",
+        "RevertMe",
+        &wallet,
+        &mut network,
+    )
+    .await;
+
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let contract_address = receipt.contract_address.unwrap();
+    let setter = abi.function("revertable").unwrap();
+
+    let gas_price = wallet.get_gas_price().await.unwrap();
+
+    // Revert on contract failure. Ensure gas is consumed according to execution.
+    let balance_before_call = wallet.get_balance(wallet.address(), None).await.unwrap();
+    let revert_call = TransactionRequest::new()
+        .to(contract_address)
+        .data(setter.encode_input(&[Token::Bool(false)]).unwrap())
+        .gas(LARGE_GAS_LIMIT);
+    let (_, receipt) = send_transaction(&mut network, revert_call.into()).await;
+
+    assert_eq!(receipt.status.unwrap().as_u32(), 0);
+    assert!(receipt.gas_used.is_some());
+    let gas_used = receipt.gas_used.unwrap();
+    assert!(gas_used > 0.into());
+    assert!(gas_used < LARGE_GAS_LIMIT.into());
+    let balance_after_call = wallet.get_balance(wallet.address(), None).await.unwrap();
+    assert_eq!(
+        balance_after_call,
+        balance_before_call - gas_price * gas_used
+    );
+
+    // Revert on out-of-gas. Ensure entire gas limit is consumed.
+    let balance_before_call = wallet.get_balance(wallet.address(), None).await.unwrap();
+
+    let fail_out_of_gas_call = TransactionRequest::new()
+        .to(contract_address)
+        .data(setter.encode_input(&[Token::Bool(true)]).unwrap())
+        .gas(SMALL_GAS_LIMIT);
+    let (_, receipt) = send_transaction(&mut network, fail_out_of_gas_call.into()).await;
+
+    assert_eq!(receipt.status.unwrap().as_u32(), 0);
+    let balance_after_call = wallet.get_balance(wallet.address(), None).await.unwrap();
+    assert_eq!(
+        balance_after_call,
+        balance_before_call - gas_price * SMALL_GAS_LIMIT
+    );
 }
 
 #[zilliqa_macros::test]


### PR DESCRIPTION
One thing I'm not sure about is whether event logs should be kept on revert - I haven't checked what Eth clients do, and I'm not sure what ZQ1 does either in these cases. So I haven't touched them here, keeping the previous behaviour of keeping them available.