### PR TITLE
Implement `ots_traceTransaction`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Please open an issue or PR for APIs that you think should be included.
 | `ots_hasCode`                             | 🟢                                              |
 | `ots_searchTransactionsAfter`             | 🟢                                              |
 | `ots_searchTransactionsBefore`            | 🟢                                              |
-| `ots_traceTransaction`                    | 🔴                                              |
+| `ots_traceTransaction`                    | 🟢                                              |
 | `web3_clientVersion`                      | 🟢                                              |
 | `web3_sha3`                               | 🟢                                              |
 | `GetCurrentMiniEpoch`                     | 🟢                                              |

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,10 +1,10 @@
 mod erigon;
 pub mod eth;
 mod net;
-mod ots;
+pub mod ots;
 pub mod subscription_id_provider;
 mod to_hex;
-mod types;
+pub mod types;
 mod web3;
 pub mod zil;
 

--- a/zilliqa/src/api/types/ots.rs
+++ b/zilliqa/src/api/types/ots.rs
@@ -1,7 +1,7 @@
 use primitive_types::{H160, H256};
 use serde::Serialize;
 
-use super::{eth, hex};
+use super::{eth, hex, option_hex};
 use crate::{message, time::SystemTime};
 
 #[derive(Clone, Serialize)]
@@ -142,4 +142,31 @@ pub struct TransactionReceiptWithTimestamp {
     pub receipt: eth::TransactionReceipt,
     #[serde(serialize_with = "hex")]
     pub timestamp: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TraceEntry {
+    #[serde(rename = "type")]
+    pub ty: TraceEntryType,
+    pub depth: u64,
+    #[serde(serialize_with = "hex")]
+    pub from: H160,
+    #[serde(serialize_with = "hex")]
+    pub to: H160,
+    #[serde(serialize_with = "option_hex")]
+    pub value: Option<u128>,
+    #[serde(serialize_with = "hex")]
+    pub input: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum TraceEntryType {
+    Call,
+    StaticCall,
+    DelegateCall,
+    CallCode,
+    Create,
+    Create2,
+    SelfDestruct,
 }

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -400,7 +400,7 @@ impl State {
             acc.nonce += 1;
         })?;
 
-        inspector.create(from_addr, contract_address);
+        inspector.create(from_addr, contract_address, txn.amount.get());
 
         Ok(TransactionApplyResult {
             success: true,
@@ -524,7 +524,7 @@ impl State {
             })
             .collect();
 
-        inspector.call(from_addr, txn.to_addr);
+        inspector.call(from_addr, txn.to_addr, txn.amount.get());
 
         Ok(TransactionApplyResult {
             success: true,

--- a/zilliqa/tests/it/ots.rs
+++ b/zilliqa/tests/it/ots.rs
@@ -225,3 +225,79 @@ async fn contract_creator(mut network: Network) {
 
     // TODO: Test Scilla contract
 }
+
+#[zilliqa_macros::test]
+async fn trace_transaction(mut network: Network) {
+    async fn get_trace(wallet: &Wallet, hash: H256) -> Value {
+        wallet
+            .provider()
+            .request("ots_traceTransaction", [hash])
+            .await
+            .unwrap()
+    }
+
+    let wallet = network.genesis_wallet().await;
+
+    let (hash, caller_abi) = deploy_contract(
+        "tests/it/contracts/CallingContract.sol",
+        "Caller",
+        &wallet,
+        &mut network,
+    )
+    .await;
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let caller_address = receipt.contract_address.unwrap();
+
+    let trace = get_trace(&wallet, hash).await;
+    assert_eq!(trace.as_array().unwrap().len(), 1);
+    let entry = &trace[0];
+    assert_eq!(entry["type"], "CREATE");
+    assert_eq!(entry["depth"], 0);
+    assert_eq!(
+        entry["from"].as_str().unwrap().parse::<H160>().unwrap(),
+        wallet.address()
+    );
+    assert_eq!(
+        entry["to"].as_str().unwrap().parse::<H160>().unwrap(),
+        caller_address
+    );
+
+    let (hash, _) = deploy_contract(
+        "tests/it/contracts/CallingContract.sol",
+        "Callee",
+        &wallet,
+        &mut network,
+    )
+    .await;
+    let receipt = wallet.get_transaction_receipt(hash).await.unwrap().unwrap();
+    let callee_address = receipt.contract_address.unwrap();
+
+    let data = caller_abi
+        .function("setX")
+        .unwrap()
+        .encode_input(&[Token::Address(callee_address), Token::Uint(123.into())])
+        .unwrap();
+
+    let tx = TransactionRequest::new().to(caller_address).data(data);
+    let hash = wallet.send_transaction(tx, None).await.unwrap().tx_hash();
+    network.run_until_receipt(&wallet, hash, 50).await;
+
+    let trace = get_trace(&wallet, hash).await;
+    assert_eq!(trace.as_array().unwrap().len(), 2);
+    let first = &trace[0];
+    let second = &trace[1];
+    assert_eq!(first["type"], "CALL");
+    assert_eq!(first["depth"], 0);
+    assert_eq!(
+        first["to"].as_str().unwrap().parse::<H160>().unwrap(),
+        caller_address
+    );
+    assert_eq!(second["type"], "CALL");
+    assert_eq!(second["depth"], 1);
+    assert_eq!(
+        second["to"].as_str().unwrap().parse::<H160>().unwrap(),
+        callee_address
+    );
+
+    // TODO: Test Scilla contract
+}


### PR DESCRIPTION
This replays the specified transaction with a custom `Inspector` that produces a trace in the desired format.

I haven't added a test case for creating a Scilla contract yet, because I don't want to slow the test suite down more. :(