### PR TITLE
Revert mempool transaction re-injection

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -191,14 +191,25 @@ fn get_storage_at(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 }
 
 fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
+    trace!("get_transaction_count: params: {:?}", params);
     let mut params = params.sequence();
     let address: H160 = params.next()?;
     let block_number: BlockNumber = params.next()?;
 
+    trace!(
+        "get_transaction_count resp: {:?}",
+        node.lock()
+            .unwrap()
+            .get_account(address, block_number)?
+            .nonce
+            .to_hex()
+    );
+
     Ok(node
         .lock()
         .unwrap()
-        .get_transaction_count(address, block_number)?
+        .get_account(address, block_number)?
+        .nonce
         .to_hex())
 }
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -463,25 +463,6 @@ impl Node {
             .get_account(address)
     }
 
-    /// Return the `nonce` of an account. If the `block_number` is [BlockNumber::Pending], any pending transactions in
-    /// our pool are also added to the nonce.
-    pub fn get_transaction_count(
-        &self,
-        address: Address,
-        block_number: BlockNumber,
-    ) -> Result<u64> {
-        let nonce = self.get_account(address, block_number)?.nonce;
-
-        if matches!(block_number, BlockNumber::Pending) {
-            Ok(self
-                .consensus
-                .transaction_pool
-                .pending_nonce(address, nonce))
-        } else {
-            Ok(nonce)
-        }
-    }
-
     pub fn get_account_storage(
         &self,
         address: Address,

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -192,21 +192,6 @@ impl TransactionPool {
         std::mem::take(&mut self.transactions).into_values()
     }
 
-    /// Calculate the effective nonce of the sender, if all the currently pending transactions in the pool were mined
-    /// in order. Effectively, this calculates the current nonce plus the number of transactions with sequential nonces
-    /// in the pool.
-    pub fn pending_nonce(&self, sender: Address, mut current_nonce: u64) -> u64 {
-        loop {
-            let index = TxIndex::Nonced(sender, current_nonce);
-            if self.transactions.get(&index).is_none() {
-                break;
-            }
-            current_nonce += 1;
-        }
-
-        current_nonce
-    }
-
     pub fn size(&self) -> usize {
         self.transactions.len()
     }

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -18,7 +18,7 @@ use futures::{future::join_all, StreamExt};
 use primitive_types::{H160, H256};
 use serde::Serialize;
 
-use crate::{deploy_contract, LocalRpcClient, Network, Wallet};
+use crate::{deploy_contract, LocalRpcClient, Network};
 
 #[zilliqa_macros::test]
 async fn call_block_number(mut network: Network) {
@@ -1055,35 +1055,4 @@ async fn block_subscription(mut network: Network) {
     );
 
     assert!(block_stream.unsubscribe().await.unwrap());
-}
-
-#[zilliqa_macros::test]
-async fn get_transaction_count_pending(mut network: Network) {
-    async fn pending_count(wallet: &Wallet) -> u64 {
-        wallet
-            .get_transaction_count(wallet.address(), Some(BlockNumber::Pending.into()))
-            .await
-            .unwrap()
-            .as_u64()
-    }
-
-    let wallet = network.genesis_wallet().await;
-
-    assert_eq!(pending_count(&wallet).await, 0);
-
-    wallet
-        .send_transaction(TransactionRequest::pay(H160::random(), 10), None)
-        .await
-        .unwrap()
-        .tx_hash();
-
-    assert_eq!(pending_count(&wallet).await, 1);
-
-    wallet
-        .send_transaction(TransactionRequest::pay(H160::random(), 10).nonce(1), None)
-        .await
-        .unwrap()
-        .tx_hash();
-
-    assert_eq!(pending_count(&wallet).await, 2);
 }


### PR DESCRIPTION
This appears to cause a significant drop in the pass rate for sharding-related tests. While we investigate the cause, lets revert the change in main and add it back once we understand what is going on.

This reverts commit e12f2b2db21842334fd8eb5cd248b37c8793dbcb.