### PR TITLE
Flush db to disk before copying it over in test

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -134,7 +134,7 @@ impl Db {
     }
 
     pub fn flush(&self) {
-        self.root.flush().unwrap();
+        while self.root.flush().unwrap() > 0 {}
     }
 
     pub fn state_trie(&self) -> Result<TrieStorage> {

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -133,6 +133,10 @@ impl Db {
         })
     }
 
+    pub fn flush(&self) {
+        self.root.flush().unwrap();
+    }
+
     pub fn state_trie(&self) -> Result<TrieStorage> {
         Ok(TrieStorage::new(self.root.open_tree(STATE_TRIE_TREE)?))
     }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -120,6 +120,10 @@ impl Node {
         Ok(node)
     }
 
+    pub fn flush(&self) {
+        self.db.flush();
+    }
+
     // TODO: Multithreading - `&mut self` -> `&self`
     pub fn handle_network_message(&mut self, from: PeerId, message: ExternalMessage) -> Result<()> {
         let to = self.peer_id;

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -86,11 +86,11 @@ impl MessageSender {
 #[derive(Debug)]
 pub struct Node {
     pub config: NodeConfig,
+    pub db: Arc<Db>,
     peer_id: PeerId,
     message_sender: MessageSender,
     reset_timeout: UnboundedSender<()>,
     consensus: Consensus,
-    db: Arc<Db>,
 }
 
 impl Node {
@@ -118,10 +118,6 @@ impl Node {
             consensus: Consensus::new(secret_key, config, message_sender, db)?,
         };
         Ok(node)
-    }
-
-    pub fn flush(&self) {
-        self.db.flush();
     }
 
     // TODO: Multithreading - `&mut self` -> `&self`

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -322,9 +322,9 @@ impl Network {
         );
         let genesis_committee = vec![validator];
 
-        //for nodes in &mut self.nodes {
-        //    nodes.inner.lock().unwrap().db.flush();
-        //}
+        for nodes in &mut self.nodes {
+            nodes.inner.lock().unwrap().db.flush();
+        }
 
         let (nodes, external_receivers, local_receivers): (Vec<_>, Vec<_>, Vec<_>) = keys
             .into_iter()

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -5,6 +5,7 @@ mod web3;
 mod zil;
 use std::{env, ops::DerefMut};
 
+//use crate::time::SystemTime;
 use ethers::solc::SHANGHAI_SOLC;
 use itertools::Itertools;
 use serde::Deserialize;
@@ -321,6 +322,10 @@ impl Network {
             keys[0].to_libp2p_keypair().public().to_peer_id(),
         );
         let genesis_committee = vec![validator];
+
+        for nodes in &mut self.nodes {
+            nodes.inner.lock().unwrap().flush();
+        }
 
         let (nodes, external_receivers, local_receivers): (Vec<_>, Vec<_>, Vec<_>) = keys
             .into_iter()

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -322,9 +322,9 @@ impl Network {
         );
         let genesis_committee = vec![validator];
 
-        for nodes in &mut self.nodes {
-            nodes.inner.lock().unwrap().db.flush();
-        }
+        //for nodes in &mut self.nodes {
+        //    nodes.inner.lock().unwrap().db.flush();
+        //}
 
         let (nodes, external_receivers, local_receivers): (Vec<_>, Vec<_>, Vec<_>) = keys
             .into_iter()

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -5,7 +5,6 @@ mod web3;
 mod zil;
 use std::{env, ops::DerefMut};
 
-//use crate::time::SystemTime;
 use ethers::solc::SHANGHAI_SOLC;
 use itertools::Itertools;
 use serde::Deserialize;

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -324,7 +324,7 @@ impl Network {
         let genesis_committee = vec![validator];
 
         for nodes in &mut self.nodes {
-            nodes.inner.lock().unwrap().flush();
+            nodes.inner.lock().unwrap().db.flush();
         }
 
         let (nodes, external_receivers, local_receivers): (Vec<_>, Vec<_>, Vec<_>) = keys


### PR DESCRIPTION
The test `consensus::network_can_die_restart` had a race condition where when it kills the nodes, their DBs are in a state of writing. This caused it to sometimes randomly fail. This forcibly flushes them so that the tests are deterministic and pass once again.