### PR TITLE
Fix local docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 .cache
-.git
 **/target/
 
 docker-compose.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt update -y && \
 
 RUN apt autoremove
 
+WORKDIR /zilliqa
+
 RUN mkdir build
 
 COPY . .
@@ -13,9 +15,9 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/target \
     cargo build --bin zilliqa && \
-    mv /target/debug/zilliqa /build/
+    mv ./target/debug/zilliqa ./build/
 
 
 FROM gcr.io/distroless/cc-debian11
 
-COPY --from=builder /build/zilliqa /zilliqa
+COPY --from=builder /zilliqa/build/zilliqa /zilliqa


### PR DESCRIPTION
1. We need to un-ignore the `.git` directory when copying files into the build container, so `vergen` can read git information.

2. Previously we copied everything into `/`. It appears `vergen` or `git2` doesn't like Git repositories named `/`, so instead we copy and build everything into `/zilliqa`.