### PR TITLE
Implement `GetSmartContracts`

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -259,3 +259,9 @@ pub struct BlockchainInfo {
 pub struct ShardingStructure {
     pub num_peers: Vec<u16>,
 }
+
+#[derive(Clone, Serialize)]
+pub struct SmartContract {
+    #[serde(serialize_with = "hex_no_prefix")]
+    pub address: H160,
+}


### PR DESCRIPTION
This API returns the list of smart contracts deployed by a given account.

I have chosen to replicate the ZQ1 implementation and exclude EVM contracts, but maybe we should include them? In this case, should we just include direct creations or also creations via other contracts?