### PR TITLE
CI: run rust fmt before kicking off the test suite, for fail-early behaviour

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,11 +39,11 @@ jobs:
       run: cargo build --release --all-targets --all-features
     - name: Clippy
       run: cargo clippy --release --all-targets --all-features -- -D warnings
+    - name: rustfmt
+      run: cargo fmt --all --check
     - name: Test
       run: cargo test --release --all-targets --all-features
       timeout-minutes: 30
-    - name: rustfmt
-      run: cargo fmt --all --check
     - name: Verify working directory is clean
       run: git diff --exit-code
   e2e_test:


### PR DESCRIPTION
Avoids the risk of having CI run for 10-15 minutes only to then fail on a rustfmt mismatch.

Assuming there isn't any deeper reason for why it was put after `cargo test` in the first place?