### PR TITLE
Update README with `eth_getUncle*` implementation status

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Please open an issue or PR for APIs that you think should be included.
 | `eth_getTransactionByHash`                | 🟢                                              |
 | `eth_getTransactionCount`                 | 🟢                                              |
 | `eth_getTransactionReceipt`               | 🟢                                              |
-| `eth_getUncleByBlockHashAndIndex`         | 🔴                                              |
-| `eth_getUncleByBlockNumberAndIndex`       | 🔴                                              |
-| `eth_getUncleCountByBlockHash`            | 🔴                                              |
-| `eth_getUncleCountByBlockNumber`          | 🔴                                              |
+| `eth_getUncleByBlockHashAndIndex`         | 🟢                                              |
+| `eth_getUncleByBlockNumberAndIndex`       | 🟢                                              |
+| `eth_getUncleCountByBlockHash`            | 🟢                                              |
+| `eth_getUncleCountByBlockNumber`          | 🟢                                              |
 | `eth_newFilter`                           | 🔴                                              |
 | `eth_newBlockFilter`                      | 🔴                                              |
 | `eth_newPendingTransactionFilter`         | 🔴                                              |

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -760,7 +760,6 @@ fn left_pad_arr<const N: usize>(v: &[u8]) -> Result<[u8; N]> {
     Ok(arr)
 }
 
-// These are no-ops basically
 fn get_uncle_count(_: Params, _: &Arc<Mutex<Node>>) -> Result<String> {
     Ok("0x0".to_string())
 }


### PR DESCRIPTION
These were implemented a while ago, but we forgot to update the supported APIs list.