### PR TITLE
Fix precision of account balances provided to Scilla

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -10,7 +10,9 @@ use crate::{
     schnorr,
     serde_util::num_as_str,
     time::SystemTime,
-    transaction::{ScillaLog, SignedTransaction, TransactionReceipt, VerifiedTransaction},
+    transaction::{
+        ScillaLog, SignedTransaction, TransactionReceipt, VerifiedTransaction, ZilAmount,
+    },
 };
 
 #[derive(Clone, Serialize)]
@@ -88,11 +90,11 @@ pub struct GetTxResponse {
     to_addr: H160,
     sender_pub_key: schnorr::PublicKey,
     #[serde(with = "num_as_str")]
-    amount: u128,
+    amount: ZilAmount,
     signature: schnorr::Signature,
     receipt: GetTxResponseReceipt,
     #[serde(with = "num_as_str")]
-    gas_price: u128,
+    gas_price: ZilAmount,
     #[serde(with = "num_as_str")]
     gas_limit: u64,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -20,7 +20,7 @@ use crate::{
     node::Node,
     schnorr,
     state::{Contract, ScillaValue},
-    transaction::{SignedTransaction, TxZilliqa, VerifiedTransaction},
+    transaction::{SignedTransaction, TxZilliqa, VerifiedTransaction, ZilAmount},
 };
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
@@ -55,10 +55,10 @@ struct TransactionParams {
     nonce: u64,
     to_addr: H160,
     #[serde(deserialize_with = "from_str")]
-    amount: u128,
+    amount: ZilAmount,
     pub_key: String,
     #[serde(deserialize_with = "from_str")]
-    gas_price: u128,
+    gas_price: ZilAmount,
     #[serde(deserialize_with = "from_str")]
     gas_limit: u64,
     #[serde(default)]
@@ -252,7 +252,7 @@ fn get_smart_contract_state(params: Params, node: &Arc<Mutex<Node>>) -> Result<V
     let account = node.get_account(smart_contract_address, BlockNumber::Latest)?;
 
     let mut result = json!({
-        "_balance": account.balance.to_string(),
+        "_balance": ZilAmount::from_amount(account.balance).to_string(),
     });
 
     fn convert(value: ScillaValue) -> Result<Value> {

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -362,7 +362,7 @@ impl State {
 
         let account = Account {
             nonce: 0,
-            balance: txn.amount,
+            balance: txn.amount.get(),
             contract: Contract::Scilla {
                 code: txn.code.clone(),
                 init_data: serde_json::to_string(&init_data)?,
@@ -420,14 +420,14 @@ impl State {
         mut inspector: impl ScillaInspector,
     ) -> Result<TransactionApplyResult> {
         self.mutate_account(from_addr, |from| {
-            from.balance -= txn.amount();
+            from.balance -= txn.amount.get();
             from.nonce += 1;
         })?;
         self.mutate_account(txn.to_addr, |to| {
-            to.balance += txn.amount();
+            to.balance += txn.amount.get();
         })?;
 
-        inspector.transfer(from_addr, txn.to_addr, txn.amount());
+        inspector.transfer(from_addr, txn.to_addr, txn.amount.get());
 
         Ok(TransactionApplyResult {
             success: true,
@@ -494,12 +494,12 @@ impl State {
         self.mutate_account(from_addr, |from| {
             from.nonce += 1;
             if output.accepted {
-                from.balance -= txn.amount();
+                from.balance -= txn.amount.get();
             }
         })?;
         self.mutate_account(txn.to_addr, |to| {
             if output.accepted {
-                to.balance += txn.amount();
+                to.balance += txn.amount.get();
             }
         })?;
 

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -34,6 +34,7 @@ use crate::{
     scilla_proto::{Map, ProtoScillaQuery, ProtoScillaVal, ValType},
     serde_util::{bool_as_str, num_as_str},
     state::{ScillaValue, State},
+    transaction::ZilAmount,
 };
 
 /// The interface to the Scilla interpreter.
@@ -167,7 +168,7 @@ impl Scilla {
         state: State,
         code: &str,
         gas_limit: u64,
-        value: u128,
+        value: ZilAmount,
         init: &[Value],
     ) -> Result<Result<(CreateOutput, H256), ErrorResponse>> {
         let args = vec![
@@ -238,7 +239,7 @@ impl Scilla {
         state: State,
         code: &str,
         gas_limit: u64,
-        value: u128,
+        value: ZilAmount,
         init: &[Value],
         msg: &Value,
     ) -> Result<Result<(InvokeOutput, H256), ErrorResponse>> {
@@ -653,7 +654,8 @@ impl ActiveCall {
         let account = self.state.get_account(addr)?;
         match name.as_str() {
             "_balance" => {
-                let val = scilla_val(format!("\"{}\"", account.balance).into_bytes());
+                let balance = ZilAmount::from_amount(account.balance);
+                let val = scilla_val(format!("\"{balance}\"").into_bytes());
                 Ok(Some((val, "Uint128".to_owned())))
             }
             "_nonce" => {


### PR DESCRIPTION
Previously, when the Scilla interpreter queried an account's balance, we would return the result in units of (10^-18) ZILs. Scilla expects the result in units of (10^-12) ZILs.

To mitigate similar bugs in the future, I have introduced a newtype for quantities of ZIL expressed in units of (10^-12) ZILs: `ZilAmount`. The intention is that we continue to use `u128` in most places (e.g. for internal storage of amounts and for EVM transactions), where we continue to expressed amounts as (10^-18) ZILs. But for places we know we want amounts expressed as (10^-12) ZILs (such as the Zilliqa API requests and responses), we use `ZilAmount` to make that clear. A `ZilAmount` can't be converted to a `u128` without multiplying it by `(10^6)` and vice-versa.