### PR TITLE
Implement `eth_subscribe` for `newHeads`

### DIFF
--- a/zilliqa/src/api/erigon.rs
+++ b/zilliqa/src/api/erigon.rs
@@ -14,13 +14,16 @@ fn get_header_by_number(params: Params, node: &Arc<Mutex<Node>>) -> Result<Optio
     let block: BlockNumber = params.one()?;
 
     // Erigon headers are a subset of the full block response. We choose to just return the full block.
-    let Some(ref header) = node.lock().unwrap().get_block_by_blocknum(block)? else {
+    let Some(ref block) = node.lock().unwrap().get_block_by_blocknum(block)? else {
         return Ok(None);
     };
 
-    let miner = node.lock().unwrap().get_proposer_reward_address(header)?;
+    let miner = node
+        .lock()
+        .unwrap()
+        .get_proposer_reward_address(block.header)?;
     Ok(Some(eth::Block::from_block(
-        header,
+        block,
         miner.unwrap_or_default(),
     )))
 }

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -2,6 +2,7 @@ mod erigon;
 pub mod eth;
 mod net;
 mod ots;
+pub mod subscription_id_provider;
 mod to_hex;
 mod types;
 mod web3;

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -34,7 +34,10 @@ fn get_block_details(params: Params, node: &Arc<Mutex<Node>>) -> Result<Option<o
     let Some(ref block) = node.lock().unwrap().get_block_by_number(block)? else {
         return Ok(None);
     };
-    let miner = node.lock().unwrap().get_proposer_reward_address(block)?;
+    let miner = node
+        .lock()
+        .unwrap()
+        .get_proposer_reward_address(block.header)?;
 
     Ok(Some(ots::BlockDetails::from_block(
         block,
@@ -51,7 +54,10 @@ fn get_block_details_by_hash(
     let Some(ref block) = node.lock().unwrap().get_block_by_hash(Hash(block_hash.0))? else {
         return Ok(None);
     };
-    let miner = node.lock().unwrap().get_proposer_reward_address(block)?;
+    let miner = node
+        .lock()
+        .unwrap()
+        .get_proposer_reward_address(block.header)?;
 
     Ok(Some(ots::BlockDetails::from_block(
         block,
@@ -73,7 +79,7 @@ fn get_block_transactions(
     let Some(block) = node.get_block_by_number(block_num)? else {
         return Ok(None);
     };
-    let miner = node.get_proposer_reward_address(&block)?;
+    let miner = node.get_proposer_reward_address(block.header)?;
 
     let start = usize::min(page_number * page_size, block.transactions.len());
     let end = usize::min((page_number + 1) * page_size, block.transactions.len());

--- a/zilliqa/src/api/subscription_id_provider.rs
+++ b/zilliqa/src/api/subscription_id_provider.rs
@@ -1,0 +1,12 @@
+use jsonrpsee::{server::IdProvider, types::SubscriptionId};
+
+use super::to_hex::ToHex;
+
+#[derive(Debug)]
+pub struct EthIdProvider;
+
+impl IdProvider for EthIdProvider {
+    fn next_id(&self) -> SubscriptionId<'static> {
+        rand::random::<u64>().to_hex().into()
+    }
+}

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -22,6 +22,32 @@ pub enum HashOrTransaction {
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Block {
+    #[serde(flatten)]
+    pub header: Header,
+    #[serde(serialize_with = "hex")]
+    pub size: u64,
+    pub transactions: Vec<HashOrTransaction>,
+    pub uncles: Vec<H256>,
+}
+
+impl Block {
+    pub fn from_block(block: &message::Block, miner: H160) -> Self {
+        Block {
+            header: Header::from_header(block.header, miner),
+            size: 0,
+            transactions: block
+                .transactions
+                .iter()
+                .map(|h| HashOrTransaction::Hash(H256(h.0)))
+                .collect(),
+            uncles: vec![],
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Header {
     #[serde(serialize_with = "hex")]
     pub number: u64,
     #[serde(serialize_with = "hex")]
@@ -49,48 +75,37 @@ pub struct Block {
     #[serde(serialize_with = "hex")]
     pub extra_data: Vec<u8>,
     #[serde(serialize_with = "hex")]
-    pub size: u64,
-    #[serde(serialize_with = "hex")]
     pub gas_limit: u64,
     #[serde(serialize_with = "hex")]
     pub gas_used: u64,
     #[serde(serialize_with = "hex")]
     pub timestamp: u64,
-    pub transactions: Vec<HashOrTransaction>,
-    pub uncles: Vec<H256>,
 }
 
-impl Block {
-    pub fn from_block(block: &message::Block, miner: H160) -> Self {
+impl Header {
+    pub fn from_header(header: message::BlockHeader, miner: H160) -> Self {
         // TODO(#79): Lots of these fields are empty/zero and shouldn't be.
-        Block {
-            number: block.number(),
-            hash: H256(block.hash().0),
-            parent_hash: H256(block.parent_hash().0),
+        Header {
+            number: header.number,
+            hash: H256(header.hash.0),
+            parent_hash: H256(header.parent_hash.0),
             nonce: [0; 8],
             sha_3_uncles: H256::zero(),
             logs_bloom: [0; 256],
             transactions_root: H256::zero(),
-            state_root: H256(block.state_root_hash().0),
+            state_root: H256(header.state_root_hash.0),
             receipts_root: H256::zero(),
             miner,
             difficulty: 0,
             total_difficulty: 0,
             extra_data: vec![],
-            size: 0,
             gas_limit: BLOCK_GAS_LIMIT,
             gas_used: 0,
-            timestamp: block
-                .timestamp()
+            timestamp: header
+                .timestamp
                 .duration_since(SystemTime::UNIX_EPOCH)
                 .unwrap_or_default()
                 .as_secs(),
-            transactions: block
-                .transactions
-                .iter()
-                .map(|h| HashOrTransaction::Hash(H256(h.0)))
-                .collect(),
-            uncles: vec![],
         }
     }
 }

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -19,7 +19,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::*;
 
 use crate::{
-    api,
+    api::{self, subscription_id_provider::EthIdProvider},
     cfg::NodeConfig,
     crypto::SecretKey,
     health::HealthLayer,
@@ -85,6 +85,7 @@ impl NodeLauncher {
             let port = config.json_rpc_port;
             let server = jsonrpsee::server::ServerBuilder::new()
                 .set_http_middleware(middleware)
+                .set_id_provider(EthIdProvider)
                 .build((Ipv4Addr::UNSPECIFIED, port))
                 .await;
 


### PR DESCRIPTION
This adds the `eth_subscribe` and `eth_unsubscribe` APIs for the Ethereum pub-sub protocol.

Currently, only `newHeads` are supported (`logs` and `newPendingTransactions` are also specified). The API only works over a websocket, because they need a duplex connection.

The implementation works by adding a `broadcast::Sender` to `Consensus` which publishes `BlockHeader`s whenvever they are produced. When a client makes a new subscription, it subscribes to this sender. The sender keeps a buffer of the 4 latest blocks in memory. If any reciever falls behind these 4 blocks (because sending the blocks to the client is too slow), it will be disconnected.