### PR TITLE
Fix response format of `GetVersion`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,6 +2219,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git2"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b3ba52851e73b46a4c3df1d89343741112003f0f6f13beb0dfac9e457c3fdcd"
+dependencies = [
+ "bitflags 2.4.2",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +2965,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.16.2+1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3387,6 +3412,18 @@ dependencies = [
  "bitflags 2.4.2",
  "libc",
  "redox_syscall 0.4.1",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -6302,6 +6339,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "vergen"
 version = "8.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6309,6 +6352,7 @@ checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
 dependencies = [
  "anyhow",
  "cfg-if",
+ "git2",
  "rustversion",
  "time",
 ]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -20,7 +20,8 @@ test_contract_bytecode = []
 fake_time = []
 
 [build-dependencies]
-vergen = { version = "8.3.1", features = ["git", "gitcl"] }
+anyhow = { version = "1.0.81", features = ["backtrace"] }
+vergen = { version = "8.3.1", features = ["git", "git2"] }
 
 [dependencies]
 anyhow = { version = "1.0.81", features = ["backtrace"] }

--- a/zilliqa/build.rs
+++ b/zilliqa/build.rs
@@ -1,12 +1,12 @@
-use std::error::Error;
-
+use anyhow::Result;
 use vergen::EmitBuilder;
 
-// This build script will be executed when building the project and will provide
-// the git commit as an environment variable
-fn main() -> Result<(), Box<dyn Error>> {
-    // Emit the instructions
-    EmitBuilder::builder().all_git().emit()?;
+fn main() -> Result<()> {
+    EmitBuilder::builder()
+        .git_describe(true, true, None)
+        .git_sha(false)
+        .fail_on_error()
+        .emit()?;
 
     Ok(())
 }

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Result};
 use jsonrpsee::{types::Params, RpcModule};
 use primitive_types::{H160, H256};
 use serde::{Deserialize, Deserializer};
-use serde_json::json;
+use serde_json::{json, Value};
 
 use super::types::zil;
 use crate::{
@@ -34,7 +34,7 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
             ("GetLatestTxBlock", get_latest_tx_block),
             ("GetMinimumGasPrice", get_minimum_gas_price),
             ("GetNetworkId", get_network_id),
-            ("GetVersion", get_git_commit),
+            ("GetVersion", get_version),
         ],
     )
 }
@@ -201,8 +201,13 @@ fn get_network_id(_: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     Ok(network_id.to_string())
 }
 
-fn get_git_commit(_: Params, _: &Arc<Mutex<Node>>) -> Result<String> {
-    Ok(env!("VERGEN_GIT_DESCRIBE").to_string())
+fn get_version(_: Params, _: &Arc<Mutex<Node>>) -> Result<Value> {
+    let commit = env!("VERGEN_GIT_SHA");
+    let version = env!("VERGEN_GIT_DESCRIBE");
+    Ok(json!({
+        "Commit": commit,
+        "Version": version,
+    }))
 }
 
 fn get_smart_contract_state(params: Params, node: &Arc<Mutex<Node>>) -> Result<serde_json::Value> {


### PR DESCRIPTION
It now returns an object containing `Commit` and `Version` fields, which is what ZQ1 does.

`Commit` is populated by the full SHA of the git commit at which the node was built.

`Version` is populated by a git tag, if one exists or an abbreviated commit SHA if not. If the working directory is dirty, `-dirty` is appended to the version. This is close to the output of `git describe --always --dirty --tags`.

Example output when `HEAD` is tagged:
```
{
    "Commit": "c2ecdc27e588a0ababcbe9a00567351d739664b4",
    "Version": "foobar"
}
```

Example output when `HEAD` is not tagged:
```
{
    "Commit": "c2ecdc27e588a0ababcbe9a00567351d739664b4",
    "Version": "c2ecdc2"
}
```