### PR TITLE
Add `accepted`, `errors` and `exceptions` to Scilla receipts

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1927,6 +1927,9 @@ impl Consensus {
                 contract_address: result.contract_address,
                 logs: result.logs,
                 gas_used: result.gas_used,
+                accepted: result.accepted,
+                errors: result.errors,
+                exceptions: result.exceptions,
             };
             info!(?receipt, "applied transaction {:?}", receipt);
             block_receipts.push(receipt);

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use anyhow::{anyhow, Result};
 use bytes::{BufMut, BytesMut};
 use k256::{
@@ -19,7 +21,9 @@ use sha3::{
 };
 
 use crate::{
-    crypto, schnorr,
+    crypto,
+    exec::{ScillaError, ScillaException},
+    schnorr,
     state::Address,
     zq1_proto::{Code, Data, Nonce, ProtoTransactionCoreInfo},
 };
@@ -645,6 +649,9 @@ pub struct TransactionReceipt {
     pub gas_used: u64,
     pub contract_address: Option<Address>,
     pub logs: Vec<Log>,
+    pub accepted: Option<bool>,
+    pub errors: BTreeMap<u64, Vec<ScillaError>>,
+    pub exceptions: Vec<ScillaException>,
 }
 
 fn strip_leading_zeroes(bytes: &[u8]) -> &[u8] {


### PR DESCRIPTION
```rust
/// If the transaction was a call to a Scilla contract, whether the called contract accepted the ZIL sent to it.
pub accepted: Option<bool>,
/// Errors from calls to Scilla contracts. Indexed by the call depth of erroring contract.
pub errors: BTreeMap<u64, Vec<ScillaError>>,
/// Exceptions from calls to Scilla contracts.
pub exceptions: Vec<ScillaException>,
```