### PR TITLE
Remove touched address index

### DIFF
--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -10,7 +10,7 @@ use super::{
     eth::{get_transaction_inner, get_transaction_receipt_inner},
     types::ots,
 };
-use crate::{crypto::Hash, message::BlockNumber, node::Node, state::Address, time::SystemTime};
+use crate::{crypto::Hash, message::BlockNumber, node::Node};
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     super::declare_module!(
@@ -21,8 +21,6 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
             ("ots_getBlockDetailsByHash", get_block_details_by_hash),
             ("ots_getBlockTransactions", get_block_transactions),
             ("ots_hasCode", has_code),
-            ("ots_searchTransactionsAfter", search_transactions_after),
-            ("ots_searchTransactionsBefore", search_transactions_before),
             ("ots_getInternalOperations", get_internal_operations),
         ],
     )
@@ -116,125 +114,6 @@ fn has_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
         .is_empty();
 
     Ok(!empty)
-}
-
-fn search_transactions_inner(
-    node: &Arc<Mutex<Node>>,
-    address: Address,
-    block_number: u64,
-    page_size: usize,
-    reverse: bool,
-) -> Result<ots::Transactions> {
-    let mut touched = node.lock().unwrap().get_touched_transactions(address)?;
-
-    // If searching in reverse, we should start with the most recent transaction and work backwards.
-    if reverse {
-        touched.reverse();
-    }
-
-    let mut transactions = Vec::with_capacity(page_size);
-    let mut receipts = Vec::with_capacity(page_size);
-
-    // Keep track of the current block number. Once we reach `page_size` transactions, we still need to continue adding
-    // transactions from the current block.
-    let mut current_block = u64::MAX;
-    // This will be set to false if we break out of the loop, indicating to the caller there are further pages.
-    let mut finished = true;
-
-    for hash in touched {
-        let txn = get_transaction_inner(hash, &node.lock().unwrap())
-            .unwrap()
-            .unwrap();
-
-        let txn_block_number = match txn.block_number {
-            Some(txn_block_number) => txn_block_number,
-            None => continue,
-        };
-
-        let cmp = if !reverse {
-            PartialOrd::le
-        } else {
-            PartialOrd::ge
-        };
-        if cmp(&txn_block_number, &block_number) {
-            continue;
-        }
-
-        // Don't break until we have at least `page_size` transactions AND we've added everything from the last searched block.
-        if transactions.len() >= page_size && txn_block_number != current_block {
-            finished = false;
-            break;
-        }
-
-        let timestamp = node
-            .lock()
-            .unwrap()
-            .get_block_by_hash(Hash(txn.block_hash.unwrap_or_default().0))?
-            .unwrap()
-            .timestamp();
-
-        transactions.push(txn);
-
-        let node = node.lock().unwrap();
-        let receipt = ots::TransactionReceiptWithTimestamp {
-            receipt: get_transaction_receipt_inner(hash, &node).unwrap().unwrap(),
-            timestamp: timestamp
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .unwrap()
-                .as_secs(),
-        };
-        receipts.push(receipt);
-
-        current_block = txn_block_number;
-    }
-
-    // The results should always be returned in descending order (latest to earliest). If we were searching forwards
-    // in time, we should reverse the results to ensure they are in descending order.
-    if !reverse {
-        transactions.reverse();
-        receipts.reverse();
-    }
-
-    // `first_page` should be set if this was the latest page in time and `last_page` should be set if this was the
-    // earliest page in time.
-    let (first_page, last_page) = if reverse {
-        (block_number == u64::MAX, finished)
-    } else {
-        (finished, block_number == 0)
-    };
-
-    Ok(ots::Transactions {
-        transactions,
-        receipts,
-        first_page,
-        last_page,
-    })
-}
-
-fn search_transactions_after(params: Params, node: &Arc<Mutex<Node>>) -> Result<ots::Transactions> {
-    let mut params = params.sequence();
-    let address: H160 = params.next()?;
-    let block_number: u64 = params.next()?;
-    let page_size: usize = params.next()?;
-
-    search_transactions_inner(node, address, block_number, page_size, false)
-}
-
-fn search_transactions_before(
-    params: Params,
-    node: &Arc<Mutex<Node>>,
-) -> Result<ots::Transactions> {
-    let mut params = params.sequence();
-    let address: H160 = params.next()?;
-    let mut block_number: u64 = params.next()?;
-    let page_size: usize = params.next()?;
-
-    // A `block_number` of `0` tells us to search from the most recent block.
-    if block_number == 0 {
-        block_number = u64::MAX;
-    }
-
-    search_transactions_inner(node, address, block_number, page_size, true)
 }
 
 fn get_internal_operations(

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -461,10 +461,6 @@ impl Node {
         self.consensus.get_transaction_by_hash(hash)
     }
 
-    pub fn get_touched_transactions(&self, address: Address) -> Result<Vec<Hash>> {
-        self.consensus.get_touched_transactions(address)
-    }
-
     fn handle_block_request(&mut self, source: PeerId, request: BlockRequest) -> Result<()> {
         let block = match request.0 {
             crate::message::BlockRef::Hash(hash) => self.consensus.get_block(&hash),


### PR DESCRIPTION
It currently doesn't work. We will need to re-add something similar to support Otterscan (tracked in our roadmap). I figured it was counterproductive to leave non-working code in the repository and I'd rather recover anything useful when we implement this properly later.