### PR TITLE
allow seed in spans

### DIFF
--- a/zilliqa-macros/src/test.rs
+++ b/zilliqa-macros/src/test.rs
@@ -55,22 +55,33 @@ pub(crate) fn test_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
                     let subscriber = tracing_subscriber::fmt()
                         .with_ansi(false)
                         .with_env_filter(tracing_subscriber::EnvFilter::from_default_env());
+
                     let _guard = tracing_subscriber::util::SubscriberInitExt::set_default(subscriber);
 
-                    let mut rng = <rand_chacha::ChaCha8Rng as rand_core::SeedableRng>::seed_from_u64(seed);
-                    let network = crate::Network::new(std::sync::Arc::new(std::sync::Mutex::new(rng)), 4, seed);
+                    // Optionally print the seed in each tests logging so it can be filtered out later.
+                    use tracing::Instrument;
+                    let span = if std::env::var_os("ZQ_TEST_SEED_SPANS").is_some() {
+                        tracing::span!(tracing::Level::INFO, "", seed)
+                    } else {
+                        tracing::span!(tracing::Level::INFO, "")
+                    };
 
-                    // Call the original test function, wrapped in `catch_unwind` so we can detect the panic.
-                    let result = futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
-                        zilliqa::time::with_fake_time(#inner_name(network))
-                    )).await;
+                    async move {
+                        let mut rng = <rand_chacha::ChaCha8Rng as rand_core::SeedableRng>::seed_from_u64(seed);
+                        let network = crate::Network::new(std::sync::Arc::new(std::sync::Mutex::new(rng)), 4, seed);
 
-                    match result {
-                        Ok(()) => {},
-                        Err(e) => {
-                            std::panic::resume_unwind(e);
+                        // Call the original test function, wrapped in `catch_unwind` so we can detect the panic.
+                        let result = futures::FutureExt::catch_unwind(std::panic::AssertUnwindSafe(
+                            zilliqa::time::with_fake_time(#inner_name(network))
+                        )).await;
+
+                        match result {
+                            Ok(()) => {},
+                            Err(e) => {
+                                std::panic::resume_unwind(e);
+                            }
                         }
-                    }
+                    }.instrument(span).await
                 });
                 id_to_seed.insert(handle.id(), seed);
             }
@@ -92,6 +103,7 @@ pub(crate) fn test_macro(_args: TokenStream, item: TokenStream) -> TokenStream {
                     }
                 }
 
+                failure_examples.sort();
                 let total = success + failure;
                 println!("Total seeds tested: {total}");
                 println!("\x1b[0;32mSuccess: {success}\x1b[0m");


### PR DESCRIPTION
example `ZQ_TEST_SEED_SPANS=1 RUST_LOG=zilliqa=trace,it=trace cargo test  --release --test it -- consensus::launch_shard`

Produces:

```
2023-12-05T20:01:53.776561Z TRACE {seed=16741818491380055426}:handle_message{index=12}: zilliqa::consensus: head block request: highest block number: 4
2023-12-05T20:01:53.776567Z TRACE {seed=16741818491380055426}:handle_message{index=12}: zilliqa::consensus: handling block proposal de38f21300ab3f2d97787efabdc41468c08840b035d2a8362df0d59c6a87fb36 block_view=5 block_number=5
2023-12-05T20:01:53.777132Z TRACE {seed=16741818491380055426}:handle_message{index=12}: zilliqa::consensus: (check block) I think the block proposer is: 12D3KooWKnS5uGQ1X3KAp95PA65CtEvkNdTWVBtrxrwLhhJUtFYr, we are 12D3KooWDp2EZLhPeH58WebRCFkd8mN5EGFsH1SU2jrtv3zyMG77
```

Useful to turn on when you have a test which only fails when multiple are running at the same time (race conditions).