### PR TITLE
Fix the z2 perf async transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,7 @@ for details.
 
 Automated bootstrap of a 4 nodes Zilliqa 2.0 aka zq2 network.
 
-Build the images first:
-
-```bash
-docker build . -t zq2-node0
-```
-
-Then run:
+Run:
 
 ```bash
 docker-compose up
@@ -50,11 +44,22 @@ docker-compose up
 ## Testing
 
 The tests can be run with `cargo test`.
-Most tests create an in-memory network of nodes, with the libp2p networking layer stubbed out and send API requests to
-the network.
+Most tests create an in-memory network of nodes, with the libp2p networking layer stubbed out and send API requests to the network.
 
 Some tests involve compiling Solidity code.
 `svm-rs` will automatically download and use a suitable version for your platform when you run these tests.
+
+To install `svm-rs` run:
+
+```
+cargo install svm-rs
+```
+
+Then you can install a suitable Solc version by executing:
+
+```
+svm install <solc version>
+```
 
 ## Logging
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     environment:
       RUST_BACKTRACE: 1
       RUST_LOG: zilliqa=info,opentelemetry=trace,opentelemetry_otlp=trace
+    image: zq2-node0
     build:
       context: .
       dockerfile: Dockerfile

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -272,3 +272,31 @@ pub struct SmartContract {
     #[serde(serialize_with = "hex_no_prefix")]
     pub address: H160,
 }
+
+#[derive(Clone, Debug)]
+pub enum RPCErrorCode {
+    // Standard JSON-RPC 2.0 errors
+    // RPC_INVALID_REQUEST is internally mapped to HTTP_BAD_REQUEST (400).
+    // It should not be used for application-layer errors.
+    RpcInvalidRequest = -32600,
+    // RPC_METHOD_NOT_FOUND is internally mapped to HTTP_NOT_FOUND (404).
+    // It should not be used for application-layer errors.
+    RpcMethodNotFound = -32601,
+    RpcInvalidParams = -32602,
+    // RPC_INTERNAL_ERROR should only be used for genuine errors in bitcoind
+    // (for example datadir corruption).
+    RpcInternalError = -32603,
+    RpcParseError = -32700,
+
+    // General application defined errors
+    RpcMiscError = -1,             // std::exception thrown in command handling
+    RpcTypeError = -3,             // Unexpected type was passed as parameter
+    RpcInvalidAddressOrKey = -5,   // Invalid address or key
+    RpcInvalidParameter = -8,      // Invalid, missing or duplicate parameter
+    RpcDatabaseError = -20,        // Database error
+    RpcDeserializationError = -22, // Error parsing or validating structure in raw format
+    RpcVerifyError = -25,          // General error during transaction or block submission
+    RpcVerifyRejected = -26,       // Transaction or block was rejected by network rules
+    RpcInWarmup = -28,             // Client still warming up
+    RpcMethodDeprecated = -32,     // RPC method is deprecated
+}

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -103,6 +103,7 @@ pub struct TxBlockHeader {
 pub struct GetTxResponse {
     #[serde(rename = "ID", serialize_with = "hex_no_prefix")]
     id: H256,
+    #[serde(with = "num_as_str")]
     version: u32,
     #[serde(with = "num_as_str")]
     nonce: u64,


### PR DESCRIPTION
- Added JSON RPC Error codes as defined in ZQ1.
- Now, when "Txn Hash not Present" is encountered in the `GetTransaction` function, it returns the error code -20 (RpcDatabaseError). This ensures consistency with ZQ1 SDK to receive the same error code.
- The `version` value returned by `GetTransactionResponse` is converted to a string. This is also fixed by the https://github.com/Zilliqa/zq2/pull/885.
- Some minor doc and docker-compose build fix