### PR TITLE
Replace `primitive_types` with `alloy-primitives`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,16 +91,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy-consensus"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#af788afe934d4c54ec1fcb6bb4b16ce385f913ab"
+dependencies = [
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#af788afe934d4c54ec1fcb6bb4b16ce385f913ab"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "c-kzg",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "alloy-primitives"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c715249705afa1e32be79dabfd35e2ef0f1cc02ad2cf48c9d1e20026ee637b"
+checksum = "525448f6afc1b70dd0f9d0a8145631bf2f5e434678ab23ab18409ca264cae6b3"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
+ "getrandom",
  "hex-literal",
  "itoa",
  "k256",
@@ -118,8 +146,30 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d58d9f5da7b40e9bfff0b7e7816700be4019db97d4b6359fe7f94a9e22e42ac"
 dependencies = [
+ "alloy-rlp-derive",
  "arrayvec",
  "bytes",
+]
+
+[[package]]
+name = "alloy-rlp-derive"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a047897373be4bbb0224c1afdabca92648dc57a9c9ef6e7b0be3aff7a859c83"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git#af788afe934d4c54ec1fcb6bb4b16ce385f913ab"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1713,11 +1763,10 @@ dependencies = [
 name = "eth_trie"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "criterion",
- "ethereum-types",
  "hashbrown 0.14.5",
  "hex",
- "keccak-hash",
  "log",
  "parking_lot 0.12.2",
  "rand",
@@ -3416,16 +3465,6 @@ checksum = "bb8515fff80ed850aea4a1595f2e519c003e2a00a82fe168ebf5269196caf444"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
-]
-
-[[package]]
-name = "keccak-hash"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b286e6b663fb926e1eeb68528e69cb70ed46c6d65871a21b2215ae8154c6d3c"
-dependencies = [
- "primitive-types",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -8095,6 +8134,7 @@ dependencies = [
 name = "z2"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "async-trait",
  "clap",
@@ -8164,6 +8204,10 @@ dependencies = [
 name = "zilliqa"
 version = "0.1.0"
 dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-primitives",
+ "alloy-rlp",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -8201,8 +8245,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "revm",
- "rlp",
- "ruint",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/eth-trie.rs/Cargo.toml
+++ b/eth-trie.rs/Cargo.toml
@@ -9,17 +9,17 @@ readme = "README.md"
 keywords = ["patricia", "mpt", "evm", "trie", "ethereum"]
 
 [dependencies]
+alloy-primitives = { version = "0.7.2", features = ["rlp"] }
 hashbrown = "0.14.5"
-keccak-hash = "0.10.0"
 log = "0.4.21"
 parking_lot = "0.12.2"
 rlp = "0.5.2"
 
 [dev-dependencies]
+alloy-primitives = { version = "0.7.2", features = ["getrandom"] }
 rand = "0.8.5"
 hex = "0.4.3"
 criterion = "0.5.1"
-ethereum-types = "0.14.1"
 uuid = { version = "1.8.0", features = ["serde", "v4"] }
 
 [[bench]]

--- a/eth-trie.rs/src/errors.rs
+++ b/eth-trie.rs/src/errors.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt};
 
-use keccak_hash::H256;
+use alloy_primitives::B256;
 use rlp::DecoderError;
 
 use crate::nibbles::Nibbles;
@@ -12,9 +12,9 @@ pub enum TrieError {
     InvalidData,
     InvalidProof,
     MissingTrieNode {
-        node_hash: H256,
+        node_hash: B256,
         traversed: Option<Nibbles>,
-        root_hash: Option<H256>,
+        root_hash: Option<B256>,
         err_key: Option<Vec<u8>>,
     },
 }

--- a/eth-trie.rs/src/node.rs
+++ b/eth-trie.rs/src/node.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use keccak_hash::H256;
+use alloy_primitives::B256;
 
 use crate::nibbles::Nibbles;
 
@@ -29,7 +29,7 @@ impl Node {
         Node::Extension(ext)
     }
 
-    pub fn from_hash(hash: H256) -> Self {
+    pub fn from_hash(hash: B256) -> Self {
         let hash_node = Arc::new(HashNode { hash });
         Node::Hash(hash_node)
     }
@@ -70,7 +70,7 @@ pub struct ExtensionNode {
 
 #[derive(Debug)]
 pub struct HashNode {
-    pub hash: H256,
+    pub hash: B256,
 }
 
 pub fn empty_children() -> [Node; 16] {

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -21,6 +21,7 @@ test = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+alloy-primitives = "0.7.2"
 anyhow = "1.0.82"
 async-trait = "0.1.80"
 clap = { version = "4.5.4", features = ["derive"] }

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -1,6 +1,7 @@
 //use serde::{Deserialize, Serialize};
-use std::{path::PathBuf, str::FromStr};
+use std::path::PathBuf;
 
+use alloy_primitives::{address, Address};
 use anyhow::{anyhow, Result};
 use libp2p::PeerId;
 use tokio::fs;
@@ -8,7 +9,7 @@ use toml;
 /// This module should eventually generate configuration files
 /// For now, it just generates secret keys (which should be different each run, or we will become dependent on their values)
 use zilliqa::crypto::SecretKey;
-use zilliqa::{cfg, crypto::NodePublicKey, state::Address};
+use zilliqa::{cfg, crypto::NodePublicKey};
 
 use crate::{
     collector::{self, Collector},
@@ -139,12 +140,12 @@ impl Setup {
 
         let genesis_accounts: Vec<(Address, String)> = vec![
             (
-                Address::from_str("7E5F4552091A69125d5DfCb7b8C2659029395Bdf")?,
+                address!("7E5F4552091A69125d5DfCb7b8C2659029395Bdf"),
                 "5000000000000000000000".to_string(),
             ),
             // privkey db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3
             (
-                Address::from_str("0xcb57ec3f064a16cadb36c7c712f4c9fa62b77415")?,
+                address!("cb57ec3f064a16cadb36c7c712f4c9fa62b77415"),
                 "5000000000000000000000".to_string(),
             ),
         ];

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -24,6 +24,8 @@ anyhow = { version = "1.0.81", features = ["backtrace"] }
 vergen = { version = "8.3.1", features = ["git", "git2"] }
 
 [dependencies]
+alloy-primitives = { version = "0.7.2", features = ["rlp", "serde"] }
+alloy-rlp = { version = "0.3.4", features = ["derive"] }
 anyhow = { version = "1.0.81", features = ["backtrace"] }
 async-trait = "0.1.80"
 base64 = "0.22.1"
@@ -51,14 +53,11 @@ opentelemetry = { version = "0.21.0", features = ["metrics"] }
 opentelemetry_sdk = { version = "0.21.2", features = ["rt-tokio"] }
 opentelemetry-otlp = { version = "0.14.0", features = ["metrics"] }
 paste = "1.0.14"
-primitive-types = { version = "0.12.2", features = ["serde"] }
 prost = "0.12.4"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 revm = { version = "8.0.0", features = ["optional_balance_check"] }
-rlp = "0.5.2"
-ruint = { version = "1.12.1", features = ["serde"] }
 serde = { version = "1.0.200", features = ["derive", "rc"] }
 serde_bytes = "0.11.14"
 serde_json = { version = "1.0.115", features = ["raw_value"] }
@@ -74,13 +73,17 @@ tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", version = "0.1.0", features = ["serde", "k256"] }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", version = "0.1.0", features = ["serde"] }
 
 [dev-dependencies]
+alloy-primitives = { version = "0.7.2", features = ["rand"] }
 async-trait = "0.1.80"
 ethers = { version = "2.0.14", default-features = false, features = ["ethers-solc", "legacy"] }
 ethers-solc = { version = "2.0.13", features = ["svm-solc"] }
 fs_extra = "1.3.0"
 indicatif = "0.17.8"
+primitive-types = { version = "0.12.2" }
 ureq = "2.9.7"
 zilliqa = { path = ".", default-features = false, features = ["fake_time"] }
 zilliqa-macros = { path = "../zilliqa-macros" }

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -532,13 +532,13 @@ pub(super) fn get_transaction_receipt_inner(
     hash: Hash,
     node: &MutexGuard<Node>,
 ) -> Result<Option<eth::TransactionReceipt>> {
-    let Some(signed_transaction) = dbg!(node.get_transaction_by_hash(hash))? else {
+    let Some(signed_transaction) = node.get_transaction_by_hash(hash)? else {
         warn!("Failed to get TX by hash when getting TX receipt! {}", hash);
         return Ok(None);
     };
     // TODO: Return error if receipt or block does not exist.
 
-    let Some(receipt) = dbg!(node.get_transaction_receipt(hash))? else {
+    let Some(receipt) = node.get_transaction_receipt(hash)? else {
         warn!("Failed to get TX receipt when getting TX receipt! {}", hash);
         return Ok(None);
     };
@@ -548,7 +548,7 @@ pub(super) fn get_transaction_receipt_inner(
         hash, receipt
     );
 
-    let Some(block) = dbg!(node.get_block_by_hash(receipt.block_hash))? else {
+    let Some(block) = node.get_block_by_hash(receipt.block_hash)? else {
         warn!("Failed to get block when getting TX receipt! {}", hash);
         return Ok(None);
     };

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -2,13 +2,15 @@
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
+use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy};
+use alloy_eips::eip2930::AccessList;
+use alloy_primitives::{Address, Bytes, Parity, Signature, TxKind, B256, U256, U64};
+use alloy_rlp::{Decodable, Header};
 use anyhow::{anyhow, Result};
 use itertools::{Either, Itertools};
 use jsonrpsee::{
     core::StringError, types::Params, PendingSubscriptionSink, RpcModule, SubscriptionMessage,
 };
-use primitive_types::{H160, H256, U256};
-use rlp::Rlp;
 use serde::Deserialize;
 use tracing::*;
 
@@ -20,10 +22,7 @@ use crate::{
     crypto::Hash,
     message::{Block, BlockNumber},
     node::Node,
-    state::Address,
-    transaction::{
-        EthSignature, EvmGas, SignedTransaction, Transaction, TxEip1559, TxEip2930, TxLegacy,
-    },
+    transaction::{EvmGas, SignedTransaction, Transaction},
 };
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
@@ -145,7 +144,7 @@ fn estimate_gas(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 
 fn get_balance(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     let mut params = params.sequence();
-    let address: H160 = params.next()?;
+    let address: Address = params.next()?;
     let block_number: BlockNumber = params.next()?;
 
     Ok(node
@@ -158,7 +157,7 @@ fn get_balance(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 fn get_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     trace!("get_code: params: {:?}", params);
     let mut params = params.sequence();
-    let address: H160 = params.next()?;
+    let address: Address = params.next()?;
     let block_number: BlockNumber = params.next()?;
 
     Ok(node
@@ -174,13 +173,10 @@ fn get_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 fn get_storage_at(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     trace!("get_storage_at: params: {:?}", params);
     let mut params = params.sequence();
-    let address: H160 = params.next()?;
+    let address: Address = params.next()?;
     let position: U256 = params.next()?;
+    let position = B256::new(position.to_be_bytes());
     let block_number: BlockNumber = params.next()?;
-
-    let mut position_bytes = [0; 32];
-    position.to_big_endian(&mut position_bytes);
-    let position = H256::from_slice(&position_bytes);
 
     let value = node
         .lock()
@@ -193,7 +189,7 @@ fn get_storage_at(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     trace!("get_transaction_count: params: {:?}", params);
     let mut params = params.sequence();
-    let address: H160 = params.next()?;
+    let address: Address = params.next()?;
     let block_number: BlockNumber = params.next()?;
 
     trace!(
@@ -232,7 +228,7 @@ fn get_block_by_number(params: Params, node: &Arc<Mutex<Node>>) -> Result<Option
 
 fn get_block_by_hash(params: Params, node: &Arc<Mutex<Node>>) -> Result<Option<eth::Block>> {
     let mut params = params.sequence();
-    let hash: H256 = params.next()?;
+    let hash: B256 = params.next()?;
     let full: bool = params.next()?;
 
     let node = node.lock().unwrap();
@@ -271,7 +267,7 @@ fn get_block_transaction_count_by_hash(
     params: Params,
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<String>> {
-    let hash: H256 = params.one()?;
+    let hash: B256 = params.one()?;
 
     let node = node.lock().unwrap();
     let block = node.get_block_by_hash(Hash(hash.0))?;
@@ -298,7 +294,7 @@ fn get_block_transaction_count_by_number(
 struct GetLogsParams {
     from_block: Option<BlockNumber>,
     to_block: Option<BlockNumber>,
-    address: Option<OneOrMany<H160>>,
+    address: Option<OneOrMany<Address>>,
     /// Topics matches a prefix of the list of topics from each log. An empty element slice matches any topic. Non-empty
     /// elements represent an alternative that matches any of the contained topics.
     ///
@@ -308,8 +304,8 @@ struct GetLogsParams {
     /// * `[[], [B]]` or `[None, [B]]`  matches any topic in first position AND B in second position
     /// * `[[A], [B]]`                  matches topic A in first position AND B in second position
     /// * `[[A, B], [C, D]]`            matches topic (A OR B) in first position AND (C OR D) in second position
-    topics: Vec<OneOrMany<H256>>,
-    block_hash: Option<H256>,
+    topics: Vec<OneOrMany<B256>>,
+    block_hash: Option<B256>,
 }
 
 fn get_logs(params: Params, node: &Arc<Mutex<Node>>) -> Result<Vec<eth::Log>> {
@@ -411,8 +407,8 @@ fn get_transaction_by_block_hash_and_index(
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<eth::Transaction>> {
     let mut params = params.sequence();
-    let block_hash: H256 = params.next()?;
-    let index: ruint::aliases::U64 = params.next()?;
+    let block_hash: B256 = params.next()?;
+    let index: U64 = params.next()?;
 
     let node = node.lock().unwrap();
 
@@ -432,7 +428,7 @@ fn get_transaction_by_block_number_and_index(
 ) -> Result<Option<eth::Transaction>> {
     let mut params = params.sequence();
     let block_number: BlockNumber = params.next()?;
-    let index: ruint::aliases::U64 = params.next()?;
+    let index: U64 = params.next()?;
 
     let node = node.lock().unwrap();
 
@@ -451,7 +447,7 @@ fn get_transaction_by_hash(
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<eth::Transaction>> {
     trace!("get_transaction_by_hash: params: {:?}", params);
-    let hash: H256 = params.one()?;
+    let hash: B256 = params.one()?;
     let hash: Hash = Hash(hash.0);
     let node = node.lock().unwrap();
 
@@ -506,7 +502,7 @@ pub(super) fn get_transaction_inner(
         gas_price,
         max_fee_per_gas,
         max_priority_fee_per_gas,
-        hash: H256(hash.0),
+        hash: hash.into(),
         input: transaction.payload().to_vec(),
         nonce: transaction.nonce().unwrap_or(u64::MAX),
         to: transaction.to_addr(),
@@ -536,13 +532,13 @@ pub(super) fn get_transaction_receipt_inner(
     hash: Hash,
     node: &MutexGuard<Node>,
 ) -> Result<Option<eth::TransactionReceipt>> {
-    let Some(signed_transaction) = node.get_transaction_by_hash(hash)? else {
+    let Some(signed_transaction) = dbg!(node.get_transaction_by_hash(hash))? else {
         warn!("Failed to get TX by hash when getting TX receipt! {}", hash);
         return Ok(None);
     };
     // TODO: Return error if receipt or block does not exist.
 
-    let Some(receipt) = node.get_transaction_receipt(hash)? else {
+    let Some(receipt) = dbg!(node.get_transaction_receipt(hash))? else {
         warn!("Failed to get TX receipt when getting TX receipt! {}", hash);
         return Ok(None);
     };
@@ -552,7 +548,7 @@ pub(super) fn get_transaction_receipt_inner(
         hash, receipt
     );
 
-    let Some(block) = node.get_block_by_hash(receipt.block_hash)? else {
+    let Some(block) = dbg!(node.get_block_by_hash(receipt.block_hash))? else {
         warn!("Failed to get block when getting TX receipt! {}", hash);
         return Ok(None);
     };
@@ -586,9 +582,9 @@ pub(super) fn get_transaction_receipt_inner(
     let from = signed_transaction.signer;
     let transaction = signed_transaction.tx.into_transaction();
     let receipt = eth::TransactionReceipt {
-        transaction_hash: H256(hash.0),
+        transaction_hash: hash.into(),
         transaction_index: transaction_index as u64,
-        block_hash: H256(block.hash().0),
+        block_hash: block.hash().into(),
         block_number: block.number(),
         from,
         to: transaction.to_addr(),
@@ -610,8 +606,8 @@ fn get_transaction_receipt(
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<eth::TransactionReceipt>> {
     trace!("get_transaction_receipt: params: {:?}", params);
-    let hash: H256 = params.one()?;
-    let hash: Hash = Hash(hash.0);
+    let hash: B256 = params.one()?;
+    let hash: Hash = hash.into();
     let node = node.lock().unwrap();
     get_transaction_receipt_inner(hash, &node)
 }
@@ -632,7 +628,7 @@ fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<Strin
         }
     }
 
-    let transaction_hash = H256(node.lock().unwrap().create_transaction(transaction)?.0);
+    let transaction_hash = B256::from(node.lock().unwrap().create_transaction(transaction)?);
 
     Ok(transaction_hash.to_hex())
 }
@@ -643,9 +639,9 @@ fn parse_transaction(bytes: &[u8]) -> Result<SignedTransaction> {
     // If it starts with a value in the range [0, 0x7f] then it is a new transaction type, if it starts with a value in
     // the range [0xc0, 0xfe] then it is a legacy transaction type."
     match bytes[0] {
-        0xc0..=0xfe => parse_legacy_transaction(Rlp::new(bytes)),
-        0x01 => parse_eip2930_transaction(Rlp::new(&bytes[1..])),
-        0x02 => parse_eip1559_transaction(Rlp::new(&bytes[1..])),
+        0xc0..=0xfe => parse_legacy_transaction(bytes),
+        0x01 => parse_eip2930_transaction(&bytes[1..]),
+        0x02 => parse_eip1559_transaction(&bytes[1..]),
         _ => Err(anyhow!(
             "invalid transaction with starting byte {}",
             bytes[0]
@@ -653,97 +649,82 @@ fn parse_transaction(bytes: &[u8]) -> Result<SignedTransaction> {
     }
 }
 
-fn parse_legacy_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
-    let nonce = rlp.val_at(0)?;
-    let gas_price = rlp.val_at(1)?;
-    let gas_limit = rlp.val_at(2)?;
-    let to_addr = rlp.val_at::<Vec<u8>>(3)?;
-    let amount = rlp.val_at(4)?;
-    let payload = rlp.val_at(5)?;
-    let v = rlp.val_at::<u64>(6)?;
-    let r = left_pad_arr(&rlp.val_at::<Vec<_>>(7)?)?;
-    let s = left_pad_arr(&rlp.val_at::<Vec<_>>(8)?)?;
+fn parse_legacy_transaction(mut buf: &[u8]) -> Result<SignedTransaction> {
+    let mut bytes = Header::decode_bytes(&mut buf, true)?;
 
-    // If `v` is greater than `35`, then this is an EIP-155 value which includes the chain ID. If not, it must
-    // be set to either `27` or `28`.
-    let (y_is_odd, chain_id) = if v >= 35 {
-        // The last bit of `v - 35` tells us whether Y is odd; the other bits tell us the chain ID.
-        ((v - 35) % 2 != 0, Some((v - 35) / 2))
-    } else if v == 27 {
-        (false, None)
-    } else if v == 28 {
-        (true, None)
-    } else {
-        return Err(anyhow!("invalid signature with v={v}"));
-    };
+    let nonce = u64::decode(&mut bytes)?;
+    let gas_price = u128::decode(&mut bytes)?;
+    let gas_limit = u128::decode(&mut bytes)?;
+    let to = TxKind::decode(&mut bytes)?;
+    let value = U256::decode(&mut bytes)?;
+    let input = Bytes::decode(&mut bytes)?;
+    let v = u64::decode(&mut bytes)?;
+    let r = U256::decode(&mut bytes)?;
+    let s = U256::decode(&mut bytes)?;
 
-    let sig = EthSignature { r, s, y_is_odd };
+    let sig = Signature::from_rs_and_parity(r, s, v)?;
 
     let tx = TxLegacy {
-        chain_id,
+        chain_id: sig.v().chain_id(),
         nonce,
         gas_price,
         gas_limit,
-        to_addr: (!to_addr.is_empty()).then(|| Address::from_slice(&to_addr)),
-        amount,
-        payload,
+        to,
+        value,
+        input,
     };
 
     Ok(SignedTransaction::Legacy { tx, sig })
 }
 
-fn parse_eip2930_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
-    let chain_id = rlp.val_at(0)?;
-    let nonce = rlp.val_at(1)?;
-    let gas_price = rlp.val_at(2)?;
-    let gas_limit = rlp.val_at(3)?;
-    let to_addr = rlp.val_at::<Vec<u8>>(4)?;
-    let amount = rlp.val_at(5)?;
-    let payload = rlp.val_at(6)?;
-    let access_list = rlp
-        .at(7)?
-        .iter()
-        .map(|rlp| Ok((rlp.val_at::<H160>(0)?, rlp.list_at::<H256>(1)?)))
-        .collect::<Result<Vec<_>>>()?;
-    let y_is_odd = rlp.val_at::<bool>(8)?;
-    let r = left_pad_arr(&rlp.val_at::<Vec<_>>(9)?)?;
-    let s = left_pad_arr(&rlp.val_at::<Vec<_>>(10)?)?;
+fn parse_eip2930_transaction(mut buf: &[u8]) -> Result<SignedTransaction> {
+    let mut bytes = Header::decode_bytes(&mut buf, true)?;
 
-    let sig = EthSignature { r, s, y_is_odd };
+    let chain_id = u64::decode(&mut bytes)?;
+    let nonce = u64::decode(&mut bytes)?;
+    let gas_price = u128::decode(&mut bytes)?;
+    let gas_limit = u128::decode(&mut bytes)?;
+    let to = TxKind::decode(&mut bytes)?;
+    let value = U256::decode(&mut bytes)?;
+    let input = Bytes::decode(&mut bytes)?;
+    let access_list = AccessList::decode(&mut bytes)?;
+    let y_is_odd = bool::decode(&mut bytes)?;
+    let r = U256::decode(&mut bytes)?;
+    let s = U256::decode(&mut bytes)?;
+
+    let sig = Signature::from_rs_and_parity(r, s, Parity::Parity(y_is_odd))?;
 
     let tx = TxEip2930 {
         chain_id,
         nonce,
         gas_price,
         gas_limit,
-        to_addr: (!to_addr.is_empty()).then(|| Address::from_slice(&to_addr)),
-        amount,
-        payload,
+        to,
+        value,
+        input,
         access_list,
     };
 
     Ok(SignedTransaction::Eip2930 { tx, sig })
 }
 
-fn parse_eip1559_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
-    let chain_id = rlp.val_at(0)?;
-    let nonce = rlp.val_at(1)?;
-    let max_priority_fee_per_gas = rlp.val_at(2)?;
-    let max_fee_per_gas = rlp.val_at(3)?;
-    let gas_limit = rlp.val_at(4)?;
-    let to_addr = rlp.val_at::<Vec<u8>>(5)?;
-    let amount = rlp.val_at(6)?;
-    let payload = rlp.val_at(7)?;
-    let access_list = rlp
-        .at(8)?
-        .iter()
-        .map(|rlp| Ok((rlp.val_at::<H160>(0)?, rlp.list_at::<H256>(1)?)))
-        .collect::<Result<Vec<_>>>()?;
-    let y_is_odd = rlp.val_at::<bool>(9)?;
-    let r = left_pad_arr(&rlp.val_at::<Vec<_>>(10)?)?;
-    let s = left_pad_arr(&rlp.val_at::<Vec<_>>(11)?)?;
+fn parse_eip1559_transaction(mut buf: &[u8]) -> Result<SignedTransaction> {
+    let mut bytes = Header::decode_bytes(&mut buf, true)?;
 
-    let sig = EthSignature { r, s, y_is_odd };
+    let chain_id = u64::decode(&mut bytes)?;
+    let nonce = u64::decode(&mut bytes)?;
+    let max_priority_fee_per_gas = u128::decode(&mut bytes)?;
+    let max_fee_per_gas = u128::decode(&mut bytes)?;
+    let gas_limit = u128::decode(&mut bytes)?;
+    let to = TxKind::decode(&mut bytes)?;
+    let value = U256::decode(&mut bytes)?;
+    let input = Bytes::decode(&mut bytes)?;
+    let access_list = AccessList::decode(&mut bytes)?;
+    let y_is_odd = bool::decode(&mut bytes)?;
+    let r = U256::decode(&mut bytes)?;
+    let s = U256::decode(&mut bytes)?;
+
+    let sig = Signature::from_rs_and_parity(r, s, Parity::Parity(y_is_odd))?;
 
     let tx = TxEip1559 {
         chain_id,
@@ -751,33 +732,13 @@ fn parse_eip1559_transaction(rlp: Rlp<'_>) -> Result<SignedTransaction> {
         max_priority_fee_per_gas,
         max_fee_per_gas,
         gas_limit,
-        to_addr: (!to_addr.is_empty()).then(|| Address::from_slice(&to_addr)),
-        amount,
-        payload,
+        to,
+        value,
+        input,
         access_list,
     };
 
     Ok(SignedTransaction::Eip1559 { tx, sig })
-}
-
-fn left_pad_arr<const N: usize>(v: &[u8]) -> Result<[u8; N]> {
-    let mut arr = [0; N];
-
-    if v.len() > arr.len() {
-        return Err(anyhow!(
-            "invalid length: {}, expected: {}",
-            v.len(),
-            arr.len()
-        ));
-    }
-
-    if !v.is_empty() && v[0] == 0 {
-        return Err(anyhow!("unnecessary leading zero"));
-    }
-
-    let start = arr.len() - v.len();
-    arr[start..].copy_from_slice(v);
-    Ok(arr)
 }
 
 fn get_uncle_count(_: Params, _: &Arc<Mutex<Node>>) -> Result<String> {
@@ -836,66 +797,4 @@ async fn subscribe(
     }
 
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use primitive_types::U256;
-
-    use crate::{
-        api::eth::{left_pad_arr, parse_transaction},
-        crypto::Hash,
-        transaction::{EthSignature, EvmGas, SignedTransaction, TxLegacy, VerifiedTransaction},
-    };
-
-    #[test]
-    fn test_transaction_from_rlp() {
-        // From https://github.com/ethereum/EIPs/blob/master/EIPS/eip-155.md#example
-        let transaction = hex::decode("f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83").unwrap();
-        let signed_tx = parse_transaction(&transaction).unwrap();
-        let recovered_tx = signed_tx.verify().unwrap();
-        let expected = VerifiedTransaction {
-            tx: SignedTransaction::Legacy {
-                tx: TxLegacy {
-                    chain_id: Some(1),
-                    nonce: 9,
-                    gas_price: 20 * 10_u128.pow(9),
-                    gas_limit: EvmGas(21000),
-                    to_addr: Some("0x3535353535353535353535353535353535353535".parse().unwrap()),
-                    amount: 10u128.pow(18),
-                    payload: Vec::new(),
-                },
-                sig: EthSignature {
-                    r: U256::from_dec_str("18515461264373351373200002665853028612451056578545711640558177340181847433846").unwrap().into(),
-                    s: U256::from_dec_str("46948507304638947509940763649030358759909902576025900602547168820602576006531").unwrap().into(),
-                    y_is_odd: false,
-                },
-            },
-            signer: "0x9d8A62f656a8d1615C1294fd71e9CFb3E4855A4F".parse().unwrap(),
-            hash: Hash::from_bytes(hex::decode("33469b22e9f636356c4160a87eb19df52b7412e8eac32a4a55ffe88ea8350788").unwrap()).unwrap(),
-        };
-        assert_eq!(recovered_tx, expected);
-    }
-
-    #[test]
-    fn test_left_pad_arr() {
-        let cases = [
-            ("", Ok([0; 4])),
-            ("01", Ok([0, 0, 0, 1])),
-            ("ffffffff", Ok([255; 4])),
-            ("ffffffffff", Err("invalid length: 5, expected: 4")),
-            ("0001", Err("unnecessary leading zero")),
-        ];
-
-        for (val, expected) in cases {
-            let vec = hex::decode(val).unwrap();
-            let actual = left_pad_arr(&vec);
-
-            match (expected, actual) {
-                (Ok(e), Ok(a)) => assert_eq!(e, a),
-                (Err(e), Err(a)) => assert_eq!(e, a.to_string()),
-                _ => panic!("case failed: {val}"),
-            }
-        }
-    }
 }

--- a/zilliqa/src/api/to_hex.rs
+++ b/zilliqa/src/api/to_hex.rs
@@ -1,4 +1,4 @@
-use primitive_types::{H128, H160, H256, H384, H512, H768, U128, U256, U512};
+use alloy_primitives::{Address, B128, B256, B512, U128, U256, U512};
 
 use crate::transaction::{EvmGas, ScillaGas};
 
@@ -74,12 +74,10 @@ as_ref_impl!(str);
 as_ref_impl!(String);
 as_ref_impl!([u8]);
 as_ref_impl!(Vec<u8>);
-as_ref_impl!(H128);
-as_ref_impl!(H160);
-as_ref_impl!(H256);
-as_ref_impl!(H384);
-as_ref_impl!(H512);
-as_ref_impl!(H768);
+as_ref_impl!(B128);
+as_ref_impl!(Address);
+as_ref_impl!(B256);
+as_ref_impl!(B512);
 
 int_impl!(i8);
 int_impl!(i16);
@@ -101,7 +99,7 @@ int_impl!(U512);
 mod tests {
     use std::assert_eq;
 
-    use primitive_types::U128;
+    use alloy_primitives::U128;
 
     use super::ToHex;
 
@@ -133,8 +131,8 @@ mod tests {
     #[test]
     fn test_big_int_to_hex() {
         let cases = [
-            (U128::zero(), "0x0"),
-            (256.into(), "0x100"),
+            (U128::ZERO, "0x0"),
+            (256u64.try_into().unwrap(), "0x100"),
             (U128::MAX, "0xffffffffffffffffffffffffffffffff"),
         ];
 

--- a/zilliqa/src/api/types/ots.rs
+++ b/zilliqa/src/api/types/ots.rs
@@ -1,4 +1,4 @@
-use primitive_types::{H160, H256};
+use alloy_primitives::{Address, B256};
 use serde::Serialize;
 
 use super::{eth, hex, option_hex};
@@ -10,21 +10,21 @@ pub struct Block {
     #[serde(serialize_with = "hex")]
     number: u64,
     #[serde(serialize_with = "hex")]
-    hash: H256,
+    hash: B256,
     #[serde(serialize_with = "hex")]
-    parent_hash: H256,
+    parent_hash: B256,
     #[serde(serialize_with = "hex")]
     nonce: u64,
     #[serde(serialize_with = "hex")]
-    sha_3_uncles: H256,
+    sha_3_uncles: B256,
     #[serde(serialize_with = "hex")]
-    transactions_root: H256,
+    transactions_root: B256,
     #[serde(serialize_with = "hex")]
-    state_root: H256,
+    state_root: B256,
     #[serde(serialize_with = "hex")]
-    receipts_root: H256,
+    receipts_root: B256,
     #[serde(serialize_with = "hex")]
-    miner: H160,
+    miner: Address,
     #[serde(serialize_with = "hex")]
     difficulty: u64,
     #[serde(serialize_with = "hex")]
@@ -40,7 +40,7 @@ pub struct Block {
     #[serde(serialize_with = "hex")]
     timestamp: u64,
     transaction_count: usize,
-    uncles: Vec<H256>,
+    uncles: Vec<B256>,
     #[serde(serialize_with = "hex")]
     base_fee_per_gas: u64,
 }
@@ -63,7 +63,7 @@ pub struct BlockDetails {
 }
 
 impl BlockDetails {
-    pub fn from_block(block: &message::Block, miner: H160) -> Self {
+    pub fn from_block(block: &message::Block, miner: Address) -> Self {
         BlockDetails {
             block: Block::from_block(block, miner),
             issuance: BlockIssuance {
@@ -88,17 +88,17 @@ pub struct BlockIssuance {
 }
 
 impl Block {
-    pub fn from_block(block: &message::Block, miner: H160) -> Self {
+    pub fn from_block(block: &message::Block, miner: Address) -> Self {
         // TODO(#79): Lots of these fields are empty/zero and shouldn't be.
         Block {
             number: block.number(),
-            hash: H256(block.hash().0),
-            parent_hash: H256(block.parent_hash().0),
+            hash: block.hash().into(),
+            parent_hash: block.parent_hash().into(),
             nonce: 0,
-            sha_3_uncles: H256::zero(),
-            transactions_root: H256::zero(),
-            state_root: H256(block.state_root_hash().0),
-            receipts_root: H256::zero(),
+            sha_3_uncles: B256::ZERO,
+            transactions_root: B256::ZERO,
+            state_root: block.state_root_hash().into(),
+            receipts_root: B256::ZERO,
             miner,
             difficulty: 0,
             total_difficulty: 0,
@@ -150,9 +150,9 @@ pub struct TraceEntry {
     pub ty: TraceEntryType,
     pub depth: u64,
     #[serde(serialize_with = "hex")]
-    pub from: H160,
+    pub from: Address,
     #[serde(serialize_with = "hex")]
-    pub to: H160,
+    pub to: Address,
     #[serde(serialize_with = "option_hex")]
     pub value: Option<u128>,
     #[serde(serialize_with = "hex")]
@@ -176,9 +176,9 @@ pub struct Operation {
     #[serde(rename = "type")]
     pub ty: OperationType,
     #[serde(serialize_with = "hex")]
-    pub from: H160,
+    pub from: Address,
     #[serde(serialize_with = "hex")]
-    pub to: H160,
+    pub to: Address,
     #[serde(serialize_with = "hex")]
     pub value: u128,
 }

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,12 +1,10 @@
 use std::time::Duration;
 
+use alloy_primitives::Address;
 use libp2p::{Multiaddr, PeerId};
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    crypto::{Hash, NodePublicKey},
-    state::Address,
-};
+use crate::crypto::{Hash, NodePublicKey};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default, deny_unknown_fields)]

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1274,10 +1274,12 @@ impl Consensus {
     }
 
     pub fn get_transaction_by_hash(&self, hash: Hash) -> Result<Option<VerifiedTransaction>> {
-        Ok(dbg!(dbg!(self.db.get_transaction(&dbg!(hash)))?
-            .map(|tx| dbg!(tx.verify()))
-            .transpose())?
-        .or_else(|| self.transaction_pool.get_transaction(hash).cloned()))
+        Ok(self
+            .db
+            .get_transaction(&hash)?
+            .map(|tx| tx.verify())
+            .transpose()?
+            .or_else(|| self.transaction_pool.get_transaction(hash).cloned()))
     }
 
     pub fn get_transaction_receipt(&self, hash: &Hash) -> Result<Option<TransactionReceipt>> {

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -6,18 +6,16 @@
 
 use std::fmt::Display;
 
+use alloy_primitives::{Address, B256};
 use anyhow::{anyhow, Result};
 use bls12_381::{G1Projective, G2Affine};
 use bls_signatures::Serialize as BlsSerialize;
 use k256::ecdsa::{signature::hazmat::PrehashVerifier, Signature as EcdsaSignature, VerifyingKey};
-use primitive_types::H256;
 use serde::{
     de::{self, Unexpected},
     Deserialize, Serialize,
 };
 use sha3::{Digest, Keccak256};
-
-use crate::state::Address;
 
 /// The signature type used internally in consensus, to e.g. sign block proposals.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -293,9 +291,15 @@ impl Hash {
     }
 }
 
-impl From<H256> for Hash {
-    fn from(value: H256) -> Self {
-        Self(value.into())
+impl From<B256> for Hash {
+    fn from(value: B256) -> Self {
+        Self(value.0)
+    }
+}
+
+impl From<Hash> for B256 {
+    fn from(value: Hash) -> Self {
+        Self(value.0)
     }
 }
 

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
+use alloy_primitives::Address;
 use anyhow::Result;
-use primitive_types::H160;
 use sled::{Batch, Tree};
 
 use crate::{
@@ -200,16 +200,15 @@ impl Db {
             .transpose()
     }
 
-    pub fn add_touched_address(&self, address: H160, txn_hash: Hash) -> Result<()> {
-        self.touched_address
-            .merge(address.as_bytes(), txn_hash.as_bytes())?;
+    pub fn add_touched_address(&self, address: Address, txn_hash: Hash) -> Result<()> {
+        self.touched_address.merge(address, txn_hash.as_bytes())?;
         Ok(())
     }
 
-    pub fn get_touched_addresses(&self, address: H160) -> Result<Vec<Hash>> {
+    pub fn get_touched_addresses(&self, address: Address) -> Result<Vec<Hash>> {
         Ok(self
             .touched_address
-            .get(address.as_bytes())?
+            .get(address)?
             .map(|b| b.chunks_exact(Hash::LEN).map(Hash::from_bytes).collect())
             .transpose()?
             .unwrap_or_default())

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -8,10 +8,10 @@ use std::{
     sync::Arc,
 };
 
+use alloy_primitives::{Address, U256};
 use anyhow::{anyhow, Result};
 use eth_trie::Trie;
 use ethabi::Token;
-use primitive_types::{H160, H256, U256};
 use revm::{
     inspector_handle_register,
     primitives::{
@@ -33,7 +33,7 @@ use crate::{
     message::BlockHeader,
     precompiles::get_custom_precompiles,
     scilla,
-    state::{contract_addr, Account, Address, Contract, ScillaValue, State},
+    state::{contract_addr, Account, Contract, ScillaValue, State},
     time::SystemTime,
     transaction::{
         total_scilla_gas_price, EvmGas, Log, ScillaGas, ScillaParam, Transaction, TxZilliqa,
@@ -110,19 +110,14 @@ impl Error for DatabaseError {
 impl Database for &State {
     type Error = DatabaseError;
 
-    fn basic(
-        &mut self,
-        address: revm::primitives::Address,
-    ) -> Result<Option<AccountInfo>, Self::Error> {
-        let address = H160(address.into_array());
-
+    fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         if !self.has_account(address)? {
             return Ok(None);
         }
 
         let account = self.get_account(address)?;
         let account_info = AccountInfo {
-            balance: revm::primitives::U256::from(account.balance),
+            balance: U256::from(account.balance),
             nonce: account.nonce,
             code_hash: KECCAK_EMPTY,
             code: Some(Bytecode {
@@ -138,20 +133,15 @@ impl Database for &State {
         unimplemented!()
     }
 
-    fn storage(
-        &mut self,
-        address: revm::primitives::Address,
-        index: revm::primitives::U256,
-    ) -> Result<revm::primitives::U256, Self::Error> {
-        let address = H160(address.into_array());
-        let index = H256(index.to_be_bytes());
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        let index = B256::new(index.to_be_bytes());
 
         let result = self.get_account_storage(address, index)?;
 
-        Ok(revm::primitives::U256::from_be_bytes(result.0))
+        Ok(U256::from_be_bytes(result.0))
     }
 
-    fn block_hash(&mut self, _number: revm::primitives::U256) -> Result<B256, Self::Error> {
+    fn block_hash(&mut self, _number: U256) -> Result<B256, Self::Error> {
         // TODO
         Ok(B256::ZERO)
     }
@@ -176,7 +166,7 @@ impl State {
         override_address: Option<Address>,
     ) -> Result<Address> {
         let ResultAndState { result, mut state } = self.apply_transaction_evm(
-            H160::zero(),
+            Address::ZERO,
             None,
             GAS_PRICE,
             BLOCK_GAS_LIMIT,
@@ -194,7 +184,7 @@ impl State {
                 ..
             } => {
                 let addr = if let Some(override_address) = override_address {
-                    let override_address = revm::primitives::Address::from(override_address.0);
+                    let override_address = Address::from(override_address.0);
                     let account = state
                         .remove(&addr)
                         .ok_or_else(|| anyhow!("deployment did not change the contract account"))?;
@@ -205,7 +195,7 @@ impl State {
                 };
 
                 self.apply_delta_evm(state)?;
-                Ok(H160(addr.into_array()))
+                Ok(addr)
             }
             ExecutionResult::Success { .. } => {
                 Err(anyhow!("deployment did not create a transaction"))
@@ -232,18 +222,18 @@ impl State {
         let mut evm = Evm::builder()
             .with_db(self)
             .with_block_env(BlockEnv {
-                number: revm::primitives::U256::from(current_block.number),
-                coinbase: revm::primitives::Address::ZERO,
-                timestamp: revm::primitives::U256::from(
+                number: U256::from(current_block.number),
+                coinbase: Address::ZERO,
+                timestamp: U256::from(
                     current_block
                         .timestamp
                         .duration_since(SystemTime::UNIX_EPOCH)
                         .unwrap_or_default()
                         .as_secs(),
                 ),
-                gas_limit: revm::primitives::U256::from(BLOCK_GAS_LIMIT.0),
-                basefee: revm::primitives::U256::from(GAS_PRICE),
-                difficulty: revm::primitives::U256::from(1),
+                gas_limit: U256::from(BLOCK_GAS_LIMIT.0),
+                basefee: U256::from(GAS_PRICE),
+                difficulty: U256::from(1),
                 prevrandao: Some(B256::ZERO),
                 blob_excess_gas_and_price: None,
             })
@@ -261,11 +251,11 @@ impl State {
             .with_tx_env(TxEnv {
                 caller: from_addr.0.into(),
                 gas_limit: gas_limit.0,
-                gas_price: revm::primitives::U256::from(gas_price),
+                gas_price: U256::from(gas_price),
                 transact_to: to_addr
                     .map(|a| TransactTo::call(a.0.into()))
                     .unwrap_or_else(TransactTo::create),
-                value: revm::primitives::U256::from(amount),
+                value: U256::from(amount),
                 data: payload.clone().into(),
                 nonce,
                 chain_id: Some(chain_id),
@@ -290,7 +280,7 @@ impl State {
 
     fn apply_transaction_scilla(
         &mut self,
-        from_addr: H160,
+        from_addr: Address,
         current_block: BlockHeader,
         txn: TxZilliqa,
         inspector: impl ScillaInspector,
@@ -330,7 +320,7 @@ impl State {
     #[track_caller]
     fn deduct_from_account(
         &mut self,
-        addr: H160,
+        addr: Address,
         amount: ZilAmount,
     ) -> Result<Option<TransactionApplyResult>> {
         let caller = std::panic::Location::caller();
@@ -357,7 +347,7 @@ impl State {
 
     fn scilla_create(
         &mut self,
-        from_addr: H160,
+        from_addr: Address,
         txn: TxZilliqa,
         current_block: BlockHeader,
         mut inspector: impl ScillaInspector,
@@ -510,7 +500,7 @@ impl State {
 
     fn scilla_transfer_to_eoa(
         &mut self,
-        from_addr: H160,
+        from_addr: Address,
         txn: TxZilliqa,
         mut inspector: impl ScillaInspector,
     ) -> Result<TransactionApplyResult> {
@@ -554,7 +544,7 @@ impl State {
 
     fn scilla_call(
         &mut self,
-        from_addr: H160,
+        from_addr: Address,
         txn: TxZilliqa,
         mut inspector: impl ScillaInspector,
     ) -> Result<TransactionApplyResult> {
@@ -705,20 +695,14 @@ impl State {
                     ..
                 } = result
                 {
-                    c.map(|a| H160(a.into_array()))
+                    c
                 } else {
                     None
                 },
                 logs: result
                     .logs()
                     .iter()
-                    .map(|l| {
-                        Log::evm(
-                            H160(l.address.into_array()),
-                            l.topics().iter().map(|t| H256(t.0)).collect(),
-                            l.data.data.to_vec(),
-                        )
-                    })
+                    .map(|l| Log::evm(l.address, l.topics().to_vec(), l.data.data.to_vec()))
                     .collect(),
                 gas_used: EvmGas(result.gas_used()),
                 output: match result {
@@ -740,19 +724,17 @@ impl State {
     /// Applies a state delta from an EVM execution to the state.
     pub(crate) fn apply_delta_evm(
         &mut self,
-        state: revm::primitives::HashMap<revm::primitives::Address, revm::primitives::Account>,
+        state: revm::primitives::HashMap<Address, revm::primitives::Account>,
     ) -> Result<()> {
         for (address, account) in state {
-            let address = H160(address.into_array());
-
             let mut storage = self.get_account_trie(address)?;
 
             for (index, value) in account.changed_storage_slots() {
-                let index = H256(index.to_be_bytes());
-                let value = H256(value.present_value().to_be_bytes());
+                let index = B256::new(index.to_be_bytes());
+                let value = B256::new(value.present_value().to_be_bytes());
                 trace!(?address, ?index, ?value, "update storage");
 
-                storage.insert(&Self::account_storage_key(address, index), value.as_bytes())?;
+                storage.insert(&Self::account_storage_key(address, index), value.as_slice())?;
             }
 
             let account = Account {
@@ -782,7 +764,7 @@ impl State {
         let data = contracts::deposit::GET_STAKERS.encode_input(&[])?;
 
         let stakers = self.call_contract(
-            Address::zero(),
+            Address::ZERO,
             Some(contract_addr::DEPOSIT),
             data,
             0,
@@ -810,7 +792,7 @@ impl State {
             contracts::deposit::GET_STAKE.encode_input(&[Token::Bytes(public_key.as_bytes())])?;
 
         let stake = self.call_contract(
-            Address::zero(),
+            Address::ZERO,
             Some(contract_addr::DEPOSIT),
             data,
             0,
@@ -820,7 +802,7 @@ impl State {
             BlockHeader::default(),
         )?;
 
-        Ok(NonZeroU128::new(U256::from_big_endian(&stake).as_u128()))
+        Ok(NonZeroU128::new(U256::from_be_slice(&stake).to()))
     }
 
     pub fn get_reward_address(&self, public_key: NodePublicKey) -> Result<Option<Address>> {
@@ -828,7 +810,7 @@ impl State {
             .encode_input(&[Token::Bytes(public_key.as_bytes())])?;
 
         let return_value = self.call_contract(
-            Address::zero(),
+            Address::ZERO,
             Some(contract_addr::DEPOSIT),
             data,
             0,
@@ -842,6 +824,7 @@ impl State {
             .clone()
             .into_address()
             .unwrap();
+        let addr = Address::new(addr.0);
 
         Ok((!addr.is_zero()).then_some(addr))
     }
@@ -850,7 +833,7 @@ impl State {
         let data = contracts::deposit::TOTAL_STAKE.encode_input(&[])?;
 
         let return_value = self.call_contract(
-            Address::zero(),
+            Address::ZERO,
             Some(contract_addr::DEPOSIT),
             data,
             0,
@@ -966,10 +949,10 @@ impl TransactionOutput {
 }
 
 /// Gets the contract address if a contract creation [TxZilliqa] is sent by `sender` with `nonce`.
-pub fn zil_contract_address(sender: H160, nonce: u64) -> H160 {
+pub fn zil_contract_address(sender: Address, nonce: u64) -> Address {
     let mut hasher = Sha256::new();
-    hasher.update(sender.as_bytes());
+    hasher.update(sender.into_array());
     hasher.update(nonce.to_be_bytes());
     let hashed = hasher.finalize();
-    H160::from_slice(&hashed[12..])
+    Address::from_slice(&hashed[12..])
 }

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -5,10 +5,10 @@ use std::{
     str::FromStr,
 };
 
+use alloy_primitives::Address;
 use anyhow::{anyhow, Result};
 use bitvec::{bitvec, order::Msb0};
 use libp2p::PeerId;
-use primitive_types::H160;
 use serde::{Deserialize, Deserializer, Serialize};
 use sha3::{Digest, Keccak256};
 use time::{macros::format_description, OffsetDateTime};
@@ -205,8 +205,8 @@ pub struct BlockBatchResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IntershardCall {
-    pub source_address: H160,
-    pub target_address: Option<H160>,
+    pub source_address: Address,
+    pub target_address: Option<Address>,
     pub source_chain_id: u64,
     pub bridge_nonce: u64,
     pub calldata: Vec<u8>,
@@ -218,7 +218,7 @@ pub struct IntershardCall {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ExternalMessage {
     Proposal(Proposal),
-    Vote(Vote),
+    Vote(Box<Vote>),
     NewView(Box<NewView>),
     BlockRequest(BlockRequest),
     BlockResponse(BlockResponse),
@@ -458,7 +458,7 @@ impl Default for BlockHeader {
             hash: Hash::ZERO,
             parent_hash: Hash::ZERO,
             signature: NodeSignature::identity(),
-            state_root_hash: Hash(Keccak256::digest(rlp::NULL_RLP).into()),
+            state_root_hash: Hash(Keccak256::digest([alloy_rlp::EMPTY_STRING_CODE]).into()),
             timestamp: SystemTime::UNIX_EPOCH,
         }
     }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1,8 +1,8 @@
 use std::{sync::Arc, time::Duration};
 
+use alloy_primitives::{Address, B256};
 use anyhow::{anyhow, Result};
 use libp2p::PeerId;
-use primitive_types::H256;
 use revm::Inspector;
 use tokio::sync::{broadcast, mpsc::UnboundedSender};
 use tracing::*;
@@ -19,7 +19,7 @@ use crate::{
         BlockResponse, ExternalMessage, InternalMessage, IntershardCall, Proposal,
     },
     p2p_node::{LocalMessageTuple, OutboundMessageTuple},
-    state::{Account, Address, State},
+    state::{Account, State},
     transaction::{
         EvmGas, SignedTransaction, TransactionReceipt, TxIntershard, VerifiedTransaction,
     },
@@ -156,7 +156,7 @@ impl Node {
                 }
             }
             ExternalMessage::Vote(m) => {
-                if let Some((block, transactions)) = self.consensus.vote(m)? {
+                if let Some((block, transactions)) = self.consensus.vote(*m)? {
                     self.message_sender
                         .broadcast_external_message(ExternalMessage::Proposal(
                             Proposal::from_parts(block, transactions),
@@ -335,7 +335,7 @@ impl Node {
         let mut state = self
             .consensus
             .state()
-            .at_root(H256(parent.state_root_hash().0));
+            .at_root(parent.state_root_hash().into());
 
         for other_txn_hash in block.transactions {
             if txn_hash != other_txn_hash {
@@ -376,7 +376,7 @@ impl Node {
         let state = self
             .consensus
             .state()
-            .at_root(H256(block.state_root_hash().0));
+            .at_root(block.state_root_hash().into());
 
         state.call_contract(
             from_addr,
@@ -431,7 +431,7 @@ impl Node {
         let state = self
             .consensus
             .state()
-            .at_root(H256(block.state_root_hash().0));
+            .at_root(block.state_root_hash().into());
 
         state.estimate_gas(
             from_addr,
@@ -466,9 +466,9 @@ impl Node {
     pub fn get_account_storage(
         &self,
         address: Address,
-        index: H256,
+        index: B256,
         block_number: BlockNumber,
-    ) -> Result<H256> {
+    ) -> Result<B256> {
         self.consensus
             .try_get_state_at(self.get_number(block_number))?
             .get_account_storage(address, index)

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -221,8 +221,12 @@ mod tests {
                     value: U256::ZERO,
                     input: Bytes::new(),
                 },
-                sig: Signature::from_rs_and_parity(U256::from(1), U256::from(1), Parity::Parity(false))
-                    .unwrap(),
+                sig: Signature::from_rs_and_parity(
+                    U256::from(1),
+                    U256::from(1),
+                    Parity::Parity(false),
+                )
+                .unwrap(),
             },
             signer: from_addr,
             hash: Hash::compute([from_addr.as_slice(), &[nonce]]),

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -3,9 +3,10 @@ use std::{
     collections::{BTreeMap, BinaryHeap},
 };
 
+use alloy_primitives::Address;
+
 use crate::{
     crypto::Hash,
-    state::Address,
     transaction::{SignedTransaction, VerifiedTransaction},
 };
 
@@ -199,15 +200,13 @@ impl TransactionPool {
 
 #[cfg(test)]
 mod tests {
-    use primitive_types::H160;
+    use alloy_consensus::TxLegacy;
+    use alloy_primitives::{Address, Bytes, Parity, Signature, TxKind, U256};
 
     use super::TransactionPool;
     use crate::{
         crypto::Hash,
-        state::Address,
-        transaction::{
-            EthSignature, EvmGas, SignedTransaction, TxIntershard, TxLegacy, VerifiedTransaction,
-        },
+        transaction::{EvmGas, SignedTransaction, TxIntershard, VerifiedTransaction},
     };
 
     fn transaction(from_addr: Address, nonce: u8, gas_price: u128) -> VerifiedTransaction {
@@ -217,19 +216,16 @@ mod tests {
                     chain_id: Some(0),
                     nonce: nonce as u64,
                     gas_price,
-                    gas_limit: EvmGas(0),
-                    to_addr: None,
-                    amount: 0,
-                    payload: vec![],
+                    gas_limit: 0,
+                    to: TxKind::Create,
+                    value: U256::ZERO,
+                    input: Bytes::new(),
                 },
-                sig: EthSignature {
-                    r: [0; 32],
-                    s: [0; 32],
-                    y_is_odd: false,
-                },
+                sig: Signature::from_rs_and_parity(U256::from(1), U256::from(1), Parity::Parity(false))
+                    .unwrap(),
             },
             signer: from_addr,
-            hash: Hash::compute([from_addr.as_bytes(), &[nonce]]),
+            hash: Hash::compute([from_addr.as_slice(), &[nonce]]),
         }
     }
 
@@ -249,9 +245,9 @@ mod tests {
                     to_addr: None,
                     payload: vec![],
                 },
-                from: H160::zero(),
+                from: Address::ZERO,
             },
-            signer: H160::zero(),
+            signer: Address::ZERO,
             hash: Hash::compute([[shard_nonce], [from_shard]]),
         }
     }

--- a/zilliqa/src/precompiles.rs
+++ b/zilliqa/src/precompiles.rs
@@ -44,15 +44,13 @@ impl ERC20Precompile {
                 "Decoded value is not a proper address type!".into(),
             ));
         };
+        let address = Address::new(address.0);
 
         let Ok(account) = context.db.get_account(address) else {
-            return Ok((
-                0u64,
-                encode(&[Token::Uint(primitive_types::U256::from(0))]).into(),
-            ));
+            return Ok((0u64, encode(&[Token::Uint(ethabi::Uint::from(0))]).into()));
         };
 
-        let balance = primitive_types::U256::from(account.balance);
+        let balance = ethabi::Uint::from(account.balance);
         let output = encode(&[Token::Uint(balance)]);
 
         // Don't charge gas

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -5,15 +5,12 @@ use std::{
     str::FromStr,
 };
 
+use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy};
+use alloy_primitives::{keccak256, Address, Signature, B256, U256};
+use alloy_rlp::{Encodable, Header, EMPTY_STRING_CODE};
 use anyhow::{anyhow, Result};
 use bytes::{BufMut, BytesMut};
-use k256::{
-    ecdsa::{RecoveryId, Signature, VerifyingKey},
-    elliptic_curve::sec1::ToEncodedPoint,
-};
-use primitive_types::{H160, H256};
-use prost::Message;
-use rlp::RlpStream;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use sha3::{
@@ -29,7 +26,6 @@ use crate::{
     crypto,
     exec::{ScillaError, ScillaException},
     schnorr,
-    state::Address,
     zq1_proto::{Code, Data, Nonce, ProtoTransactionCoreInfo},
 };
 
@@ -39,16 +35,19 @@ use crate::{
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum SignedTransaction {
     Legacy {
+        #[serde(with = "ser_rlp")]
         tx: TxLegacy,
-        sig: EthSignature,
+        sig: Signature,
     },
     Eip2930 {
+        #[serde(with = "ser_rlp")]
         tx: TxEip2930,
-        sig: EthSignature,
+        sig: Signature,
     },
     Eip1559 {
+        #[serde(with = "ser_rlp")]
         tx: TxEip1559,
-        sig: EthSignature,
+        sig: Signature,
     },
     Zilliqa {
         tx: TxZilliqa,
@@ -63,6 +62,32 @@ pub enum SignedTransaction {
     },
 }
 
+// alloy's transaction types contain annotations (such as `skip_serializing_if`) which cause issues when
+// (de)serializing with serde. Therefore, we serialize these transactions in their RLP form instead.
+mod ser_rlp {
+    use alloy_rlp::{Decodable, Encodable};
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        T: Encodable,
+        S: Serializer,
+    {
+        let mut buf = Vec::with_capacity(value.length());
+        value.encode(&mut buf);
+        serializer.serialize_bytes(&buf)
+    }
+
+    pub fn deserialize<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+    where
+        T: Decodable,
+        D: Deserializer<'de>,
+    {
+        let buf = <Vec<u8>>::deserialize(deserializer)?;
+        T::decode(&mut buf.as_slice()).map_err(de::Error::custom)
+    }
+}
+
 impl SignedTransaction {
     pub fn into_transaction(self) -> Transaction {
         match self {
@@ -74,40 +99,35 @@ impl SignedTransaction {
         }
     }
 
-    pub fn sig_r(&self) -> [u8; 32] {
+    pub fn sig_r(&self) -> U256 {
         match self {
-            SignedTransaction::Legacy { sig, .. } => sig.r,
-            SignedTransaction::Eip2930 { sig, .. } => sig.r,
-            SignedTransaction::Eip1559 { sig, .. } => sig.r,
-            SignedTransaction::Zilliqa { sig, .. } => sig.r().to_bytes().into(),
-            SignedTransaction::Intershard { .. } => [0; 32],
+            SignedTransaction::Legacy { sig, .. } => sig.r(),
+            SignedTransaction::Eip2930 { sig, .. } => sig.r(),
+            SignedTransaction::Eip1559 { sig, .. } => sig.r(),
+            SignedTransaction::Zilliqa { sig, .. } => {
+                U256::from_be_bytes(sig.r().to_bytes().into())
+            }
+            SignedTransaction::Intershard { .. } => U256::ZERO,
         }
     }
 
-    pub fn sig_s(&self) -> [u8; 32] {
+    pub fn sig_s(&self) -> U256 {
         match self {
-            SignedTransaction::Legacy { sig, .. } => sig.s,
-            SignedTransaction::Eip2930 { sig, .. } => sig.s,
-            SignedTransaction::Eip1559 { sig, .. } => sig.s,
-            SignedTransaction::Zilliqa { sig, .. } => sig.s().to_bytes().into(),
-            SignedTransaction::Intershard { .. } => [0; 32],
+            SignedTransaction::Legacy { sig, .. } => sig.s(),
+            SignedTransaction::Eip2930 { sig, .. } => sig.s(),
+            SignedTransaction::Eip1559 { sig, .. } => sig.s(),
+            SignedTransaction::Zilliqa { sig, .. } => {
+                U256::from_be_bytes(sig.s().to_bytes().into())
+            }
+            SignedTransaction::Intershard { .. } => U256::ZERO,
         }
     }
 
     pub fn sig_v(&self) -> u64 {
         match self {
-            SignedTransaction::Legacy {
-                sig,
-                tx: TxLegacy {
-                    chain_id: Some(c), ..
-                },
-            } => (sig.y_is_odd as u64) + c * 2 + 35,
-            SignedTransaction::Legacy {
-                sig,
-                tx: TxLegacy { chain_id: None, .. },
-            } => (sig.y_is_odd as u64) + 27,
-            SignedTransaction::Eip2930 { sig, .. } => sig.y_is_odd as u64,
-            SignedTransaction::Eip1559 { sig, .. } => sig.y_is_odd as u64,
+            SignedTransaction::Legacy { sig, .. } => sig.v().to_u64(),
+            SignedTransaction::Eip2930 { sig, .. } => sig.v().to_u64(),
+            SignedTransaction::Eip1559 { sig, .. } => sig.v().to_u64(),
             SignedTransaction::Zilliqa { .. } => 0,
             SignedTransaction::Intershard { .. } => 0,
         }
@@ -148,56 +168,46 @@ impl SignedTransaction {
     }
 
     pub fn verify(self) -> Result<VerifiedTransaction> {
-        let signer = match &self {
+        let (tx, signer, hash) = match self {
             SignedTransaction::Legacy { tx, sig } => {
-                let recovery_id = RecoveryId::new(sig.y_is_odd, false);
-                let signature = Signature::from_scalars(sig.r, sig.s)?;
-                let key = VerifyingKey::recover_from_prehash(
-                    &tx.signature_hash().0,
-                    &signature,
-                    recovery_id,
-                )?;
-                ecdsa_key_to_address(&key)
+                let signed = tx.into_signed(sig);
+                let signer = signed.recover_signer()?;
+                let (tx, _, hash) = signed.into_parts();
+                (SignedTransaction::Legacy { tx, sig }, signer, hash.into())
             }
             SignedTransaction::Eip2930 { tx, sig } => {
-                let recovery_id = RecoveryId::new(sig.y_is_odd, false);
-                let signature = Signature::from_scalars(sig.r, sig.s)?;
-                let key = VerifyingKey::recover_from_prehash(
-                    &tx.signature_hash().0,
-                    &signature,
-                    recovery_id,
-                )?;
-                ecdsa_key_to_address(&key)
+                let signed = tx.into_signed(sig);
+                let signer = signed.recover_signer()?;
+                let (tx, _, hash) = signed.into_parts();
+                (SignedTransaction::Eip2930 { tx, sig }, signer, hash.into())
             }
             SignedTransaction::Eip1559 { tx, sig } => {
-                let recovery_id = RecoveryId::new(sig.y_is_odd, false);
-                let signature = Signature::from_scalars(sig.r, sig.s)?;
-                let key = VerifyingKey::recover_from_prehash(
-                    &tx.signature_hash().0,
-                    &signature,
-                    recovery_id,
-                )?;
-                ecdsa_key_to_address(&key)
+                let signed = tx.into_signed(sig);
+                let signer = signed.recover_signer()?;
+                let (tx, _, hash) = signed.into_parts();
+                (SignedTransaction::Eip1559 { tx, sig }, signer, hash.into())
             }
             SignedTransaction::Zilliqa { tx, key, sig } => {
-                let txn_data = encode_zilliqa_transaction(tx, *key);
+                let txn_data = encode_zilliqa_transaction(&tx, key);
 
-                schnorr::verify(&txn_data, *key, *sig)
-                    .ok_or_else(|| anyhow!("invalid signature"))?;
+                schnorr::verify(&txn_data, key, sig).ok_or_else(|| anyhow!("invalid signature"))?;
 
                 let hashed = Sha256::digest(key.to_encoded_point(true).as_bytes());
                 let (_, bytes): (GenericArray<u8, U12>, GenericArray<u8, U20>) = hashed.split();
-                H160(bytes.into())
-            }
-            SignedTransaction::Intershard { from, .. } => *from,
-        };
-        let hash = self.calculate_hash();
+                let signer = Address::new(bytes.into());
 
-        Ok(VerifiedTransaction {
-            tx: self,
-            signer,
-            hash,
-        })
+                let tx = SignedTransaction::Zilliqa { tx, key, sig };
+                let hash = tx.calculate_hash();
+                (tx, signer, hash)
+            }
+            SignedTransaction::Intershard { tx, from } => {
+                let tx = SignedTransaction::Intershard { tx, from };
+                let hash = tx.calculate_hash();
+                (tx, from, hash)
+            }
+        };
+
+        Ok(VerifiedTransaction { tx, signer, hash })
     }
 
     /// Calculate the hash of this transaction. If you need to do this more than once, consider caching the result
@@ -205,66 +215,36 @@ impl SignedTransaction {
     pub fn calculate_hash(&self) -> crypto::Hash {
         match self {
             SignedTransaction::Legacy { tx, sig } => {
-                let mut rlp = RlpStream::new_list(9);
-                tx.encode_fields(&mut rlp);
-                sig.encode_legacy(&mut rlp, tx.chain_id);
-                crypto::Hash(Keccak256::digest(rlp.out()).into())
+                let mut out = BytesMut::with_capacity(1024);
+                tx.encode_with_signature_fields(sig, &mut out);
+                (keccak256(out)).into()
             }
             SignedTransaction::Eip2930 { tx, sig } => {
-                let mut buffer = BytesMut::with_capacity(1024);
-                buffer.put_u8(1);
-                let mut rlp = RlpStream::new_list_with_buffer(buffer, 11);
-                tx.encode_fields(&mut rlp);
-                sig.encode(&mut rlp);
-                crypto::Hash(Keccak256::digest(rlp.out()).into())
+                let mut out = BytesMut::with_capacity(1024);
+                tx.encode_with_signature(sig, &mut out, false);
+                (keccak256(out)).into()
             }
             SignedTransaction::Eip1559 { tx, sig } => {
-                let mut buffer = BytesMut::with_capacity(1024);
-                buffer.put_u8(2);
-                let mut rlp = RlpStream::new_list_with_buffer(buffer, 12);
-                tx.encode_fields(&mut rlp);
-                sig.encode(&mut rlp);
-                crypto::Hash(Keccak256::digest(rlp.out()).into())
+                let mut out = BytesMut::with_capacity(1024);
+                tx.encode_with_signature(sig, &mut out, false);
+                (keccak256(out)).into()
             }
             SignedTransaction::Zilliqa { tx, key, .. } => {
                 let txn_data = encode_zilliqa_transaction(tx, *key);
                 crypto::Hash(Sha256::digest(txn_data).into())
             }
             SignedTransaction::Intershard { tx, from } => {
-                let mut rlp = RlpStream::new_list(7);
-                tx.encode_fields(&mut rlp);
-                rlp.append(from);
-                crypto::Hash(Keccak256::digest(rlp.out()).into())
+                let mut buffer = BytesMut::with_capacity(1024);
+                Header {
+                    list: true,
+                    payload_length: 7,
+                }
+                .encode(&mut buffer);
+                tx.encode_fields(&mut buffer);
+                from.encode(&mut buffer);
+                crypto::Hash(Keccak256::digest(buffer).into())
             }
         }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct EthSignature {
-    pub r: [u8; 32],
-    pub s: [u8; 32],
-    // True if the parity of the y value of the signature is odd.
-    pub y_is_odd: bool,
-}
-
-impl EthSignature {
-    fn encode(&self, rlp: &mut RlpStream) {
-        rlp.append(&self.y_is_odd)
-            .append(&strip_leading_zeroes(self.r.as_slice()))
-            .append(&strip_leading_zeroes(self.s.as_slice()));
-    }
-
-    fn encode_legacy(&self, rlp: &mut RlpStream, chain_id: Option<u64>) {
-        // Encode the 'v' value of the signature, based the specification of EIP-155.
-        let v = if let Some(chain_id) = chain_id {
-            (self.y_is_odd as u64) + chain_id * 2 + 35
-        } else {
-            (self.y_is_odd as u64) + 27
-        };
-        rlp.append(&v)
-            .append(&strip_leading_zeroes(self.r.as_slice()))
-            .append(&strip_leading_zeroes(self.s.as_slice()));
     }
 }
 
@@ -326,9 +306,9 @@ impl Transaction {
 
     pub fn gas_limit(&self) -> EvmGas {
         match self {
-            Transaction::Legacy(TxLegacy { gas_limit, .. }) => *gas_limit,
-            Transaction::Eip2930(TxEip2930 { gas_limit, .. }) => *gas_limit,
-            Transaction::Eip1559(TxEip1559 { gas_limit, .. }) => *gas_limit,
+            Transaction::Legacy(TxLegacy { gas_limit, .. }) => EvmGas(*gas_limit as u64),
+            Transaction::Eip2930(TxEip2930 { gas_limit, .. }) => EvmGas(*gas_limit as u64),
+            Transaction::Eip1559(TxEip1559 { gas_limit, .. }) => EvmGas(*gas_limit as u64),
             Transaction::Zilliqa(TxZilliqa { gas_limit, .. }) => (*gas_limit).into(),
             Transaction::Intershard(TxIntershard { gas_limit, .. }) => *gas_limit,
         }
@@ -336,9 +316,9 @@ impl Transaction {
 
     pub fn to_addr(&self) -> Option<Address> {
         match self {
-            Transaction::Legacy(TxLegacy { to_addr, .. }) => *to_addr,
-            Transaction::Eip2930(TxEip2930 { to_addr, .. }) => *to_addr,
-            Transaction::Eip1559(TxEip1559 { to_addr, .. }) => *to_addr,
+            Transaction::Legacy(TxLegacy { to, .. }) => to.to().copied(),
+            Transaction::Eip2930(TxEip2930 { to, .. }) => to.to().copied(),
+            Transaction::Eip1559(TxEip1559 { to, .. }) => to.to().copied(),
             // Note: we map the zero address to 'None' here so it is consistent with eth txs (contract creation).
             Transaction::Zilliqa(TxZilliqa { to_addr, .. }) => {
                 if !to_addr.is_zero() {
@@ -353,9 +333,9 @@ impl Transaction {
 
     pub fn amount(&self) -> u128 {
         match self {
-            Transaction::Legacy(TxLegacy { amount, .. }) => *amount,
-            Transaction::Eip2930(TxEip2930 { amount, .. }) => *amount,
-            Transaction::Eip1559(TxEip1559 { amount, .. }) => *amount,
+            Transaction::Legacy(TxLegacy { value, .. }) => value.to(),
+            Transaction::Eip2930(TxEip2930 { value, .. }) => value.to(),
+            Transaction::Eip1559(TxEip1559 { value, .. }) => value.to(),
             Transaction::Zilliqa(t) => t.amount.get(),
             Transaction::Intershard(_) => 0,
         }
@@ -363,9 +343,9 @@ impl Transaction {
 
     pub fn payload(&self) -> &[u8] {
         match self {
-            Transaction::Legacy(TxLegacy { payload, .. }) => payload,
-            Transaction::Eip2930(TxEip2930 { payload, .. }) => payload,
-            Transaction::Eip1559(TxEip1559 { payload, .. }) => payload,
+            Transaction::Legacy(TxLegacy { input, .. }) => input.as_ref(),
+            Transaction::Eip2930(TxEip2930 { input, .. }) => input.as_ref(),
+            Transaction::Eip1559(TxEip1559 { input, .. }) => input.as_ref(),
             // Zilliqa transactions can have both code and data set, but code takes precedence if it is non-empty.
             Transaction::Zilliqa(TxZilliqa { code, data, .. }) => {
                 if !code.is_empty() {
@@ -378,11 +358,23 @@ impl Transaction {
         }
     }
 
-    pub fn access_list(&self) -> Option<&[(Address, Vec<H256>)]> {
+    pub fn access_list(&self) -> Option<Vec<(Address, Vec<B256>)>> {
         match self {
             Transaction::Legacy(_) => None,
-            Transaction::Eip2930(TxEip2930 { access_list, .. }) => Some(access_list),
-            Transaction::Eip1559(TxEip1559 { access_list, .. }) => Some(access_list),
+            Transaction::Eip2930(TxEip2930 { access_list, .. }) => Some(
+                access_list
+                    .0
+                    .iter()
+                    .map(|i| (i.address, i.storage_keys.clone()))
+                    .collect(),
+            ),
+            Transaction::Eip1559(TxEip1559 { access_list, .. }) => Some(
+                access_list
+                    .0
+                    .iter()
+                    .map(|i| (i.address, i.storage_keys.clone()))
+                    .collect(),
+            ),
             Transaction::Zilliqa(_) => None,
             Transaction::Intershard(_) => None,
         }
@@ -419,39 +411,6 @@ impl From<TxIntershard> for Transaction {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TxLegacy {
-    /// `None` for non-EIP-155 transactions without replay protection.
-    pub chain_id: Option<u64>,
-    pub nonce: u64,
-    pub gas_price: u128,
-    pub gas_limit: EvmGas,
-    pub to_addr: Option<Address>,
-    pub amount: u128,
-    pub payload: Vec<u8>,
-}
-
-impl TxLegacy {
-    /// Returns the "signature hash" of the transaction, over which the transaction's signature is calculated.
-    fn signature_hash(&self) -> crypto::Hash {
-        let mut rlp = RlpStream::new_list(if self.chain_id.is_some() { 9 } else { 6 });
-        self.encode_fields(&mut rlp);
-        if let Some(chain_id) = &self.chain_id {
-            rlp.append(chain_id).append(&0u8).append(&0u8);
-        }
-        crypto::Hash(Keccak256::digest(rlp.out()).into())
-    }
-
-    fn encode_fields(&self, rlp: &mut RlpStream) {
-        rlp.append(&self.nonce)
-            .append(&self.gas_price)
-            .append(&self.gas_limit)
-            .append(&rlp_option_addr(&self.to_addr))
-            .append(&self.amount)
-            .append(&self.payload);
-    }
-}
-
 /// Nonceless
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TxIntershard {
@@ -467,86 +426,14 @@ pub struct TxIntershard {
 }
 
 impl TxIntershard {
-    fn encode_fields(&self, rlp: &mut RlpStream) {
-        rlp.append(&self.chain_id)
-            .append(&self.source_chain)
-            .append(&self.bridge_nonce)
-            .append(&self.gas_price)
-            .append(&self.gas_limit)
-            .append(&self.to_addr)
-            .append(&self.payload);
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TxEip2930 {
-    pub chain_id: u64,
-    pub nonce: u64,
-    pub gas_price: u128,
-    pub gas_limit: EvmGas,
-    pub to_addr: Option<Address>,
-    pub amount: u128,
-    pub payload: Vec<u8>,
-    pub access_list: Vec<(Address, Vec<H256>)>,
-}
-
-impl TxEip2930 {
-    /// Returns the "signature hash" of the transaction, over which the transaction's signature is calculated.
-    fn signature_hash(&self) -> crypto::Hash {
-        let mut buffer = BytesMut::with_capacity(1024);
-        buffer.put_u8(1);
-        let mut rlp = RlpStream::new_list_with_buffer(buffer, 8);
-        self.encode_fields(&mut rlp);
-
-        crypto::Hash(Keccak256::digest(rlp.out()).into())
-    }
-
-    fn encode_fields(&self, rlp: &mut RlpStream) {
-        rlp.append(&self.chain_id)
-            .append(&self.nonce)
-            .append(&self.gas_price)
-            .append(&self.gas_limit)
-            .append(&rlp_option_addr(&self.to_addr))
-            .append(&self.amount)
-            .append(&self.payload);
-        encode_access_list(rlp, &self.access_list);
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct TxEip1559 {
-    pub chain_id: u64,
-    pub nonce: u64,
-    pub max_priority_fee_per_gas: u128,
-    pub max_fee_per_gas: u128,
-    pub gas_limit: EvmGas,
-    pub to_addr: Option<Address>,
-    pub amount: u128,
-    pub payload: Vec<u8>,
-    pub access_list: Vec<(Address, Vec<H256>)>,
-}
-
-impl TxEip1559 {
-    /// Returns the "signature hash" of the transaction, over which the transaction's signature is calculated.
-    fn signature_hash(&self) -> crypto::Hash {
-        let mut buffer = BytesMut::with_capacity(1024);
-        buffer.put_u8(2);
-        let mut rlp = RlpStream::new_list_with_buffer(buffer, 9);
-        self.encode_fields(&mut rlp);
-
-        crypto::Hash(Keccak256::digest(rlp.out()).into())
-    }
-
-    fn encode_fields(&self, rlp: &mut RlpStream) {
-        rlp.append(&self.chain_id)
-            .append(&self.nonce)
-            .append(&self.max_priority_fee_per_gas)
-            .append(&self.max_fee_per_gas)
-            .append(&self.gas_limit)
-            .append(&rlp_option_addr(&self.to_addr))
-            .append(&self.amount)
-            .append(&self.payload);
-        encode_access_list(rlp, &self.access_list);
+    fn encode_fields(&self, out: &mut BytesMut) {
+        self.chain_id.encode(out);
+        self.source_chain.encode(out);
+        self.bridge_nonce.encode(out);
+        self.gas_price.encode(out);
+        self.gas_limit.encode(out);
+        encode_option_addr(&self.to_addr, out);
+        self.payload.as_slice().encode(out);
     }
 }
 
@@ -685,22 +572,26 @@ impl FromStr for EvmGas {
     }
 }
 
-impl rlp::Decodable for EvmGas {
-    fn decode(rlp: &rlp::Rlp) -> Result<Self, rlp::DecoderError> {
-        Ok(EvmGas(<u64 as rlp::Decodable>::decode(rlp)?))
+impl alloy_rlp::Decodable for EvmGas {
+    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
+        Ok(EvmGas(<u64 as alloy_rlp::Decodable>::decode(buf)?))
     }
 }
 
-impl rlp::Encodable for EvmGas {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        self.0.rlp_append(s)
+impl alloy_rlp::Encodable for EvmGas {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.0.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.0.length()
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EvmLog {
     pub address: Address,
-    pub topics: Vec<H256>,
+    pub topics: Vec<B256>,
     pub data: Vec<u8>,
 }
 
@@ -719,7 +610,7 @@ pub enum Log {
 }
 
 impl Log {
-    pub fn evm(address: Address, topics: Vec<H256>, data: Vec<u8>) -> Self {
+    pub fn evm(address: Address, topics: Vec<B256>, data: Vec<u8>) -> Self {
         Log::Evm(EvmLog {
             address,
             topics,
@@ -780,36 +671,16 @@ pub struct TransactionReceipt {
     pub exceptions: Vec<ScillaException>,
 }
 
-fn strip_leading_zeroes(bytes: &[u8]) -> &[u8] {
-    // If `bytes` is all zeroes, default to `bytes.len() - 2`. This is because zeroes should be
-    // encoded as `[0]`.
-    let first_non_zero = bytes
-        .iter()
-        .position(|b| *b != 0)
-        .unwrap_or(bytes.len() - 2);
-
-    &bytes[first_non_zero..]
-}
-
-fn ecdsa_key_to_address(key: &VerifyingKey) -> Address {
-    // Remove the first byte before hashing - The first byte specifies the encoding tag.
-    let hashed = Keccak256::digest(&key.to_encoded_point(false).as_bytes()[1..]);
-    let (_, bytes): (GenericArray<u8, U12>, GenericArray<u8, U20>) = hashed.split();
-    H160(bytes.into())
-}
-
-/// Encode an `Option<H160>` ready to be added to an [RlpStream].
+/// RLP-encode an `Option<Address>`.
 /// `None` is represented as an empty string.
-fn rlp_option_addr(addr: &Option<H160>) -> &[u8] {
-    addr.as_ref().map(|a| a.as_ref()).unwrap_or_default()
-}
-
-fn encode_access_list(rlp: &mut RlpStream, access_list: &[(Address, Vec<H256>)]) {
-    rlp.begin_list(access_list.len());
-    for (address, storage_keys) in access_list {
-        rlp.begin_list(2);
-        rlp.append(address);
-        rlp.append_list(storage_keys);
+fn encode_option_addr(addr: &Option<Address>, out: &mut BytesMut) {
+    match addr {
+        Some(addr) => {
+            addr.encode(out);
+        }
+        None => {
+            out.put_u8(EMPTY_STRING_CODE);
+        }
     }
 }
 
@@ -818,7 +689,7 @@ fn encode_zilliqa_transaction(txn: &TxZilliqa, pub_key: schnorr::PublicKey) -> V
     let oneof9 = (!txn.data.is_empty()).then_some(Data::Data(txn.data.clone().into_bytes()));
     let proto = ProtoTransactionCoreInfo {
         version: (((txn.chain_id) as u32) << 16) | 0x0001,
-        toaddr: txn.to_addr.as_bytes().to_vec(),
+        toaddr: txn.to_addr.as_slice().to_vec(),
         senderpubkey: Some(pub_key.to_sec1_bytes().into()),
         amount: Some((txn.amount).to_be_bytes().to_vec().into()),
         gasprice: Some((txn.gas_price).to_be_bytes().to_vec().into()),
@@ -827,5 +698,5 @@ fn encode_zilliqa_transaction(txn: &TxZilliqa, pub_key: schnorr::PublicKey) -> V
         oneof8,
         oneof9,
     };
-    proto.encode_to_vec()
+    prost::Message::encode_to_vec(&proto)
 }

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -3,13 +3,10 @@ use ethers::{
     abi::FunctionExt, prelude::DeploymentTxFactory, providers::Middleware,
     types::TransactionRequest,
 };
-use primitive_types::{H160, U256};
+use primitive_types::{H160, H256, U256};
 use tokio::sync::Mutex;
 use tracing::*;
-use zilliqa::{
-    contracts,
-    state::contract_addr::{self, SHARD_REGISTRY},
-};
+use zilliqa::{contracts, crypto::Hash, state::contract_addr};
 
 use crate::{compile_contract, deploy_contract, deploy_contract_with_args, Network, Wallet};
 
@@ -199,7 +196,7 @@ async fn create_shard(
             Token::Uint((700 + 0x8000).into()),
             Token::Uint(5000.into()),
             Token::FixedBytes(shard_genesis.0.to_vec()),
-            Token::Address(SHARD_REGISTRY),
+            Token::Address(H160(contract_addr::SHARD_REGISTRY.into_array())),
         ]
         .as_slice(),
         wallet,
@@ -212,7 +209,7 @@ async fn create_shard(
 
     // * Register the shard in the shard registry on the main shard
     let tx_request = TransactionRequest::new()
-        .to(contract_addr::SHARD_REGISTRY)
+        .to(H160(contract_addr::SHARD_REGISTRY.into_array()))
         .data(
             contracts::shard_registry::ADD_SHARD
                 .encode_input(&[
@@ -376,7 +373,7 @@ async fn dynamic_cross_shard_link_creation(mut network: Network) {
         ])
         .unwrap();
     let tx_request = TransactionRequest::new()
-        .to(contract_addr::INTERSHARD_BRIDGE)
+        .to(H160(contract_addr::INTERSHARD_BRIDGE.into_array()))
         .data(data);
 
     // Send it from the shard wallet's address
@@ -497,7 +494,7 @@ async fn cross_shard_contract_creation(mut network: Network) {
         ])
         .unwrap();
     let tx_request = TransactionRequest::new()
-        .to(contract_addr::INTERSHARD_BRIDGE)
+        .to(H160(contract_addr::INTERSHARD_BRIDGE.into_array()))
         .data(data);
 
     // Send it from the shard wallet's address
@@ -569,7 +566,7 @@ async fn handle_forking_correctly(mut network: Network) {
         .unwrap();
 
     // Send a single TX to the network
-    let hash = wallet
+    let hash: H256 = wallet
         .send_transaction(TransactionRequest::pay(H160::random(), 10), None)
         .await
         .unwrap()
@@ -580,11 +577,11 @@ async fn handle_forking_correctly(mut network: Network) {
     // Check that node 0 has executed the transaction while the others haven't
     let first = network
         .get_node(0)
-        .get_transaction_receipt(hash.into())
+        .get_transaction_receipt(Hash(hash.0))
         .unwrap();
     let second = network
         .get_node(1)
-        .get_transaction_receipt(hash.into())
+        .get_transaction_receipt(Hash(hash.0))
         .unwrap();
 
     // Only the first node should have executed the transaction
@@ -599,7 +596,7 @@ async fn handle_forking_correctly(mut network: Network) {
     network
         .run_until(
             |n| {
-                let receipt = n.get_node(0).get_transaction_receipt(hash.into());
+                let receipt = n.get_node(0).get_transaction_receipt(Hash(hash.0));
                 match receipt {
                     Ok(Some(receipt)) => receipt.block_hash != original_receipt.block_hash,
                     _ => false,

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -610,6 +610,7 @@ async fn send_legacy_transaction_without_chain_id(mut network: Network) {
 
     let sig = wallet.signer().sign_hash(tx.sighash()).unwrap();
     let expected_hash = tx.hash(&sig);
+    eprintln!("expected: {}", hex::encode(tx.rlp_signed(&sig)));
 
     // Drop down to the provider, to prevent the wallet middleware from setting the chain ID.
     let hash = wallet

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1,3 +1,4 @@
+use alloy_primitives::Address;
 use ethers::{
     abi::Tokenize,
     providers::{Middleware, PubsubClient},
@@ -60,7 +61,6 @@ use zilliqa::{
     crypto::{NodePublicKey, SecretKey},
     message::{ExternalMessage, InternalMessage},
     node::Node,
-    state::Address,
 };
 
 /// (source, destination, message) for both
@@ -227,7 +227,7 @@ impl Network {
                 (
                     k.node_public_key(),
                     stake.to_string(),
-                    Address::random_using(rng.lock().unwrap().deref_mut()),
+                    Address::random_with(rng.lock().unwrap().deref_mut()),
                 )
             })
             .collect();
@@ -295,7 +295,7 @@ impl Network {
 
     fn genesis_accounts(genesis_key: &SigningKey) -> Vec<(Address, String)> {
         vec![(
-            secret_key_to_address(genesis_key),
+            Address::new(secret_key_to_address(genesis_key).0),
             1_000_000_000u128
                 .checked_mul(10u128.pow(18))
                 .unwrap()
@@ -392,7 +392,7 @@ impl Network {
                 (
                     k.node_public_key(),
                     stake.to_string(),
-                    Address::random_using(self.rng.lock().unwrap().deref_mut()),
+                    Address::random_with(self.rng.lock().unwrap().deref_mut()),
                 )
             })
             .collect();

--- a/zilliqa/tests/it/staking.rs
+++ b/zilliqa/tests/it/staking.rs
@@ -45,7 +45,7 @@ async fn deposit_stake(
 
     // Stake the new validator's funds.
     let tx = TransactionRequest::new()
-        .to(contract_addr::DEPOSIT)
+        .to(H160(contract_addr::DEPOSIT.into_array()))
         .value(stake)
         .data(
             contracts::deposit::DEPOSIT
@@ -64,7 +64,7 @@ async fn get_stakers(
     wallet: &SignerMiddleware<Provider<LocalRpcClient>, LocalWallet>,
 ) -> Vec<NodePublicKey> {
     let tx = TransactionRequest::new()
-        .to(contract_addr::DEPOSIT)
+        .to(H160(contract_addr::DEPOSIT.into_array()))
         .data(contracts::deposit::GET_STAKERS.encode_input(&[]).unwrap());
     let stakers = wallet.call(&tx.into(), None).await.unwrap();
     let stakers = contracts::deposit::GET_STAKERS


### PR DESCRIPTION
Sorry for the large commit. 99% of it is just find-and-replace.

`alloy` is used internally by `revm`, so converting to it in our own code removes a load of conversion code between the two types.

Also, `alloy` has a bunch of useful types and utilities we can use to simplify our code. This commit replaces the
`Tx{Legacy,Eip{2930,1559}}` types we had with alloy's version. In future, we can also utilise the API types defined by alloy.

(specifically, I wanted to use the alloy-provided types for `trace_replayTransaction` which prompted this PR)