### PR TITLE
Ignore errors when bootstrapping Kademlia

### DIFF
--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -312,7 +312,7 @@ impl P2pNode {
                         // We failed to send a message to a peer. The likely reason is that we don't know their
                         // address. Someone else in the network must know it, because we learnt their peer ID.
                         // Therefore, we can attempt to learn their address by triggering a Kademlia bootstrap.
-                        self.swarm.behaviour_mut().kademlia.bootstrap()?;
+                        let _ = self.swarm.behaviour_mut().kademlia.bootstrap();
                     }
                     _ => {},
                 },


### PR DESCRIPTION
We already do this in most places, but I missed one. The only error that can actually occur at this call is "No peers", which is fine.