### PR TITLE
Make `block_production_even_when_lossy_network` test more reliable

### DIFF
--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -75,7 +75,7 @@ async fn block_production_even_when_lossy_network(mut network: Network) {
         .unwrap();
 
     // now, wait until block 15 has been produced, but dropping 10% of the messages.
-    for _ in 0..1000 {
+    for _ in 0..1000000 {
         network.randomly_drop_messages_then_tick(failure_rate).await;
         if get_block_number(&mut network) >= finish_block {
             break;


### PR DESCRIPTION
All of the failures I identified were just multiple 'unlucky' runs where many messages get dropped. So I've just increased the time we wait before failing.

This shouldn't meaningfully increase the runtime of the test since these situations only occur rarely and will only affect a small proportion of test seeds.