### PR TITLE
Buffer votes for blocks we don't know about

### DIFF
--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -229,6 +229,15 @@ pub enum ExternalMessage {
     JoinCommittee(NodePublicKey),
 }
 
+impl ExternalMessage {
+    pub fn into_proposal(self) -> Option<Proposal> {
+        match self {
+            ExternalMessage::Proposal(p) => Some(p),
+            _ => None,
+        }
+    }
+}
+
 /// A message intended only for local communication between shard nodes and/or the parent p2p node,
 /// but not sent over the network.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -69,6 +69,10 @@ impl MessageSender {
     }
 }
 
+/// Messages sent by [Consensus].
+/// Tuple of (destination, message).
+pub type NetworkMessage = (Option<PeerId>, ExternalMessage);
+
 /// The central data structure for a blockchain node.
 ///
 /// # Transaction Lifecycle
@@ -130,10 +134,13 @@ impl Node {
             ExternalMessage::Proposal(m) => {
                 let m_view = m.header.view;
 
-                if let Some((leader, vote)) = self.consensus.proposal(m, false)? {
+                if let Some((to, message)) = self.consensus.proposal(m, false)? {
                     self.reset_timeout.send(())?;
-                    self.message_sender
-                        .send_external_message(leader, ExternalMessage::Vote(vote))?;
+                    if let Some(to) = to {
+                        self.message_sender.send_external_message(to, message)?;
+                    } else {
+                        self.message_sender.broadcast_external_message(message)?;
+                    }
                 } else {
                     info!("We had nothing to respond to proposal, lets try to join committee for view {m_view:}");
                     self.message_sender.send_external_message(

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -572,7 +572,12 @@ impl Node {
         let length_recvd = response.proposals.len();
 
         for block in response.proposals {
-            was_new = self.consensus.receive_block(block)?;
+            let (new, proposal) = self.consensus.receive_block(block)?;
+            was_new = new;
+            if let Some(proposal) = proposal {
+                self.message_sender
+                    .broadcast_external_message(ExternalMessage::Proposal(proposal))?;
+            }
         }
 
         if was_new && length_recvd > 1 {

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -8,10 +8,12 @@ mod consensus;
 mod eth;
 mod persistence;
 mod staking;
+mod unreliable;
 mod web3;
 mod zil;
+
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     env,
     fmt::Debug,
     fs,
@@ -156,6 +158,9 @@ struct Network {
     // We keep `nodes` and `receivers` separate so we can independently borrow each half of this struct, while keeping
     // the borrow checker happy.
     nodes: Vec<TestNode>,
+    // We keep track of a list of disconnected nodes. These nodes will not recieve any messages until they are removed
+    // from this list.
+    disconnected: HashSet<usize>,
     /// A stream of messages from each node. The stream items are a tuple of (source, destination, message).
     /// If the destination is `None`, the message is a broadcast.
     receivers: Vec<BoxStream<'static, StreamMessage>>,
@@ -273,6 +278,7 @@ impl Network {
             genesis_committee,
             genesis_deposits,
             nodes,
+            disconnected: HashSet::new(),
             send_to_parent,
             shard_id,
             receivers,
@@ -747,14 +753,23 @@ impl Network {
             }
             AnyMessage::External(external_message) => {
                 let nodes: Vec<(usize, &TestNode)> = if let Some(destination) = destination {
-                    vec![self
+                    let (index, node) = self
                         .nodes
                         .iter()
                         .enumerate()
                         .find(|(_, n)| n.peer_id == destination)
-                        .unwrap()]
+                        .unwrap();
+                    if self.disconnected.contains(&index) {
+                        vec![]
+                    } else {
+                        vec![(index, node)]
+                    }
                 } else {
-                    self.nodes.iter().enumerate().collect()
+                    self.nodes
+                        .iter()
+                        .enumerate()
+                        .filter(|(index, _)| !self.disconnected.contains(index))
+                        .collect()
                 };
                 for (index, node) in nodes.iter() {
                     let span = tracing::span!(tracing::Level::INFO, "handle_message", index);
@@ -840,8 +855,35 @@ impl Network {
         .unwrap();
     }
 
+    pub fn disconnect_node(&mut self, index: usize) {
+        self.disconnected.insert(index);
+    }
+
+    pub fn connect_node(&mut self, index: usize) {
+        self.disconnected.remove(&index);
+    }
+
     pub fn random_index(&mut self) -> usize {
         self.rng.lock().unwrap().gen_range(0..self.nodes.len())
+    }
+
+    pub async fn wallet_of_node(
+        &mut self,
+        index: usize,
+    ) -> SignerMiddleware<Provider<LocalRpcClient>, LocalWallet> {
+        let key = SigningKey::random(self.rng.lock().unwrap().deref_mut());
+        let wallet: LocalWallet = key.into();
+        let node = &self.nodes[index];
+        let client = LocalRpcClient {
+            id: Arc::new(AtomicU64::new(0)),
+            rpc_module: node.rpc_module.clone(),
+            subscriptions: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let provider = Provider::new(client);
+
+        SignerMiddleware::new_with_provider_chain(provider, wallet)
+            .await
+            .unwrap()
     }
 
     /// Returns (index, TestNode)

--- a/zilliqa/tests/it/unreliable.rs
+++ b/zilliqa/tests/it/unreliable.rs
@@ -1,0 +1,35 @@
+use crate::Network;
+
+#[zilliqa_macros::test]
+async fn blocks_are_produced_while_a_node_restarts(mut network: Network) {
+    let restarted_node = network.random_index();
+    let wallet = network.wallet_of_node(restarted_node).await;
+
+    // Select a wallet connected to a different node, so we can query the network when the first node is disconnected.
+    let other_wallet = loop {
+        let i = network.random_index();
+        if i != restarted_node {
+            break i;
+        }
+    };
+    let other_wallet = network.wallet_of_node(other_wallet).await;
+
+    // Produce a few blocks to start with. Enough for everyone to join the consensus committee.
+    // TODO(#721): Once the committee is visible in the API, we can avoid waiting as long.
+    network.run_until_block(&wallet, 8.into(), 400).await;
+
+    // Disconnect the node we are 'restarting'.
+    network.disconnect_node(restarted_node);
+
+    // Produce 2 more blocks.
+    network.run_until_block(&other_wallet, 10.into(), 400).await;
+
+    // Reconnect the 'restarted' node.
+    network.connect_node(restarted_node);
+
+    // TODO(#721): We should assert here that a new view occurred if-and-only-if the 'restarted' node was the proposer
+    // of blocks 3 or 4. This would tell us that we aren't producing new views unnecessarily.
+
+    // Ensure more blocks are produced.
+    network.run_until_block(&wallet, 12.into(), 400).await;
+}


### PR DESCRIPTION
Votes can arrive for blocks we aren't yet aware of in (at least) two circumstances:
* If we disconnect and reconnect, we will download the blocks we missed, but nodes might send us their votes for the next block before we've received the missed blocks.
* Due to network latency, a vote for a block proposal could arrive before the block proposal itself.

Before this commit, the node ignores these votes and the network eventually recovers via a new view. However, this slows things down so we should recover faster if possible. Instead, we store votes for unknown blocks in memory and replay them if the block later becomes known to us.

The implementation is fairly straight forward but there are a few caveats and TODOs:
* The return type of `Consensus::proposal` is now more complicated, as it doesn't just return a `Message::Vote` any more. If the proposal results in some buffered votes being replayed and those votes form a supermajority, then the node can immediately propose the next block.
* There's nothing which limits the memory usage of buffered votes. A malicious node is perfectly able to send us loads of votes with non-existant block hashes, which we will store forever. I've raised #719 to resolve this.
* When applying buffered votes as a result of a proposal, they take priority over our own vote. This means we lose out on the cosigner reward. #720
* The unreliability test could be improved to be more efficient and to assert a stricter condition on the network - #721.