### PR TITLE
Improve infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5976,6 +5976,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5985,12 +5995,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/infra/tf/apps.tf
+++ b/infra/tf/apps.tf
@@ -82,10 +82,10 @@ module "otterscan" {
   name  = "otterscan"
   image = "zilliqa/otterscan:develop"
   env = [
-    ["ERIGON_URL", "https://api.zq2-devnet.zilstg.dev"],
+    ["ERIGON_URL", "https://api.${var.subdomain}"],
   ]
-  static_ip_name = "explorer-zq2-devnet-zilstg-dev"
-  domain         = "explorer.zq2-devnet.zilstg.dev"
+  static_ip_name = "explorer-${replace(var.subdomain, ".", "-")}"
+  domain         = "explorer.${var.subdomain}"
 }
 
 module "faucet" {
@@ -94,14 +94,14 @@ module "faucet" {
   name  = "faucet"
   image = "asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa/eth-spout:89eb40d3"
   env = [
-    ["RPC_URL", "https://api.zq2-devnet.zilstg.dev"],
+    ["RPC_URL", "https://api.${var.subdomain}"],
     ["NATIVE_TOKEN_SYMBOL", "ZIL"],
     ["PRIVATE_KEY", random_id.genesis_key.hex],
     ["ETH_AMOUNT", "100"],
-    ["EXPLORER_URL", "https://explorer.zq2-devnet.zilstg.dev"],
+    ["EXPLORER_URL", "https://explorer.${var.subdomain}"],
     ["MINIMUM_SECONDS_BETWEEN_REQUESTS", "60"],
     ["BECH32_HRP", "zil"],
   ]
-  static_ip_name = "faucet-zq2-devnet-zilstg-dev"
-  domain         = "faucet.zq2-devnet.zilstg.dev"
+  static_ip_name = "faucet-${replace(var.subdomain, ".", "-")}"
+  domain         = "faucet.${var.subdomain}"
 }

--- a/infra/tf/modules/node/main.tf
+++ b/infra/tf/modules/node/main.tf
@@ -23,6 +23,11 @@ variable "binary_url" {
     nullable = false
 }
 
+variable "binary_md5" {
+    type = string
+    nullable = false
+}
+
 variable "config" {
     type = string
     nullable = false
@@ -44,6 +49,7 @@ resource "random_id" "name_suffix" {
     network_name = var.network_name
     subnetwork_name = var.subnetwork_name
     binary_url = var.binary_url
+    binary_md5 = var.binary_md5
     config = var.config
     secret_key = var.secret_key
   }
@@ -85,27 +91,77 @@ resource "google_compute_instance" "this" {
   metadata_startup_script = <<EOT
 #!/bin/bash
 
+set -Eeuxo pipefail
+
+# Install the ops-agent
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --also-install
+
+# Configure the ops-agent
+cat << EOF > /etc/google-cloud-ops-agent/config.yaml
+logging:
+  receivers:
+    zilliqa:
+      type: files
+      include_paths: [ "/zilliqa.log" ]
+  processors:
+    json:
+      type: parse_json
+      time_key: timestamp
+      time_format: "%Y-%m-%dT%H:%M:%S.%LZ"
+    move_fields:
+      type: modify_fields
+      fields:
+        jsonPayload."logging.googleapis.com/severity":
+          move_from: jsonPayload.level
+        jsonPayload."logging.googleapis.com/sourceLocation".function:
+          move_from: jsonPayload.target
+  service:
+    pipelines:
+      zilliqa:
+        receivers: [ zilliqa ]
+        processors: [ json, move_fields ]
+EOF
+sudo systemctl restart google-cloud-ops-agent
+
+# Download the Zilliqa binary
 gsutil cp ${var.binary_url} /zilliqa
+MD5_SUM=$(echo "${var.binary_md5}" | base64 --decode | hexdump -v -e '/1 "%02x" ')
+echo "$MD5_SUM /zilliqa" | md5sum --check -
 chmod +x /zilliqa
 
+# Set up our configuration
 cat << EOF > /config.toml
 ${var.config}
 EOF
 
+# Set up logrotate to limit the size of the log file
+cat << EOF > /etc/logrotate.d/zilliqa.conf
+/zilliqa.log
+{
+    rotate 0
+    maxsize 256M
+    missingok
+}
+EOF
+
+# Set up a systemd service for Zilliqa
 cat << EOF > /etc/systemd/system/zilliqa.service
 [Unit]
-Description=Zilliqa 2 Node
+Description=Zilliqa Node
 
 [Service]
 Type=simple
-ExecStart=/zilliqa ${var.secret_key}
+ExecStart=/zilliqa ${var.secret_key} --log-json
 Environment="RUST_LOG=zilliqa=debug"
 Environment="RUST_BACKTRACE=1"
+StandardOutput=append:/zilliqa.log
 
 [Install]
 WantedBy=multi-user.target
 EOF
 
+# Start the systemd service
 systemctl enable zilliqa.service
 systemctl start zilliqa.service
 EOT

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -71,7 +71,7 @@ toml = "0.8.6"
 tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 zilliqa-macros = { path = "../zilliqa-macros" }
 
 [dev-dependencies]

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -14,13 +14,20 @@ struct Args {
     secret_key: SecretKey,
     #[clap(long, short, default_value = "config.toml")]
     config_file: PathBuf,
+    #[clap(long, default_value = "false")]
+    log_json: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-
     let args = Args::parse();
+
+    let builder = tracing_subscriber::fmt();
+    if args.log_json {
+        builder.json().init();
+    } else {
+        builder.init();
+    }
 
     let config = if args.config_file.exists() {
         fs::read_to_string(&args.config_file)?


### PR DESCRIPTION
* Parameterise network's subdomain so we can deploy networks outside of `zq2-devnet.zilstg.dev`.
* Prefix binary bucket name with project ID.
* Validate `md5sum` of zilliqa binary after it is downloaded in the startup script.
* Install ops-agent in startup script, rather than letting the GCP agent policy do it for us. This simplifies things by ensuring our node can't start producing logs until we're ready to consume them. It also makes configuring the ops-agent simpler.
* Add configuration to zilliqa to output JSON logs. Enable this configuration for deployed networks.
* Configure zilliqa to output logs to `/zilliqa.log` and ops-agent to collect them from there.
* Configure ops-agent to parse the timestamp of JSON logs and move the `level` and `target` fields to a place where GCP understands their semantics.
* Configure `logrotate` to delete and rotate `/zilliqa.log` when it reaches `256MB`.