### PR TITLE
Add 'deployer' tool to perform network upgrades

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Install nightly
       run: rustup toolchain install nightly
     - name: Install dependencies
-      run: sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && sudo apt install -y solc build-essential pkg-config
+      run: sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && sudo apt install -y solc build-essential pkg-config libssl-dev
     - uses: actions/checkout@v4
       with:
         submodules: recursive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,6 +1283,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "deployer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.0",
+ "clap",
+ "colored",
+ "git2",
+ "home",
+ "libc",
+ "log",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "toml",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,6 +2270,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
  "url",
 ]
 
@@ -3128,7 +3149,9 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
 ]
 
@@ -3567,6 +3590,20 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4054,6 +4091,18 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "opentelemetry"
@@ -6166,6 +6215,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,11 @@
 resolver = "2"
 
 members = [
- "eth-trie.rs",
- "zilliqa",
- "zilliqa-macros",
- "z2",
+    "deployer",
+    "eth-trie.rs",
+    "zilliqa",
+    "zilliqa-macros",
+    "z2",
 ]
 
 [workspace.package]

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "deployer"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name="zutils"
+path="src/lib.rs"
+test=false
+
+[dependencies]
+anyhow = { version = "1.0.79", features = ["backtrace"] }
+base64 = "0.22.0"
+clap = { version = "4.4.18", features = ["derive"] }
+colored = "2.1.0"
+git2 = "0.18.1"
+home = "0.5.9"
+libc = "0.2.153"
+log = "0.4.21"
+serde = { version = "1.0.195", features = ["derive"] }
+serde_json = "1.0.113"
+tempfile = "3.9.0"
+tokio = { version = "1.32.0", features = ["full"] }
+toml = "0.8.8"

--- a/deployer/README.md
+++ b/deployer/README.md
@@ -1,0 +1,35 @@
+# ZQ2 deployer
+
+The `deployer` is the `zq2` to go tool for the basic network operations.
+
+It allows us to upgrade `zq2` networks and perform Zilliqa 1.0 to Zilliqa 2.0 persistence conversions.
+
+## How-to upgrade a ZQ2 network
+
+Upgrade Zilliqa 2.0 on GCP requires you to:
+
+ * Log in: `gcloud auth login --update-adc`
+ *  Create the configuration for your network:
+
+    To configure the `deployer`, you need to specify:
+
+    - `zq2_network_name`: string - the network name of the Zilliqa 2.0 network you want to upgrade. This is the value you specified as the label `zq2-network` for your GCP VM. The `deployer` will select all the VMs with that label as the target for the upgrade.
+
+    - `gcp_project`: string - the project ID where your network is running.
+
+    - `gcs_binary_bucket`: string - the GCS bucket used to stage the Zilliqa 2.0 binaries. The `deployer` will build the binary for the specified version and save them in the given `gcs_binary_bucket`. Afterwards, it will connect VM by VM, download that binary, swap the `/zilliqa` with the one downloaded from the bucket before restarting the process.
+
+    ```
+    cargo run --release --bin deployer -- new <zq2_network_name> <gcp_project> <gcs_binary_bucket>
+    ```
+
+    Here an example of the generated configuration file, `<zq2_network_name>.toml`:
+
+    ```toml
+    name = "<zq2_network_name>"
+    version = "main"
+    gcp_project = "<gcp_project>"
+    binary_bucket = "<gcp_binary_bucket>
+    ```
+
+ * Perform the upgrade by running: `cargo run --bin deployer -- upgrade <zq2_network_name>.toml`

