### PR TITLE
Run CI with nightly Rust compiler

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,13 @@ jobs:
     steps:
     - name: Install Rust
       run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+    - name: Select nightly version
+      id: select-version
+      # We select the nightly version from the final day of the previous month. This ensures we use a reasonably
+      # up-to-date compiler, but also that we don't invalidate our cache every night when a new version is released.
+      run: echo "version=$(date -d "$(date +'%Y%m01') -1 day" +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+    - name: Switch to nightly
+      run: rustup override set nightly-${{ steps.select-version.outputs.version }}
     - name: Install dependencies
       run: sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && sudo apt install -y solc build-essential
     - uses: actions/checkout@v4
@@ -35,10 +42,10 @@ jobs:
     - name: Test
       run: cargo test --release --all-targets --all-features
       timeout-minutes: 30
-    - name: Verify working directory is clean
-      run: git diff --exit-code
     - name: rustfmt
       run: cargo fmt --all --check
+    - name: Verify working directory is clean
+      run: git diff --exit-code
   e2e_test:
     runs-on: ubuntu-latest
     steps:

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -1,7 +1,6 @@
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Result};
-
 use jsonrpsee::{types::Params, RpcModule};
 use primitive_types::{H160, H256};
 

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -1,11 +1,10 @@
 //! Manages execution of transactions on state.
 
-use crate::state::contract_addr;
-use ethabi::Token;
 use std::num::NonZeroU128;
 
 use anyhow::{anyhow, Result};
 use eth_trie::Trie;
+use ethabi::Token;
 use primitive_types::{H160, H256, U256};
 use revm::{
     primitives::{
@@ -17,13 +16,13 @@ use revm::{
 use tracing::*;
 
 use crate::{
-    contracts, crypto::Hash, crypto::NodePublicKey, eth_helpers::extract_revert_msg,
-    state::Account, time::SystemTime, transaction::Log,
-};
-use crate::{
+    contracts,
+    crypto::{Hash, NodePublicKey},
+    eth_helpers::extract_revert_msg,
     message::BlockHeader,
-    state::{Address, State},
-    transaction::VerifiedTransaction,
+    state::{contract_addr, Account, Address, State},
+    time::SystemTime,
+    transaction::{Log, VerifiedTransaction},
 };
 
 /// Data returned after applying a [Transaction] to [State].

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
-
 use libp2p::PeerId;
 use primitive_types::H256;
 use tokio::sync::mpsc::UnboundedSender;

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -1,13 +1,15 @@
+use std::{
+    cmp::Ordering,
+    collections::{BTreeMap, BinaryHeap},
+};
+
+use tracing::*;
+
 use crate::{
     crypto::Hash,
     state::Address,
     transaction::{SignedTransaction, VerifiedTransaction},
 };
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, BinaryHeap},
-};
-use tracing::*;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum TxIndex {
@@ -112,9 +114,7 @@ impl TransactionPool {
     /// consecutive with a previously returned transaction, from the same sender.
     pub fn best_transaction(&mut self) -> Option<VerifiedTransaction> {
         loop {
-            let Some(ReadyItem { tx_index, .. }) = self.ready.pop() else {
-                return None;
-            };
+            let ReadyItem { tx_index, .. } = self.ready.pop()?;
             let Some(transaction) = self.transactions.remove(&tx_index) else {
                 // A transaction might have been ready, but it might have gotten popped
                 // or the sender's nonce might have increased, making it invalid. In this case,
@@ -179,16 +179,12 @@ impl TransactionPool {
     }
 
     pub fn get_transaction(&self, hash: Hash) -> Option<&VerifiedTransaction> {
-        let Some(tx_index) = self.hash_to_index.get(&hash) else {
-            return None;
-        };
+        let tx_index = self.hash_to_index.get(&hash)?;
         self.transactions.get(tx_index)
     }
 
     pub fn pop_transaction(&mut self, hash: Hash) -> Option<VerifiedTransaction> {
-        let Some(tx_index) = self.hash_to_index.get(&hash) else {
-            return None;
-        };
+        let tx_index = self.hash_to_index.get(&hash)?;
         self.transactions.remove(tx_index)
     }
 
@@ -227,6 +223,8 @@ impl TransactionPool {
 
 #[cfg(test)]
 mod tests {
+    use primitive_types::H160;
+
     use super::TransactionPool;
     use crate::{
         crypto::Hash,
@@ -235,7 +233,6 @@ mod tests {
             EthSignature, SignedTransaction, TxIntershard, TxLegacy, VerifiedTransaction,
         },
     };
-    use primitive_types::H160;
 
     fn transaction(from_addr: Address, nonce: u8, gas_price: u128) -> VerifiedTransaction {
         VerifiedTransaction {

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -1,5 +1,3 @@
-use crate::exec::BLOCK_GAS_LIMIT;
-use crate::exec::GAS_PRICE;
 use std::{hash::Hash, sync::Arc};
 
 use anyhow::{anyhow, Result};
@@ -10,7 +8,13 @@ use revm::primitives::ResultAndState;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
-use crate::{cfg::ConsensusConfig, contracts, crypto, db::TrieStorage, message::BlockHeader};
+use crate::{
+    cfg::ConsensusConfig,
+    contracts, crypto,
+    db::TrieStorage,
+    exec::{BLOCK_GAS_LIMIT, GAS_PRICE},
+    message::BlockHeader,
+};
 
 #[derive(Debug)]
 /// The state of the blockchain, consisting of:

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -5,26 +5,12 @@ mod persistence;
 mod staking;
 mod web3;
 mod zil;
-use std::{env, ops::DerefMut};
-
-use ethers::{
-    solc::SHANGHAI_SOLC,
-    types::{Bytes, TransactionReceipt},
-};
-use itertools::Itertools;
-use serde::Deserialize;
-use zilliqa::{
-    cfg::{ConsensusConfig, NodeConfig},
-    crypto::{NodePublicKey, SecretKey},
-    message::{ExternalMessage, InternalMessage},
-    node::Node,
-    state::Address,
-};
-
 use std::{
     collections::HashMap,
+    env,
     fmt::Debug,
     fs,
+    ops::DerefMut,
     rc::Rc,
     sync::{
         atomic::{AtomicU64, Ordering},
@@ -40,11 +26,13 @@ use ethers::{
     prelude::{CompilerInput, DeploymentTxFactory, EvmVersion, SignerMiddleware},
     providers::{HttpClientError, JsonRpcClient, JsonRpcError, Provider},
     signers::LocalWallet,
-    types::{H256, U64},
+    solc::SHANGHAI_SOLC,
+    types::{Bytes, TransactionReceipt, H256, U64},
     utils::secret_key_to_address,
 };
 use fs_extra::dir::*;
 use futures::{stream::BoxStream, Future, FutureExt, StreamExt};
+use itertools::Itertools;
 use jsonrpsee::{
     types::{Id, RequestSer, Response, ResponsePayload},
     RpcModule,
@@ -53,11 +41,18 @@ use k256::ecdsa::SigningKey;
 use libp2p::PeerId;
 use rand::{seq::SliceRandom, Rng};
 use rand_chacha::ChaCha8Rng;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tempfile::TempDir;
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::*;
+use zilliqa::{
+    cfg::{ConsensusConfig, NodeConfig},
+    crypto::{NodePublicKey, SecretKey},
+    message::{ExternalMessage, InternalMessage},
+    node::Node,
+    state::Address,
+};
 
 /// (source, destination, message) for both
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This ensures the nightly-only options in our `rustfmt.toml` are respected.

This commit also fixes the new Clippy lints introduced by the current nightly version.
