### PR TITLE
Implement `ots_searchTransactions{Before,After}`

### DIFF
--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -8,7 +8,7 @@ use super::{
     eth::{get_transaction_inner, get_transaction_receipt_inner},
     types::ots,
 };
-use crate::{crypto::Hash, message::BlockNumber, node::Node, state::Contract};
+use crate::{crypto::Hash, message::BlockNumber, node::Node, state::Contract, time::SystemTime};
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     super::declare_module!(
@@ -19,6 +19,8 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
             ("ots_getBlockDetailsByHash", get_block_details_by_hash),
             ("ots_getBlockTransactions", get_block_transactions),
             ("ots_hasCode", has_code),
+            ("ots_searchTransactionsAfter", search_transactions_after),
+            ("ots_searchTransactionsBefore", search_transactions_before),
         ],
     )
 }
@@ -123,4 +125,123 @@ fn has_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
     };
 
     Ok(!empty)
+}
+
+fn search_transactions_inner(
+    node: &Arc<Mutex<Node>>,
+    address: H160,
+    block_number: u64,
+    page_size: usize,
+    reverse: bool,
+) -> Result<ots::Transactions> {
+    let mut touched = node.lock().unwrap().get_touched_transactions(address)?;
+
+    // If searching in reverse, we should start with the most recent transaction and work backwards.
+    if reverse {
+        touched.reverse();
+    }
+
+    let mut transactions = Vec::with_capacity(page_size);
+    let mut receipts = Vec::with_capacity(page_size);
+
+    // Keep track of the current block number. Once we reach `page_size` transactions, we still need to continue adding
+    // transactions from the current block.
+    let mut current_block = u64::MAX;
+    // This will be set to false if we break out of the loop, indicating to the caller there are further pages.
+    let mut finished = true;
+
+    for hash in touched {
+        let txn = get_transaction_inner(hash, &node.lock().unwrap())
+            .unwrap()
+            .unwrap();
+
+        let txn_block_number = match txn.block_number {
+            Some(txn_block_number) => txn_block_number,
+            None => continue,
+        };
+
+        let cmp = if !reverse {
+            PartialOrd::le
+        } else {
+            PartialOrd::ge
+        };
+        if cmp(&txn_block_number, &block_number) {
+            continue;
+        }
+
+        // Don't break until we have at least `page_size` transactions AND we've added everything from the last searched block.
+        if transactions.len() >= page_size && txn_block_number != current_block {
+            finished = false;
+            break;
+        }
+
+        let timestamp = node
+            .lock()
+            .unwrap()
+            .get_block_by_hash(Hash(txn.block_hash.unwrap_or_default().0))?
+            .unwrap()
+            .timestamp();
+
+        transactions.push(txn);
+
+        let node = node.lock().unwrap();
+        let receipt = ots::TransactionReceiptWithTimestamp {
+            receipt: get_transaction_receipt_inner(hash, &node).unwrap().unwrap(),
+            timestamp: timestamp
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .unwrap()
+                .as_secs(),
+        };
+        receipts.push(receipt);
+
+        current_block = txn_block_number;
+    }
+
+    // The results should always be returned in descending order (latest to earliest). If we were searching forwards
+    // in time, we should reverse the results to ensure they are in descending order.
+    if !reverse {
+        transactions.reverse();
+        receipts.reverse();
+    }
+
+    // `first_page` should be set if this was the latest page in time and `last_page` should be set if this was the
+    // earliest page in time.
+    let (first_page, last_page) = if reverse {
+        (block_number == u64::MAX, finished)
+    } else {
+        (finished, block_number == 0)
+    };
+
+    Ok(ots::Transactions {
+        transactions,
+        receipts,
+        first_page,
+        last_page,
+    })
+}
+
+fn search_transactions_after(params: Params, node: &Arc<Mutex<Node>>) -> Result<ots::Transactions> {
+    let mut params = params.sequence();
+    let address: H160 = params.next()?;
+    let block_number: u64 = params.next()?;
+    let page_size: usize = params.next()?;
+
+    search_transactions_inner(node, address, block_number, page_size, false)
+}
+
+fn search_transactions_before(
+    params: Params,
+    node: &Arc<Mutex<Node>>,
+) -> Result<ots::Transactions> {
+    let mut params = params.sequence();
+    let address: H160 = params.next()?;
+    let mut block_number: u64 = params.next()?;
+    let page_size: usize = params.next()?;
+
+    // A `block_number` of `0` tells us to search from the most recent block.
+    if block_number == 0 {
+        block_number = u64::MAX;
+    }
+
+    search_transactions_inner(node, address, block_number, page_size, true)
 }

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -181,7 +181,7 @@ pub struct TransactionReceipt {
     pub logs: Vec<Log>,
     #[serde(serialize_with = "hex")]
     pub logs_bloom: [u8; 256],
-    #[serde(serialize_with = "hex")]
+    #[serde(rename = "type", serialize_with = "hex")]
     pub ty: u64,
     #[serde(serialize_with = "bool_as_int")]
     pub status: bool,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -3,7 +3,7 @@ use std::{collections::BTreeMap, error::Error, fmt::Display, sync::Arc};
 use anyhow::{anyhow, Result};
 use bitvec::bitvec;
 use libp2p::PeerId;
-use primitive_types::{H256, U256};
+use primitive_types::{H160, H256, U256};
 use rand::{
     distributions::{Distribution, WeightedIndex},
     prelude::IteratorRandom,
@@ -11,6 +11,7 @@ use rand::{
 };
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
+use revm::Inspector;
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 use tracing::*;
@@ -22,6 +23,7 @@ use crate::{
     crypto::{Hash, NodePublicKey, NodeSignature, SecretKey},
     db::Db,
     exec::TransactionApplyResult,
+    inspector::{self, ScillaInspector, TouchedAddressInspector},
     message::{
         AggregateQc, BitSlice, BitVec, Block, BlockHeader, BlockRef, Committee, ExternalMessage,
         InternalMessage, NewView, Proposal, QuorumCertificate, Vote,
@@ -668,18 +670,22 @@ impl Consensus {
         Ok(())
     }
 
-    pub fn apply_transaction(
+    pub fn apply_transaction<I: for<'s> Inspector<&'s State> + ScillaInspector>(
         &mut self,
         txn: VerifiedTransaction,
         current_block: BlockHeader,
+        inspector: I,
     ) -> Result<Option<TransactionApplyResult>> {
         let hash = txn.hash;
 
         self.db.insert_transaction(&hash, &txn.tx)?;
 
-        let result =
-            self.state
-                .apply_transaction(txn.clone(), self.config.eth_chain_id, current_block);
+        let result = self.state.apply_transaction(
+            txn.clone(),
+            self.config.eth_chain_id,
+            current_block,
+            inspector,
+        );
         let result = match result {
             Ok(r) => r,
             Err(error) => {
@@ -711,6 +717,10 @@ impl Consensus {
                     .unwrap_or(true)
             })
             .collect()
+    }
+
+    pub fn get_touched_transactions(&self, address: H160) -> Result<Vec<Hash>> {
+        self.db.get_touched_addresses(address)
     }
 
     /// Clear up anything in memory that is no longer required. This is to avoid memory leaks.
@@ -845,7 +855,7 @@ impl Consensus {
                     let applied_transactions: Vec<_> = transactions
                         .into_iter()
                         .filter_map(|tx| {
-                            self.apply_transaction(tx.clone(), parent_header)
+                            self.apply_transaction(tx.clone(), parent_header, inspector::noop())
                                 .transpose()
                                 .map(|r| r.map(|_| tx))
                         })
@@ -1915,11 +1925,15 @@ impl Consensus {
         for txn in transactions {
             self.new_transaction(txn.clone())?;
             let tx_hash = txn.hash;
+            let mut inspector = TouchedAddressInspector::default();
             let result = self
-                .apply_transaction(txn.clone(), parent.header)?
+                .apply_transaction(txn.clone(), parent.header, &mut inspector)?
                 .ok_or_else(|| anyhow!("proposed transaction failed to execute"))?;
             self.db
                 .insert_block_hash_reverse_index(&tx_hash, &block.hash())?;
+            for address in inspector.touched {
+                self.db.add_touched_address(address, tx_hash)?;
+            }
             let receipt = TransactionReceipt {
                 block_hash: block.hash(),
                 tx_hash,

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -272,7 +272,8 @@ impl SecretKey {
 pub struct Hash(pub [u8; 32]);
 
 impl Hash {
-    pub const ZERO: Hash = Hash([0; 32]);
+    pub const ZERO: Hash = Hash([0; Hash::LEN]);
+    pub const LEN: usize = 32;
 
     pub fn from_bytes(bytes: impl AsRef<[u8]>) -> Result<Self> {
         let bytes = bytes.as_ref();

--- a/zilliqa/src/inspector.rs
+++ b/zilliqa/src/inspector.rs
@@ -1,0 +1,99 @@
+use std::collections::HashSet;
+
+use primitive_types::H160;
+use revm::{
+    inspectors::NoOpInspector,
+    interpreter::{CallInputs, CallOutcome, CreateInputs, CreateOutcome},
+    Database, EvmContext, Inspector,
+};
+
+/// Provides callbacks from the Scilla interpreter.
+pub trait ScillaInspector {
+    fn create(&mut self, creator: H160, contract_address: H160) {
+        let _ = contract_address;
+        let _ = creator;
+    }
+    fn transfer(&mut self, from: H160, to: H160, amount: u128) {
+        let _ = amount;
+        let _ = to;
+        let _ = from;
+    }
+    fn call(&mut self, from: H160, to: H160) {
+        let _ = to;
+        let _ = from;
+    }
+}
+
+impl<T: ScillaInspector> ScillaInspector for &mut T {
+    fn create(&mut self, creator: H160, contract_address: H160) {
+        (*self).create(creator, contract_address);
+    }
+
+    fn transfer(&mut self, from: H160, to: H160, amount: u128) {
+        (*self).transfer(from, to, amount)
+    }
+
+    fn call(&mut self, from: H160, to: H160) {
+        (*self).call(from, to)
+    }
+}
+
+pub fn noop() -> NoOpInspector {
+    NoOpInspector
+}
+
+impl ScillaInspector for NoOpInspector {}
+
+#[derive(Debug, Default)]
+pub struct TouchedAddressInspector {
+    pub touched: HashSet<H160>,
+}
+
+impl<DB: Database> Inspector<DB> for TouchedAddressInspector {
+    fn call(&mut self, _: &mut EvmContext<DB>, inputs: &mut CallInputs) -> Option<CallOutcome> {
+        self.touched
+            .insert(H160(inputs.context.caller.into_array()));
+        self.touched.insert(H160(inputs.contract.into_array()));
+        None
+    }
+
+    fn create_end(
+        &mut self,
+        _: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
+        outcome: CreateOutcome,
+    ) -> CreateOutcome {
+        self.touched.insert(H160(inputs.caller.into_array()));
+        if let Some(address) = outcome.address {
+            self.touched.insert(H160(address.into_array()));
+        }
+        outcome
+    }
+
+    fn selfdestruct(
+        &mut self,
+        contract: revm::primitives::Address,
+        target: revm::primitives::Address,
+        _: ruint::aliases::U256,
+    ) {
+        self.touched.insert(H160(contract.into_array()));
+        self.touched.insert(H160(target.into_array()));
+    }
+}
+
+impl ScillaInspector for TouchedAddressInspector {
+    fn create(&mut self, creator: H160, contract_address: H160) {
+        self.touched.insert(creator);
+        self.touched.insert(contract_address);
+    }
+
+    fn transfer(&mut self, from: H160, to: H160, _: u128) {
+        self.touched.insert(from);
+        self.touched.insert(to);
+    }
+
+    fn call(&mut self, from: H160, to: H160) {
+        self.touched.insert(from);
+        self.touched.insert(to);
+    }
+}

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -9,6 +9,7 @@ mod db;
 mod eth_helpers;
 mod exec;
 mod health;
+mod inspector;
 pub mod message;
 pub mod node;
 pub mod node_launcher;

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -344,6 +344,10 @@ impl Node {
         self.consensus.state().get_reward_address(proposer)
     }
 
+    pub fn get_touched_transactions(&self, address: Address) -> Result<Vec<Hash>> {
+        self.consensus.get_touched_transactions(address)
+    }
+
     pub fn get_gas_price(&self) -> u128 {
         GAS_PRICE
     }

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -16,6 +16,7 @@ use crate::{
     contracts, crypto,
     db::TrieStorage,
     exec::{BLOCK_GAS_LIMIT, GAS_PRICE},
+    inspector,
     message::BlockHeader,
     scilla::Scilla,
 };
@@ -115,6 +116,7 @@ impl State {
                 None,
                 0,
                 BlockHeader::default(),
+                inspector::noop(),
             )?;
             if !result.is_success() {
                 return Err(anyhow!("setting stake failed: {result:?}"));

--- a/zilliqa/tests/it/contracts/CallingContract.sol
+++ b/zilliqa/tests/it/contracts/CallingContract.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: MIT
+// Source: https://solidity-by-example.org/calling-contract/
+pragma solidity ^0.8.20;
+
+contract Callee {
+    uint256 public x;
+    uint256 public value;
+
+    function setX(uint256 _x) public returns (uint256) {
+        x = _x;
+        return x;
+    }
+
+    function setXandSendEther(uint256 _x)
+        public
+        payable
+        returns (uint256, uint256)
+    {
+        x = _x;
+        value = msg.value;
+
+        return (x, value);
+    }
+}
+
+contract Caller {
+    function setX(Callee _callee, uint256 _x) public {
+        uint256 x = _callee.setX(_x);
+    }
+
+    function setXFromAddress(address _addr, uint256 _x) public {
+        Callee callee = Callee(_addr);
+        callee.setX(_x);
+    }
+
+    function setXandSendEther(Callee _callee, uint256 _x) public payable {
+        (uint256 x, uint256 value) =
+            _callee.setXandSendEther{value: msg.value}(_x);
+    }
+}

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -6,6 +6,7 @@ use primitive_types::U256;
 use serde_json::{value::RawValue, Value};
 mod consensus;
 mod eth;
+mod ots;
 mod persistence;
 mod staking;
 mod unreliable;

--- a/zilliqa/tests/it/ots.rs
+++ b/zilliqa/tests/it/ots.rs
@@ -1,0 +1,166 @@
+use std::{ops::DerefMut, str::FromStr};
+
+use ethabi::Token;
+use ethers::{
+    providers::Middleware,
+    types::{TransactionRequest, U64},
+    utils,
+};
+use futures::future::join_all;
+use itertools::Itertools;
+use primitive_types::{H160, H256};
+use serde_json::Value;
+
+use crate::{deploy_contract, Network, Wallet};
+
+async fn search_transactions(
+    wallet: &Wallet,
+    address: H160,
+    block_number: u64,
+    page_size: usize,
+    reverse: bool,
+) -> Value {
+    let method = if reverse {
+        "ots_searchTransactionsBefore"
+    } else {
+        "ots_searchTransactionsAfter"
+    };
+    wallet
+        .provider()
+        .request(
+            method,
+            [
+                utils::serialize(&address),
+                utils::serialize(&block_number),
+                utils::serialize(&page_size),
+            ],
+        )
+        .await
+        .unwrap()
+}
+
+#[zilliqa_macros::test]
+async fn search_transactions_evm(mut network: Network) {
+    let wallet = network.genesis_wallet().await;
+
+    let (hash, caller_abi) = deploy_contract(
+        "tests/it/contracts/CallingContract.sol",
+        "Caller",
+        &wallet,
+        &mut network,
+    )
+    .await;
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let caller_address = receipt.contract_address.unwrap();
+
+    let (hash, _) = deploy_contract(
+        "tests/it/contracts/CallingContract.sol",
+        "Callee",
+        &wallet,
+        &mut network,
+    )
+    .await;
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let callee_address = receipt.contract_address.unwrap();
+
+    let data = caller_abi
+        .function("setX")
+        .unwrap()
+        .encode_input(&[Token::Address(callee_address), Token::Uint(123.into())])
+        .unwrap();
+
+    let tx = TransactionRequest::new().to(caller_address).data(data);
+    let hash = wallet.send_transaction(tx, None).await.unwrap().tx_hash();
+    network.run_until_receipt(&wallet, hash, 50).await;
+
+    // Search for the transaction with: the sender, the caller contract and the callee contract.
+    let response = search_transactions(&wallet, wallet.address(), 0, 1, false).await;
+    assert_eq!(response["txs"].as_array().unwrap().len(), 1);
+    let response = search_transactions(&wallet, caller_address, 0, 1, false).await;
+    assert_eq!(response["txs"].as_array().unwrap().len(), 1);
+    let response = search_transactions(&wallet, callee_address, 0, 1, false).await;
+    assert_eq!(response["txs"].as_array().unwrap().len(), 1);
+}
+
+// TODO: Add test for searching for internal Scilla contract calls once they are supported.
+
+#[zilliqa_macros::test]
+async fn search_transactions_paging(mut network: Network) {
+    let wallet = network.genesis_wallet().await;
+
+    // Generate 16 transactions.
+    let to = H160::random_using(network.rng.lock().unwrap().deref_mut());
+    let hashes: Vec<_> = join_all((0..16).map(|i| {
+        let wallet = &wallet;
+        async move {
+            let tx = TransactionRequest::pay(to, 123).nonce(i);
+            wallet.send_transaction(tx, None).await.unwrap().tx_hash()
+        }
+    }))
+    .await;
+
+    for h in hashes {
+        network.run_until_receipt(&wallet, h, 50).await;
+    }
+
+    let page_size = 8;
+    let response = search_transactions(&wallet, wallet.address(), 0, page_size, false).await;
+    let txs = response["txs"].as_array().unwrap();
+    // Response should include at least as many transactions as the page size.
+    assert!(txs.len() >= page_size);
+    // It should include all transactions from the last block (even if this results in more txs than `page_size`).
+    let last_block_hash = txs[txs.len() - 1]["blockHash"].as_str().unwrap();
+    let last_block = wallet
+        .get_block(H256::from_str(last_block_hash).unwrap())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        txs.iter()
+            .filter(|tx| tx["blockHash"] == last_block_hash)
+            .count(),
+        last_block.transactions.len()
+    );
+    // It should be marked as the last (earliest) page because we started from the genesis block.
+    assert!(response["lastPage"].as_bool().unwrap());
+
+    let response = search_transactions(&wallet, wallet.address(), 0, 16, false).await;
+    let txs = response["txs"].as_array().unwrap();
+    // It should be marked as the first (latest) page because we queried for all 16 transactions.
+    assert!(response["firstPage"].as_bool().unwrap());
+    // Transactions should be returned in descending order (latest to earliest)
+    assert!(txs
+        .iter()
+        .map(|tx| (
+            tx["blockNumber"].as_str().unwrap().parse::<U64>().unwrap(),
+            tx["transactionIndex"]
+                .as_str()
+                .unwrap()
+                .parse::<U64>()
+                .unwrap(),
+        ))
+        .tuple_windows()
+        .all(|(a, b)| a > b));
+
+    let response = search_transactions(&wallet, wallet.address(), 0, 1, true).await;
+    let txs = response["txs"].as_array().unwrap();
+    // Searching in reverse from the latest block and a page size of 1 should only yield results from a single block.
+    assert!(!txs.is_empty());
+    assert!(txs
+        .iter()
+        .map(|tx| tx["blockHash"].as_str().unwrap())
+        .all_equal());
+    // Transactions should be returned in descending order (latest to earliest)
+    assert!(txs
+        .iter()
+        .map(|tx| (
+            tx["blockNumber"].as_str().unwrap().parse::<U64>().unwrap(),
+            tx["transactionIndex"]
+                .as_str()
+                .unwrap()
+                .parse::<U64>()
+                .unwrap(),
+        ))
+        .tuple_windows()
+        .all(|(a, b)| a > b));
+}


### PR DESCRIPTION
This is quite similar to the old implementation that I removed. When voting on a block proposal, we run transactions with an `Inspector` which records the 'touched' addresses and stores them in a separate index. This occurs for both EVM and Scilla transactions.