### PR TITLE
Fix field name in `GetBlockchainInfo` response

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -242,6 +242,7 @@ pub struct BlockchainInfo {
     pub num_transactions: u64,
     pub transaction_rate: f64,
     pub tx_block_rate: f64,
+    #[serde(rename = "DSBlockRate")]
     pub ds_block_rate: f64,
     #[serde(with = "num_as_str")]
     pub current_mini_epoch: u64,


### PR DESCRIPTION
Previously we returned `DsBlockRate`, but the capitalisation is sadly inconsistent in the existing API and we need to return `DSBlockRate`.