--- a/deployer/src/commands.rs
+++ b/deployer/src/commands.rs
@@ -1,0 +1,386 @@
+use std::{collections::HashMap, process::Stdio};
+
+use anyhow::{anyhow, Result};
+use colored::{Color, Colorize};
+use libc;
+use tokio::{
+    io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+    process::{Child, Command},
+};
+
+use crate::utils;
+
+/// Wrapper in case we later want to add stuff to it.
+pub struct ChildProcess {
+    pub child: Child,
+}
+
+// Reap on termination and return the id.
+pub fn reap_on_termination(child: ChildProcess) -> Result<u32> {
+    let id = child
+        .child
+        .id()
+        .ok_or(anyhow!("Could not get child process id"))?;
+    tokio::spawn(async move { child.child.wait_with_output().await });
+    Ok(id)
+}
+
+pub struct CommandOutput {
+    pub success: bool,
+    pub status_code: i32,
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+}
+
+impl CommandOutput {
+    pub fn fake(ok: bool) -> Self {
+        Self {
+            status_code: if ok { 0 } else { 1 },
+            success: ok,
+            stdout: Vec::new(),
+            stderr: Vec::new(),
+        }
+    }
+
+    pub fn success_or(&self, err: &str) -> Result<&Self> {
+        if self.success {
+            Ok(self)
+        } else {
+            // TODO - make this part of the error!
+            self.print();
+            Err(anyhow!("{0}", err))
+        }
+    }
+    pub fn print(&self) {
+        let output = &utils::string_or_empty_from_u8(&self.stdout);
+        let error = &utils::string_or_empty_from_u8(&self.stderr);
+        println!("---------\n{output}\n{error}\n---------\n");
+    }
+    pub fn sanitise_stdout(&self) -> Result<String> {
+        self.sanitise_to_string(&self.stdout)
+    }
+
+    pub fn sanitise_stderr(&self) -> Result<String> {
+        self.sanitise_to_string(&self.stderr)
+    }
+
+    pub fn sanitise_to_string(&self, input: &[u8]) -> Result<String> {
+        let result = utils::string_or_empty_from_u8(input);
+        Ok(result.trim().to_string())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CommandBuilder {
+    cmd: Option<String>,
+    args: Option<Vec<String>>,
+    env: Option<HashMap<String, String>>,
+    cwd: Option<String>,
+    throw_on_failure: bool,
+    display_command: bool,
+    display_str: Option<String>,
+    /// Should this command create a new session?.
+    create_new_session: bool,
+    /// Should we log the output, or return it?
+    logged: bool,
+    color: Option<Color>,
+}
+
+impl Default for CommandBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Second cut at running commands, because the option list was getting waay too long.
+impl CommandBuilder {
+    pub fn new() -> Self {
+        CommandBuilder {
+            cmd: None,
+            args: None,
+            env: None,
+            cwd: None,
+            throw_on_failure: true,
+            display_command: true,
+            display_str: None,
+            create_new_session: false,
+            logged: false,
+            color: None,
+        }
+    }
+
+    pub fn log_output(&mut self) -> &mut Self {
+        self.logged = true;
+        self
+    }
+
+    pub fn display(&mut self, what: &str) -> &mut Self {
+        self.display_str = Some(what.to_string());
+        self
+    }
+
+    pub fn color(&mut self, what: Color) -> &mut Self {
+        self.color = Some(what);
+        self
+    }
+
+    pub fn ignore_failures(&mut self) -> &mut Self {
+        self.throw_on_failure = false;
+        self
+    }
+
+    pub fn throw_on_failure(&mut self) -> &mut Self {
+        self.throw_on_failure = true;
+        self
+    }
+
+    pub fn set_throw_on_failure(&mut self, throw_on_failure: bool) -> &mut Self {
+        self.throw_on_failure = throw_on_failure;
+        self
+    }
+
+    pub fn silent(&mut self) -> &mut Self {
+        self.display_command = false;
+        self
+    }
+
+    pub fn create_new_session(&mut self) -> &mut Self {
+        self.create_new_session = true;
+        self
+    }
+
+    pub fn cmd(&mut self, cmd: &str, args: &[&str]) -> &mut Self {
+        self.cmd = Some(cmd.to_string());
+        self.args = Some(args.iter().map(|x| x.to_string()).collect());
+        self
+    }
+
+    pub fn more_args(&mut self, args: &[&str]) -> &mut Self {
+        let converted_args: Vec<String> = args.iter().map(|x| x.to_string()).collect();
+        match &mut self.args {
+            None => self.args = Some(converted_args),
+            Some(val) => val.extend(converted_args),
+        };
+        self
+    }
+
+    pub fn env_var(&mut self, name: &str, value: &str) -> &mut Self {
+        if let Some(e) = &mut self.env {
+            e.insert(name.to_string(), value.to_string());
+        } else {
+            let mut map = HashMap::<String, String>::new();
+            map.insert(name.to_string(), value.to_string());
+            self.env = Some(map);
+        }
+        self
+    }
+
+    pub fn env(&mut self, env: &HashMap<String, String>) -> &mut Self {
+        self.env = Some(env.clone());
+        self
+    }
+
+    pub fn cwd(&mut self, cwd: &str) -> &mut Self {
+        self.cwd = Some(cwd.to_string());
+        self
+    }
+
+    pub fn describe_command(&self) -> Result<String> {
+        let cmd_name = self
+            .cmd
+            .as_ref()
+            .ok_or(anyhow!("No command specified"))?
+            .clone();
+        let cwd_str = self.cwd.as_ref().map_or("", |x| x.as_str());
+        let mut result = String::new();
+        if let Some(val) = &self.display_str {
+            result.push_str(&format!("[{cwd_str}]$ {val}"));
+        } else {
+            let space_args = if let Some(args) = &self.args {
+                args.join(" ")
+            } else {
+                "".to_string()
+            };
+            result.push_str(&format!("[{cwd_str}]$ {0} {space_args}", &cmd_name));
+        }
+        Ok(result)
+    }
+    /// Common bits of starting a new process.
+    fn make_command(&self) -> Result<Command> {
+        let cmd_name = self
+            .cmd
+            .as_ref()
+            .ok_or(anyhow!("No command specified"))?
+            .clone();
+        let mut cmd = Command::new(cmd_name);
+        if self.display_command {
+            println!("{0}", self.describe_command()?)
+        }
+        if let Some(args) = &self.args {
+            cmd.args(args);
+        }
+        if let Some(env) = &self.env {
+            cmd.envs(env);
+        }
+        if let Some(cwd) = &self.cwd {
+            cmd.current_dir(cwd);
+        }
+        if self.create_new_session {
+            unsafe {
+                cmd.pre_exec(|| {
+                    libc::setsid();
+                    Ok(())
+                });
+            }
+        }
+        Ok(cmd)
+    }
+
+    pub async fn spawn(&self) -> Result<ChildProcess> {
+        let mut cmd = self.make_command()?;
+        let child = cmd.spawn()?;
+        Ok(ChildProcess { child })
+    }
+
+    pub async fn spawn_logged(&self) -> Result<ChildProcess> {
+        self.spawn_logged_with_input(None).await
+    }
+
+    pub async fn spawn_logged_with_input(&self, input: Option<&str>) -> Result<ChildProcess> {
+        let mut cmd = self.make_command()?;
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+        if input.is_some() {
+            cmd.stdin(Stdio::piped());
+        } else {
+            cmd.stdin(Stdio::null());
+        }
+        let mut child = cmd.spawn()?;
+        let output = child
+            .stdout
+            .take()
+            .ok_or(anyhow!("Cannot get process output"))?;
+        let err = child
+            .stderr
+            .take()
+            .ok_or(anyhow!("Cannot get process error"))?;
+        let current_color = self.color;
+        tokio::spawn(async move {
+            let mut out_reader = BufReader::new(output).lines();
+            while let Some(line) = out_reader.next_line().await.unwrap_or(None) {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    let mut real_line = String::new();
+                    real_line.push('\r');
+                    real_line.push('\n');
+                    real_line.push('>');
+                    real_line.push_str(trimmed);
+                    if let Some(color) = current_color {
+                        print!("{}", real_line.color(color));
+                    } else {
+                        let _ = tokio::io::stdout().write_all(real_line.as_bytes()).await;
+                    }
+                }
+            }
+        });
+        tokio::spawn(async move {
+            let mut err_reader = BufReader::new(err).lines();
+            while let Some(line) = err_reader.next_line().await.unwrap_or(None) {
+                let trimmed = line.trim();
+                if !trimmed.is_empty() {
+                    let mut real_line = String::new();
+                    real_line.push('\r');
+                    real_line.push('\n');
+                    real_line.push('!');
+                    real_line.push_str(trimmed);
+                    if let Some(color) = current_color {
+                        print!("{}", real_line.color(color));
+                    } else {
+                        let _ = tokio::io::stdout().write_all(real_line.as_bytes()).await;
+                    }
+                }
+            }
+        });
+        if let Some(val) = input {
+            let mut input = child
+                .stdin
+                .take()
+                .ok_or(anyhow!("Cannot get process input"))?;
+            let val_copy = val.to_string();
+            tokio::spawn(async move {
+                if let Err(errval) = input.write_all(val_copy.as_bytes()).await {
+                    println!("Couldn't write stdin - {0:?}", errval);
+                }
+            });
+        }
+
+        Ok(ChildProcess { child })
+    }
+
+    pub async fn run_logged(&self) -> Result<CommandOutput> {
+        let mut child = self.spawn_logged().await?;
+        let result = child.child.wait().await?;
+        let code = result.code().unwrap_or(-1);
+        if self.throw_on_failure && !result.success() {
+            return Err(anyhow!("Command failed  - {0}", code));
+        }
+        Ok(CommandOutput {
+            success: result.success(),
+            status_code: code,
+            stdout: vec![],
+            stderr: vec![],
+        })
+    }
+
+    pub async fn run(&self) -> Result<CommandOutput> {
+        if self.logged {
+            self.run_logged().await
+        } else {
+            self.run_for_output().await
+        }
+    }
+
+    pub async fn run_logged_with_input(&self, indata: &str) -> Result<()> {
+        let mut proc = self.spawn_logged_with_input(Some(indata)).await?;
+        proc.child.wait().await?;
+        Ok(())
+    }
+
+    pub async fn run_for_output(&self) -> Result<CommandOutput> {
+        let mut cmd = self.make_command()?;
+        let out = cmd.output().await?;
+        let result_code = if let Some(val) = out.status.code() {
+            val
+        } else {
+            -1
+        };
+        if self.throw_on_failure && !out.status.success() {
+            let output = &utils::string_or_empty_from_u8(&out.stdout);
+            let error = &utils::string_or_empty_from_u8(&out.stderr);
+            return Err(anyhow!("Command failed - {result_code}\n{output}\n{error}"));
+        }
+        Ok(CommandOutput {
+            success: out.status.success(),
+            status_code: result_code,
+            stdout: out.stdout,
+            stderr: out.stderr,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct BackgroundCommand {
+    pub running: Child,
+}
+
+impl BackgroundCommand {
+    pub fn new(cmd: &str, args: Vec<&str>, env: Option<&HashMap<String, String>>) -> Result<Self> {
+        let result: Child;
+        if let Some(env_tbl) = env {
+            result = Command::new(cmd).args(args).envs(env_tbl).spawn()?;
+        } else {
+            result = Command::new(cmd).args(args).spawn()?;
+        }
+        Ok(BackgroundCommand { running: result })
+    }
+}

--- a/deployer/src/lib.rs
+++ b/deployer/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod commands;
+pub mod utils;

--- a/deployer/src/main.rs
+++ b/deployer/src/main.rs
@@ -1,0 +1,264 @@
+#![allow(unused_imports)]
+
+use std::{
+    fs,
+    path::PathBuf,
+    process::{self, Stdio},
+};
+
+use anyhow::{anyhow, Result};
+use clap::{Parser, Subcommand};
+use git2::Repository;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[derive(Parser)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    New {
+        name: String,
+        gcp_project: String,
+        binary_bucket: String,
+    },
+    Upgrade {
+        config_file: PathBuf,
+    },
+}
+
+#[derive(Deserialize, Serialize)]
+struct NetworkConfig {
+    name: String,
+    version: String,
+    gcp_project: String,
+    binary_bucket: String,
+}
+
+impl NetworkConfig {
+    fn new(name: String, gcp_project: String, binary_bucket: String) -> Self {
+        Self {
+            name,
+            version: "main".to_owned(),
+            gcp_project,
+            binary_bucket,
+        }
+    }
+}
+
+async fn get_local_block_number(project: &str, instance: &str, zone: &str) -> Result<u64> {
+    let inner_command = r#"curl -s http://localhost:4201 -X POST -H 'content-type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"eth_blockNumber"}'"#;
+    let output = zutils::commands::CommandBuilder::new()
+        .cmd(
+            "gcloud",
+            &[
+                "--project",
+                &project,
+                "compute",
+                "ssh",
+                "--ssh-flag=-o StrictHostKeyChecking=no",
+                &instance,
+                "--tunnel-through-iap",
+                "--zone",
+                &zone,
+                "--command",
+                &inner_command,
+            ],
+        )
+        .run()
+        .await?;
+
+    if !output.success {
+        return Err(anyhow!(
+            "getting local block number failed: {:?}",
+            output.stderr
+        ));
+    }
+
+    let response: Value = serde_json::from_slice(&output.stdout)?;
+    let block_number = response
+        .get("result")
+        .ok_or_else(|| anyhow!("response has no result"))?
+        .as_str()
+        .ok_or_else(|| anyhow!("result is not a string"))?
+        .strip_prefix("0x")
+        .ok_or_else(|| anyhow!("result does not start with 0x"))?;
+    let block_number = u64::from_str_radix(block_number, 16)?;
+
+    Ok(block_number)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Command::New {
+            name,
+            gcp_project,
+            binary_bucket,
+        } => {
+            let config = NetworkConfig::new(name.clone(), gcp_project, binary_bucket);
+            let config = toml::to_string_pretty(&config)?;
+            fs::write(format!("{name}.toml"), config)?;
+        }
+        Command::Upgrade { config_file } => {
+            let config = fs::read_to_string(config_file)?;
+            let config: NetworkConfig = toml::from_str(&config)?;
+
+            // Checkout Zilliqa 2 source
+            let repo_dir: TempDir = TempDir::new()?;
+            let repo = Repository::clone("https://github.com/Zilliqa/zq2", repo_dir.path())?;
+            let (object, _) = repo
+                .revparse_ext(&format!("origin/{}", config.version))
+                .or_else(|_| repo.revparse_ext(&config.version))?;
+            repo.checkout_tree(&object, None)?;
+
+            let binary_name = format!("zilliqa_{}", object.id());
+            let binary_location = format!("gs://{}/{binary_name}", config.binary_bucket);
+
+            // Check if binary already exists
+            let status = process::Command::new("gsutil")
+                .args(["-q", "stat"])
+                .arg(&binary_location)
+                .status()?;
+            if !status.success() {
+                println!("Building binary");
+
+                // Build binary
+                let status = process::Command::new("cross")
+                    .args([
+                        "build",
+                        "--target",
+                        "x86_64-unknown-linux-gnu",
+                        "--profile",
+                        "release",
+                        "--bin",
+                        "zilliqa",
+                    ])
+                    .current_dir(repo_dir.path())
+                    .status()?;
+                if !status.success() {
+                    return Err(anyhow!("build failed"));
+                }
+
+                println!("Binary built, uploading to GCS");
+
+                // Upload binary to GCS
+                let binary = repo_dir
+                    .path()
+                    .join("target")
+                    .join("x86_64-unknown-linux-gnu")
+                    .join("release")
+                    .join("zilliqa");
+                let status = process::Command::new("gcloud")
+                    .arg("--project")
+                    .arg(&config.gcp_project)
+                    .args(["storage", "cp"])
+                    .arg(binary)
+                    .arg(&binary_location)
+                    .status()?;
+                if !status.success() {
+                    return Err(anyhow!("upload failed"));
+                }
+
+                println!("Binary uploaded to GCS");
+            } else {
+                println!("Binary already exists in GCS");
+            }
+
+            // Get the list of instances we need to update.
+            let output = process::Command::new("gcloud")
+                .arg("--project")
+                .arg(&config.gcp_project)
+                .args(["compute", "instances", "list"])
+                .args(["--format", "json"])
+                .args(["--filter", &format!("labels.zq2-network={}", config.name)])
+                .output()?;
+            if !output.status.success() {
+                return Err(anyhow!("listing instances failed"));
+            }
+            let output: Value = serde_json::from_slice(&output.stdout)?;
+            let instances: Vec<_> = output
+                .as_array()
+                .ok_or_else(|| anyhow!("instances is not an array"))?
+                .iter()
+                .map(|i| {
+                    let name = i
+                        .get("name")
+                        .ok_or_else(|| anyhow!("name is missing"))?
+                        .as_str()
+                        .ok_or_else(|| anyhow!("name is not a string"))?;
+                    let zone = i
+                        .get("zone")
+                        .ok_or_else(|| anyhow!("zone is missing"))?
+                        .as_str()
+                        .ok_or_else(|| anyhow!("zone is not a string"))?;
+                    Ok((name, zone))
+                })
+                .collect::<Result<_>>()?;
+
+            if instances.is_empty() {
+                println!("No instances found");
+            }
+
+            for (instance, zone) in instances {
+                println!("Upgrading instance {instance}");
+
+                let inner_command = format!(
+                    r#"
+                    sudo gcloud storage cp {binary_location} /{binary_name} &&
+                    sudo chmod +x /{binary_name} &&
+                    sudo rm /zilliqa &&
+                    sudo ln -s /{binary_name} /zilliqa &&
+                    sudo systemctl restart zilliqa.service
+                "#
+                );
+                let output = zutils::commands::CommandBuilder::new()
+                    .cmd(
+                        "gcloud",
+                        &[
+                            "--project",
+                            &config.gcp_project,
+                            "compute",
+                            "ssh",
+                            "--ssh-flag=-o StrictHostKeyChecking=no",
+                            &instance,
+                            "--tunnel-through-iap",
+                            "--zone",
+                            &zone,
+                            "--command",
+                            &inner_command,
+                        ],
+                    )
+                    .run()
+                    .await?;
+                if !output.success {
+                    println!("{:?}", output.stderr);
+                    return Err(anyhow!("upgrade failed"));
+                }
+
+                // Check the node is making progress
+                let first_block_number =
+                    get_local_block_number(&config.gcp_project, instance, zone).await?;
+                loop {
+                    let next_block_number =
+                        get_local_block_number(&config.gcp_project, instance, zone).await?;
+                    println!(
+                        "Polled block number at {next_block_number}, waiting for {} more blocks",
+                        (first_block_number + 10).saturating_sub(next_block_number)
+                    );
+                    if next_block_number >= first_block_number + 10 {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/deployer/src/utils.rs
+++ b/deployer/src/utils.rs
@@ -1,0 +1,79 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, Result};
+use base64::prelude::*;
+use home;
+use log::error;
+
+/// Get a string from a u8
+pub fn string_or_empty_from_u8(in_val: &[u8]) -> String {
+    let result: &str = if let Ok(val) = std::str::from_utf8(in_val) {
+        val
+    } else {
+        "<not_representable>"
+    };
+    result.to_string()
+}
+
+/// Get string from path
+pub fn string_from_path(in_path: &Path) -> Result<String> {
+    Ok(in_path
+        .as_os_str()
+        .to_str()
+        .ok_or(anyhow!("Cannot convert path to string"))?
+        .to_string())
+}
+
+/// Get an environment variable and returns None whether not set
+pub fn get_env_variable(var_name: &str) -> Option<String> {
+    match env::var(var_name) {
+        Ok(value) => Some(value),
+        Err(_) => None,
+    }
+}
+
+/// Remove a suffix from a string, or return the original
+pub fn remove_suffix<'a>(in_string: &'a str, suffix: &str) -> &'a str {
+    if let Some(result) = in_string.strip_suffix(suffix) {
+        result
+    } else {
+        in_string
+    }
+}
+
+pub fn relative_home_path_str(val: &str) -> Result<String> {
+    let path = relative_home_path(val)?;
+    string_from_path(&path)
+}
+
+pub fn relative_home_path(val: &str) -> Result<PathBuf> {
+    let mut home_path = home::home_dir().ok_or(anyhow!("Can't get your home directory"))?;
+    home_path.push(val);
+    Ok(home_path)
+}
+
+/// Log an error and re-propagate
+pub fn with_error_logged<T>(result: Result<T>) -> Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) => {
+            let error_message = &error;
+            error!("{error_message}");
+            Err(error)
+        }
+    }
+}
+
+pub fn decode_base64(value: &str) -> Option<String> {
+    BASE64_STANDARD
+        .decode(value)
+        .ok()
+        .and_then(|bytes| String::from_utf8(bytes).ok())
+}
+
+pub fn encode_base64(value: &str) -> String {
+    BASE64_STANDARD.encode(value)
+}


### PR DESCRIPTION
Currently we have two commands:

* `new <name> <gcp_project> <gcs_bucket>` creates the TOML configuration file for a network. This is used by other commands and intended to be checked into git somewhere.
* `upgrade <config_file>` upgrades a network, based on the values from the configuration file. It will build a ZQ2 binary at the configured revision, upload it to GCS and upgrade the binaries on each VM instance.