### PR TITLE
(fix): deployer cross compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,8 +2270,6 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
- "openssl-probe",
- "openssl-sys",
  "url",
 ]
 
@@ -3149,9 +3147,7 @@ checksum = "ee4126d8b4ee5c9d9ea891dd875cfdc1e9d0950437179104b183d7d8a74d24e8"
 dependencies = [
  "cc",
  "libc",
- "libssh2-sys",
  "libz-sys",
- "openssl-sys",
  "pkg-config",
 ]
 
@@ -3590,20 +3586,6 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.5.0",
  "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc8a030b787e2119a731f1951d6a773e2280c660f8ec4b0f5e1505a386e71ee"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -4091,18 +4073,6 @@ name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -6215,7 +6185,6 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -10,17 +10,18 @@ name="zutils"
 path="src/lib.rs"
 test=false
 
+
 [dependencies]
 anyhow = { version = "1.0.79", features = ["backtrace"] }
 base64 = "0.22.0"
 clap = { version = "4.4.18", features = ["derive"] }
 colored = "2.1.0"
-git2 = "0.18.1"
+git2 = { version = "0.18.1", default-features=false }
 home = "0.5.9"
 libc = "0.2.153"
 log = "0.4.21"
 serde = { version = "1.0.195", features = ["derive"] }
 serde_json = "1.0.113"
 tempfile = "3.9.0"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "sync", "io-std", "io-util", "process", "fs"] }
 toml = "0.8.8"


### PR DESCRIPTION
Removes the openssl-sys dependency from the git2 crate making the deployer cross-compilation working.