### PR TITLE
Fix formatting in `GetTransaction` response

### DIFF
--- a/zilliqa/src/api/to_hex.rs
+++ b/zilliqa/src/api/to_hex.rs
@@ -46,7 +46,7 @@ macro_rules! int_impl {
     };
 }
 
-impl<T: ToHex> ToHex for &T {
+impl<T: ToHex + ?Sized> ToHex for &T {
     fn to_hex_inner(&self, prefix: bool) -> String {
         (*self).to_hex_inner(prefix)
     }


### PR DESCRIPTION
* `version` should be a string.
* `senderPubKey` should be a compressed SEC1 encoed point.
* `signature` should be prefixed with `0x`.