### PR TITLE
Charge gas for Scilla transactions

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -21,7 +21,9 @@ use crate::{
     message::{Block, BlockNumber},
     node::Node,
     state::Address,
-    transaction::{EthSignature, SignedTransaction, Transaction, TxEip1559, TxEip2930, TxLegacy},
+    transaction::{
+        EthSignature, EvmGas, SignedTransaction, Transaction, TxEip1559, TxEip2930, TxLegacy,
+    },
 };
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
@@ -133,7 +135,7 @@ fn estimate_gas(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
         call_params.from,
         call_params.to,
         call_params.data.clone(),
-        call_params.gas.map(|g| g.to()),
+        call_params.gas.map(|g| EvmGas(g.to())),
         call_params.gas_price.map(|g| g.to()),
         call_params.value.to(),
     )?;
@@ -590,7 +592,7 @@ pub(super) fn get_transaction_receipt_inner(
         block_number: block.number(),
         from,
         to: transaction.to_addr(),
-        cumulative_gas_used: 0,
+        cumulative_gas_used: EvmGas(0),
         effective_gas_price: 0,
         gas_used: receipt.gas_used,
         contract_address: receipt.contract_address,
@@ -843,7 +845,7 @@ mod tests {
     use crate::{
         api::eth::{left_pad_arr, parse_transaction},
         crypto::Hash,
-        transaction::{EthSignature, SignedTransaction, TxLegacy, VerifiedTransaction},
+        transaction::{EthSignature, EvmGas, SignedTransaction, TxLegacy, VerifiedTransaction},
     };
 
     #[test]
@@ -858,7 +860,7 @@ mod tests {
                     chain_id: Some(1),
                     nonce: 9,
                     gas_price: 20 * 10_u128.pow(9),
-                    gas_limit: 21000u64,
+                    gas_limit: EvmGas(21000),
                     to_addr: Some("0x3535353535353535353535353535353535353535".parse().unwrap()),
                     amount: 10u128.pow(18),
                     payload: Vec::new(),

--- a/zilliqa/src/api/to_hex.rs
+++ b/zilliqa/src/api/to_hex.rs
@@ -1,5 +1,7 @@
 use primitive_types::{H128, H160, H256, H384, H512, H768, U128, U256, U512};
 
+use crate::transaction::{EvmGas, ScillaGas};
+
 /// A version of [hex::ToHex] which is also implemented for integer types. This version also prefixes the produced
 /// string with `"0x"` and omits leading zeroes for quantities (types with fixed lengths).
 pub trait ToHex {
@@ -53,6 +55,18 @@ impl<T: ToHex> ToHex for &T {
 impl<const N: usize> ToHex for [u8; N] {
     fn to_hex_inner(&self, prefix: bool) -> String {
         self.as_ref().to_hex_inner(prefix)
+    }
+}
+
+impl ToHex for EvmGas {
+    fn to_hex_inner(&self, prefix: bool) -> String {
+        self.0.to_hex_inner(prefix)
+    }
+}
+
+impl ToHex for ScillaGas {
+    fn to_hex_inner(&self, prefix: bool) -> String {
+        self.0.to_hex_inner(prefix)
     }
 }
 

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -7,8 +7,12 @@ use sha3::{Digest, Keccak256};
 
 use super::{bool_as_int, hex, option_hex, vec_hex};
 use crate::{
-    crypto::Hash, exec::BLOCK_GAS_LIMIT, message, state::Address, time::SystemTime,
-    transaction::EvmLog,
+    crypto::Hash,
+    exec::BLOCK_GAS_LIMIT,
+    message,
+    state::Address,
+    time::SystemTime,
+    transaction::{EvmGas, EvmLog},
 };
 
 #[derive(Clone, Serialize)]
@@ -76,9 +80,9 @@ pub struct Header {
     #[serde(serialize_with = "hex")]
     pub extra_data: Vec<u8>,
     #[serde(serialize_with = "hex")]
-    pub gas_limit: u64,
+    pub gas_limit: EvmGas,
     #[serde(serialize_with = "hex")]
-    pub gas_used: u64,
+    pub gas_used: EvmGas,
     #[serde(serialize_with = "hex")]
     pub timestamp: u64,
 }
@@ -101,7 +105,7 @@ impl Header {
             total_difficulty: 0,
             extra_data: vec![],
             gas_limit: BLOCK_GAS_LIMIT,
-            gas_used: 0,
+            gas_used: EvmGas(0),
             timestamp: header
                 .timestamp
                 .duration_since(SystemTime::UNIX_EPOCH)
@@ -122,7 +126,7 @@ pub struct Transaction {
     #[serde(serialize_with = "hex")]
     pub from: H160,
     #[serde(serialize_with = "hex")]
-    pub gas: u64,
+    pub gas: EvmGas,
     #[serde(serialize_with = "hex")]
     pub gas_price: u128,
     #[serde(serialize_with = "option_hex")]
@@ -171,11 +175,11 @@ pub struct TransactionReceipt {
     #[serde(serialize_with = "option_hex")]
     pub to: Option<H160>,
     #[serde(serialize_with = "hex")]
-    pub cumulative_gas_used: u64,
+    pub cumulative_gas_used: EvmGas,
     #[serde(serialize_with = "hex")]
-    pub effective_gas_price: u64,
+    pub effective_gas_price: u128,
     #[serde(serialize_with = "hex")]
-    pub gas_used: u64,
+    pub gas_used: EvmGas,
     #[serde(serialize_with = "option_hex")]
     pub contract_address: Option<H160>,
     pub logs: Vec<Log>,

--- a/zilliqa/src/blockhooks.rs
+++ b/zilliqa/src/blockhooks.rs
@@ -6,7 +6,7 @@ use crate::{
     contracts,
     message::IntershardCall,
     state::{contract_addr, Address},
-    transaction::TransactionReceipt,
+    transaction::{EvmGas, TransactionReceipt},
 };
 
 fn filter_receipts(
@@ -137,7 +137,7 @@ pub fn get_cross_shard_messages(
                     source_chain_id: values.next().unwrap().into_uint().unwrap().as_u64(),
                     bridge_nonce: values.next().unwrap().into_uint().unwrap().as_u64(),
                     calldata: values.next().unwrap().into_bytes().unwrap(),
-                    gas_limit: values.next().unwrap().into_uint().unwrap().as_u64(),
+                    gas_limit: EvmGas(values.next().unwrap().into_uint().unwrap().as_u64()),
                     gas_price: values.next().unwrap().into_uint().unwrap().as_u128(),
                 },
             ))

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -17,7 +17,7 @@ use crate::{
     consensus::Validator,
     crypto::{Hash, NodePublicKey, NodeSignature, SecretKey},
     time::SystemTime,
-    transaction::{SignedTransaction, VerifiedTransaction},
+    transaction::{EvmGas, SignedTransaction, VerifiedTransaction},
 };
 
 pub type BitVec = bitvec::vec::BitVec<u8, Msb0>;
@@ -203,7 +203,7 @@ pub struct BlockBatchResponse {
     pub proposals: Vec<Proposal>,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IntershardCall {
     pub source_address: H160,
     pub target_address: Option<H160>,
@@ -211,7 +211,7 @@ pub struct IntershardCall {
     pub bridge_nonce: u64,
     pub calldata: Vec<u8>,
     pub gas_price: u128,
-    pub gas_limit: u64,
+    pub gas_limit: EvmGas,
 }
 
 /// A message intended to be sent over the network as part of p2p communication.

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -20,7 +20,9 @@ use crate::{
     },
     p2p_node::{LocalMessageTuple, OutboundMessageTuple},
     state::{Account, Address, State},
-    transaction::{SignedTransaction, TransactionReceipt, TxIntershard, VerifiedTransaction},
+    transaction::{
+        EvmGas, SignedTransaction, TransactionReceipt, TxIntershard, VerifiedTransaction,
+    },
 };
 
 #[derive(Debug, Clone)]
@@ -406,7 +408,7 @@ impl Node {
         from_addr: Address,
         to_addr: Option<Address>,
         data: Vec<u8>,
-        gas: Option<u64>,
+        gas: Option<EvmGas>,
         gas_price: Option<u128>,
         value: u128,
     ) -> Result<u64> {

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -207,7 +207,7 @@ mod tests {
         crypto::Hash,
         state::Address,
         transaction::{
-            EthSignature, SignedTransaction, TxIntershard, TxLegacy, VerifiedTransaction,
+            EthSignature, EvmGas, SignedTransaction, TxIntershard, TxLegacy, VerifiedTransaction,
         },
     };
 
@@ -218,7 +218,7 @@ mod tests {
                     chain_id: Some(0),
                     nonce: nonce as u64,
                     gas_price,
-                    gas_limit: 0,
+                    gas_limit: EvmGas(0),
                     to_addr: None,
                     amount: 0,
                     payload: vec![],
@@ -246,7 +246,7 @@ mod tests {
                     bridge_nonce: shard_nonce as u64,
                     source_chain: from_shard as u64,
                     gas_price,
-                    gas_limit: 0,
+                    gas_limit: EvmGas(0),
                     to_addr: None,
                     payload: vec![],
                 },

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -185,15 +185,15 @@ impl State {
         })
     }
 
-    pub fn mutate_account<F: FnOnce(&mut Account)>(
+    pub fn mutate_account<F: FnOnce(&mut Account) -> R, R>(
         &mut self,
         address: Address,
         mutation: F,
-    ) -> Result<()> {
+    ) -> Result<R> {
         let mut account = self.get_account(address)?;
-        mutation(&mut account);
+        let result = mutation(&mut account);
         self.save_account(address, account)?;
-        Ok(())
+        Ok(result)
     }
 
     /// If using this to modify the account, ensure save_account gets called

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeMap,
     fmt::{self, Display, Formatter},
+    ops::{Add, Sub},
     str::FromStr,
 };
 
@@ -139,7 +140,9 @@ impl SignedTransaction {
             SignedTransaction::Eip2930 { tx, .. } => tx.gas_price,
             // We ignore the priority fee and just use the maximum fee.
             SignedTransaction::Eip1559 { tx, .. } => tx.max_fee_per_gas,
-            SignedTransaction::Zilliqa { tx, .. } => tx.gas_price.get(),
+            SignedTransaction::Zilliqa { tx, .. } => {
+                tx.gas_price.get() / (EVM_GAS_PER_SCILLA_GAS as u128)
+            }
             SignedTransaction::Intershard { tx, .. } => tx.gas_price,
         }
     }
@@ -316,17 +319,17 @@ impl Transaction {
             Transaction::Eip1559(TxEip1559 {
                 max_fee_per_gas, ..
             }) => *max_fee_per_gas,
-            Transaction::Zilliqa(t) => t.gas_price.get(),
+            Transaction::Zilliqa(t) => t.gas_price.get() / (EVM_GAS_PER_SCILLA_GAS as u128),
             Transaction::Intershard(TxIntershard { gas_price, .. }) => *gas_price,
         }
     }
 
-    pub fn gas_limit(&self) -> u64 {
+    pub fn gas_limit(&self) -> EvmGas {
         match self {
             Transaction::Legacy(TxLegacy { gas_limit, .. }) => *gas_limit,
             Transaction::Eip2930(TxEip2930 { gas_limit, .. }) => *gas_limit,
             Transaction::Eip1559(TxEip1559 { gas_limit, .. }) => *gas_limit,
-            Transaction::Zilliqa(TxZilliqa { gas_limit, .. }) => *gas_limit,
+            Transaction::Zilliqa(TxZilliqa { gas_limit, .. }) => (*gas_limit).into(),
             Transaction::Intershard(TxIntershard { gas_limit, .. }) => *gas_limit,
         }
     }
@@ -422,7 +425,7 @@ pub struct TxLegacy {
     pub chain_id: Option<u64>,
     pub nonce: u64,
     pub gas_price: u128,
-    pub gas_limit: u64,
+    pub gas_limit: EvmGas,
     pub to_addr: Option<Address>,
     pub amount: u128,
     pub payload: Vec<u8>,
@@ -457,7 +460,7 @@ pub struct TxIntershard {
     pub bridge_nonce: u64,
     pub source_chain: u64,
     pub gas_price: u128,
-    pub gas_limit: u64,
+    pub gas_limit: EvmGas,
     pub to_addr: Option<Address>,
     // Amount intentionally missing: cannot send native amount cross-shard
     pub payload: Vec<u8>,
@@ -480,7 +483,7 @@ pub struct TxEip2930 {
     pub chain_id: u64,
     pub nonce: u64,
     pub gas_price: u128,
-    pub gas_limit: u64,
+    pub gas_limit: EvmGas,
     pub to_addr: Option<Address>,
     pub amount: u128,
     pub payload: Vec<u8>,
@@ -516,7 +519,7 @@ pub struct TxEip1559 {
     pub nonce: u64,
     pub max_priority_fee_per_gas: u128,
     pub max_fee_per_gas: u128,
-    pub gas_limit: u64,
+    pub gas_limit: EvmGas,
     pub to_addr: Option<Address>,
     pub amount: u128,
     pub payload: Vec<u8>,
@@ -552,7 +555,7 @@ pub struct TxZilliqa {
     pub chain_id: u16,
     pub nonce: u64,
     pub gas_price: ZilAmount,
-    pub gas_limit: u64,
+    pub gas_limit: ScillaGas,
     pub to_addr: Address,
     pub amount: ZilAmount,
     pub code: String,
@@ -583,6 +586,14 @@ impl ZilAmount {
     }
 }
 
+impl Add for ZilAmount {
+    type Output = ZilAmount;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        ZilAmount(self.0.checked_add(rhs.0).expect("amount overflow"))
+    }
+}
+
 impl Display for ZilAmount {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
@@ -594,6 +605,95 @@ impl FromStr for ZilAmount {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(Self(u128::from_str(s)?))
+    }
+}
+
+/// Calculate the total price of a given `quantity` of [ScillaGas] at the specified `price`.
+/// Note that the units of the `price` should really be ([ZilAmount] / [ScillaGas])
+pub fn total_scilla_gas_price(quantity: ScillaGas, price: ZilAmount) -> ZilAmount {
+    ZilAmount(
+        (quantity.0 as u128)
+            .checked_mul(price.0)
+            .expect("amount overflow"),
+    )
+}
+
+pub const EVM_GAS_PER_SCILLA_GAS: u64 = 420;
+
+/// A quantity of Scilla gas. This is the currency used to pay for [TxZilliqa] transactions. When EVM gas is converted
+/// to Scilla gas, the quantity is rounded down.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(transparent)]
+pub struct ScillaGas(pub u64);
+
+impl ScillaGas {
+    pub fn checked_sub(self, rhs: ScillaGas) -> Option<ScillaGas> {
+        Some(ScillaGas(self.0.checked_sub(rhs.0)?))
+    }
+}
+
+impl Sub for ScillaGas {
+    type Output = ScillaGas;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        self.checked_sub(rhs).expect("scilla gas underflow")
+    }
+}
+
+impl From<EvmGas> for ScillaGas {
+    fn from(gas: EvmGas) -> Self {
+        ScillaGas(gas.0 / EVM_GAS_PER_SCILLA_GAS)
+    }
+}
+
+impl Display for ScillaGas {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for ScillaGas {
+    type Err = <u64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(u64::from_str(s)?))
+    }
+}
+
+/// A quantity of EVM gas. This is the currency used to pay for EVM transactions.
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(transparent)]
+pub struct EvmGas(pub u64);
+
+impl From<ScillaGas> for EvmGas {
+    fn from(gas: ScillaGas) -> Self {
+        EvmGas(gas.0 * EVM_GAS_PER_SCILLA_GAS)
+    }
+}
+
+impl Display for EvmGas {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for EvmGas {
+    type Err = <u64 as FromStr>::Err;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(u64::from_str(s)?))
+    }
+}
+
+impl rlp::Decodable for EvmGas {
+    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
+        Ok(EvmGas(<u64 as rlp::Decodable>::decode(rlp)?))
+    }
+}
+
+impl rlp::Encodable for EvmGas {
+    fn rlp_append(&self, s: &mut RlpStream) {
+        self.0.rlp_append(s)
     }
 }
 
@@ -672,7 +772,7 @@ pub struct TransactionReceipt {
     pub block_hash: crypto::Hash,
     pub tx_hash: crypto::Hash,
     pub success: bool,
-    pub gas_used: u64,
+    pub gas_used: EvmGas,
     pub contract_address: Option<Address>,
     pub logs: Vec<Log>,
     pub accepted: Option<bool>,
@@ -722,7 +822,7 @@ fn encode_zilliqa_transaction(txn: &TxZilliqa, pub_key: schnorr::PublicKey) -> V
         senderpubkey: Some(pub_key.to_sec1_bytes().into()),
         amount: Some((txn.amount).to_be_bytes().to_vec().into()),
         gasprice: Some((txn.gas_price).to_be_bytes().to_vec().into()),
-        gaslimit: txn.gas_limit,
+        gaslimit: txn.gas_limit.0,
         oneof2: Some(Nonce::Nonce(txn.nonce)),
         oneof8,
         oneof9,

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -65,10 +65,15 @@ async fn send_transaction(
     let wallet = network.random_wallet().await;
     let public_key = secret_key.public_key();
 
+    // Get the gas price via the Zilliqa API.
+    let gas_price: u128 = wallet
+        .provider()
+        .request("GetMinimumGasPrice", ())
+        .await
+        .unwrap();
+
     let chain_id = wallet.get_chainid().await.unwrap().as_u32() - 0x8000;
     let version = (chain_id << 16) | 1u32;
-    // FIXME: This is funky because it gets the price in 10^18 units, rather than 10^12.
-    let gas_price = wallet.get_gas_price().await.unwrap().as_u128();
     let proto = ProtoTransactionCoreInfo {
         version,
         toaddr: to_addr.as_bytes().to_vec(),


### PR DESCRIPTION
I added newtypes for both `EvmGas` and `ScillaGas` to prevent confusion between them and ensure we convert at the correct exchange rate (420:1).
