### PR TITLE
make subscriber respect RUST_LOG

### DIFF
--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use opentelemetry_otlp::{ExportConfig, WithExportConfig};
 use opentelemetry_sdk::runtime;
 use tokio::time::Duration;
+use tracing_subscriber::EnvFilter;
 use zilliqa::{cfg::Config, crypto::SecretKey, p2p_node::P2pNode};
 
 #[derive(Parser, Debug)]

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -22,11 +22,11 @@ struct Args {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
+    let builder = tracing_subscriber::fmt().with_env_filter(EnvFilter::from_default_env());
     if args.log_json {
-        let builder = tracing_subscriber::fmt();
         builder.json().init();
     } else {
-        tracing_subscriber::fmt::init();
+        builder.init();
     }
 
     let config = if args.config_file.exists() {

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -22,11 +22,11 @@ struct Args {
 async fn main() -> Result<()> {
     let args = Args::parse();
 
-    let builder = tracing_subscriber::fmt();
     if args.log_json {
+        let builder = tracing_subscriber::fmt();
         builder.json().init();
     } else {
-        builder.init();
+        tracing_subscriber::fmt::init();
     }
 
     let config = if args.config_file.exists() {

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -1,7 +1,6 @@
 use std::{fmt::Debug, ops::DerefMut};
 
-use ethabi::ethereum_types::U64;
-use ethabi::Token;
+use ethabi::{ethereum_types::U64, Token};
 use ethers::{
     abi::FunctionExt,
     providers::{Middleware, Provider},


### PR DESCRIPTION
`tracing_subscriber::fmt::init();` and `tracing_subscriber::fmt().init();` do not behave the same - the first will respect RUST_LOG and the second will not