### PR TITLE
feat(z2): print a note when you run z2 directly

### DIFF
--- a/scripts/setenv
+++ b/scripts/setenv
@@ -1,0 +1,9 @@
+set -x
+if [[ "$SHELL" == *"zsh"* ]] ; then
+   echo "Running on $SHELL ..."
+   BASEDIR=$(dirname "$0")/../
+else
+    BASEDIR=$(dirname "$BASH_SOURCE")/../
+fi
+REALPATH=$(realpath "$BASEDIR")
+export PATH=$REALPATH/scripts:$PATH

--- a/z2/README.md
+++ b/z2/README.md
@@ -1,0 +1,17 @@
+# Z2
+
+`z2` is the a CLI-based utility for Zilliqa 2 network operations.
+
+To use it:
+
+* Pick a directory. Let's call it `/my/dir`.
+* Clone `git@github.com:zilliqa/zq2` into that directory to get `/my/dir/zq2`.
+* Source the `scripts/setenv`.
+* This will give you access to the `z2` tool in [z2](../z2/) (This directory!).
+
+To-Do:
+
+[] Add the documentation for `z2 run`.
+[] Add the documentation for `z2 perf`.
+[] Add the documentation about `z2 deployer`.
+[] Import the `deployer-converter`.

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -118,16 +118,17 @@ impl fmt::Display for LogLevel {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let cli = Cli::parse();
     // Work out the base directory
     let base_dir = match env::var("ZQ2_BASE") {
         Ok(val) => val,
         _ => {
             return Err(anyhow!(
-                "Please define ZQ2_BASE or run bin/z2 from the checked out zq2 repository"
+                "Please run scripts/z2 from the checked out zq2 repository which sets ZQ2_BASE"
             ))
         }
     };
+    let cli = Cli::parse();
+
     match &cli.command {
         Commands::Run(ref arg) => {
             let mut to_run: HashSet<plumbing::Components> = HashSet::new();


### PR DESCRIPTION
`z2` prints a note advising to run it using `scripts/z2` for resource accessibility.
Add a `z2` README.md and `setenv` setup.