### PR TITLE
Implement `ots_getContractCreator`

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Please open an issue or PR for APIs that you think should be included.
 | `ots_getBlockDetails`                     | 🟢                                              |
 | `ots_getBlockDetailsByHash`               | 🟢                                              |
 | `ots_getBlockTransactions`                | 🟢                                              |
-| `ots_getContractCreator`                  | 🔴                                              |
+| `ots_getContractCreator`                  | 🟢                                              |
 | `ots_getInternalOperations`               | 🔴                                              |
 | `ots_getTransactionBySenderAndNonce`      | 🔴                                              |
 | `ots_getTransactionError`                 | 🔴                                              |

--- a/zilliqa/src/inspector.rs
+++ b/zilliqa/src/inspector.rs
@@ -97,3 +97,46 @@ impl ScillaInspector for TouchedAddressInspector {
         self.touched.insert(to);
     }
 }
+
+#[derive(Debug)]
+pub struct CreatorInspector {
+    contract: H160,
+    creator: Option<H160>,
+}
+
+impl CreatorInspector {
+    pub fn new(contract: H160) -> Self {
+        CreatorInspector {
+            contract,
+            creator: None,
+        }
+    }
+
+    pub fn creator(&self) -> Option<H160> {
+        self.creator
+    }
+}
+
+impl<DB: Database> Inspector<DB> for CreatorInspector {
+    fn create_end(
+        &mut self,
+        _: &mut EvmContext<DB>,
+        inputs: &CreateInputs,
+        outcome: CreateOutcome,
+    ) -> CreateOutcome {
+        if let Some(address) = outcome.address {
+            if H160(address.into_array()) == self.contract {
+                self.creator = Some(H160(inputs.caller.into_array()));
+            }
+        }
+        outcome
+    }
+}
+
+impl ScillaInspector for CreatorInspector {
+    fn create(&mut self, creator: H160, contract_address: H160) {
+        if contract_address == self.contract {
+            self.creator = Some(creator);
+        }
+    }
+}

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use libp2p::PeerId;
 use primitive_types::H256;
+use revm::Inspector;
 use tokio::sync::{broadcast, mpsc::UnboundedSender};
 use tracing::*;
 
@@ -12,12 +13,13 @@ use crate::{
     crypto::{Hash, NodePublicKey, SecretKey},
     db::Db,
     exec::GAS_PRICE,
+    inspector::{self, ScillaInspector},
     message::{
         Block, BlockBatchRequest, BlockBatchResponse, BlockHeader, BlockNumber, BlockRequest,
         BlockResponse, ExternalMessage, InternalMessage, IntershardCall, Proposal,
     },
     p2p_node::{LocalMessageTuple, OutboundMessageTuple},
-    state::{Account, Address},
+    state::{Account, Address, State},
     transaction::{SignedTransaction, TransactionReceipt, TxIntershard, VerifiedTransaction},
 };
 
@@ -297,6 +299,50 @@ impl Node {
 
     pub fn peer_id(&self) -> PeerId {
         self.peer_id
+    }
+
+    pub fn replay_transaction<I: for<'s> Inspector<&'s State> + ScillaInspector>(
+        &self,
+        txn_hash: Hash,
+        inspector: I,
+    ) -> Result<()> {
+        let txn = self
+            .get_transaction_by_hash(txn_hash)?
+            .ok_or_else(|| anyhow!("transaction not found: {txn_hash}"))?;
+        let receipt = self
+            .get_transaction_receipt(txn_hash)?
+            .ok_or_else(|| anyhow!("transaction not mined: {txn_hash}"))?;
+
+        let block = self
+            .get_block_by_hash(receipt.block_hash)?
+            .ok_or_else(|| anyhow!("missing block: {}", receipt.block_hash))?;
+        let parent = self
+            .get_block_by_hash(block.parent_hash())?
+            .ok_or_else(|| anyhow!("missing block: {}", block.parent_hash()))?;
+        let mut state = self
+            .consensus
+            .state()
+            .at_root(H256(parent.state_root_hash().0));
+
+        for other_txn_hash in block.transactions {
+            if txn_hash != other_txn_hash {
+                let other_txn = self
+                    .get_transaction_by_hash(other_txn_hash)?
+                    .ok_or_else(|| anyhow!("transaction not found: {other_txn_hash}"))?;
+                state.apply_transaction(
+                    other_txn,
+                    self.get_chain_id(),
+                    parent.header,
+                    inspector::noop(),
+                )?;
+            } else {
+                state.apply_transaction(txn, self.get_chain_id(), parent.header, inspector)?;
+
+                return Ok(());
+            }
+        }
+
+        Err(anyhow!("transaction not found in block: {txn_hash}"))
     }
 
     pub fn call_contract(

--- a/zilliqa/tests/it/contracts/ContractCreatesAnotherContract.sol
+++ b/zilliqa/tests/it/contracts/ContractCreatesAnotherContract.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+pragma solidity ^0.8.20;
+
+contract Creator {
+    event Created(CreateMe createMe);
+
+    function create() public {
+        CreateMe createMe = new CreateMe();
+        emit Created(createMe);
+    }
+}
+
+contract CreateMe {}


### PR DESCRIPTION
This API returns the 'creator' of a given contract. For Scilla contracts and most EVM contracts this is trivial - It is just the `from_addr` of the transaction which created the contract.

However, some EVM contracts are created by other contracts.

Therefore, we implement this by looping through the transactions which 'touched' the contract address and replaying each transaction. When replaying, we use a new `Inspector` to record the creator of a contract if one is created. When we find the transaction which created this contract, we can terminate.

I haven't added a test case for creating a Scilla contract yet, because I don't want to slow the test suite down more. :(