### PR TITLE
Implement `trace_replayTransaction`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#af788afe934d4c54ec1fcb6bb4b16ce385f913ab"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -100,13 +100,12 @@ dependencies = [
  "alloy-serde",
  "c-kzg",
  "serde",
- "sha2 0.10.8",
 ]
 
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#af788afe934d4c54ec1fcb6bb4b16ce385f913ab"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -114,6 +113,18 @@ dependencies = [
  "c-kzg",
  "once_cell",
  "serde",
+ "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-serde",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -162,13 +173,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-rpc-types"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-genesis",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde",
+ "alloy-sol-types",
+ "itertools 0.12.1",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-rpc-types-trace"
+version = "0.1.0"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-serde",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git#af788afe934d4c54ec1fcb6bb4b16ce385f913ab"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
 dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89c80a2cb97e7aa48611cbb63950336f9824a174cdf670527cc6465078a26ea1"
+dependencies = [
+ "alloy-sol-macro-input",
+ "const-hex",
+ "heck 0.4.1",
+ "indexmap 2.2.6",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+ "syn-solidity",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-input"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58894b58ac50979eeac6249661991ac40b9d541830d9a725f7714cc9ef08c23"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+ "syn-solidity",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "399287f68d1081ed8b1f4903c49687658b95b142207d7cb4ae2f4813915343ef"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-macro",
+ "const-hex",
+ "serde",
 ]
 
 [[package]]
@@ -4978,6 +5064,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5420,6 +5530,22 @@ dependencies = [
  "revm-precompile",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "revm-inspectors"
+version = "0.1.0"
+source = "git+https://github.com/paradigmxyz/evm-inspectors.git#3b6f81f2d1c16e559b0bd704f6b456ab9151ecdd"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rpc-types",
+ "alloy-rpc-types-trace",
+ "alloy-sol-types",
+ "anstyle",
+ "colorchoice",
+ "revm",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -6414,6 +6540,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa0cefd02f532035d83cfec82647c6eb53140b0485220760e669f4bad489e36"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
 ]
 
 [[package]]
@@ -7800,6 +7938,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types-trace",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -7837,6 +7976,7 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "revm",
+ "revm-inspectors",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -26,6 +26,9 @@ vergen = { version = "8.3.1", features = ["git", "git2"] }
 [dependencies]
 alloy-primitives = { version = "0.7.2", features = ["rlp", "serde"] }
 alloy-rlp = { version = "0.3.4", features = ["derive"] }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "77c1240", features = ["serde", "k256"] }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "77c1240", features = ["serde"] }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy.git", rev = "77c1240" }
 anyhow = { version = "1.0.83", features = ["backtrace"] }
 async-trait = "0.1.80"
 base64 = "0.22.1"
@@ -58,6 +61,7 @@ rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 revm = { version = "8.0.0", features = ["optional_balance_check"] }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors.git", version = "0.1.0" }
 serde = { version = "1.0.201", features = ["derive", "rc"] }
 serde_bytes = "0.11.14"
 serde_json = { version = "1.0.117", features = ["raw_value"] }
@@ -73,8 +77,6 @@ tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", version = "0.1.0", features = ["serde", "k256"] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", version = "0.1.0", features = ["serde"] }
 
 [dev-dependencies]
 alloy-primitives = { version = "0.7.2", features = ["rand"] }

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -4,6 +4,7 @@ mod net;
 pub mod ots;
 pub mod subscription_id_provider;
 mod to_hex;
+mod trace;
 pub mod types;
 mod web3;
 pub mod zil;
@@ -15,6 +16,7 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     module.merge(eth::rpc_module(node.clone())).unwrap();
     module.merge(net::rpc_module(node.clone())).unwrap();
     module.merge(ots::rpc_module(node.clone())).unwrap();
+    module.merge(trace::rpc_module(node.clone())).unwrap();
     module.merge(web3::rpc_module(node.clone())).unwrap();
     module.merge(zil::rpc_module(node)).unwrap();
 

--- a/zilliqa/src/api/trace.rs
+++ b/zilliqa/src/api/trace.rs
@@ -1,0 +1,29 @@
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+use alloy_primitives::B256;
+use alloy_rpc_types_trace::parity::{TraceResults, TraceType};
+use anyhow::Result;
+use jsonrpsee::{types::Params, RpcModule};
+
+use crate::{crypto::Hash, node::Node};
+
+pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
+    super::declare_module!(node, [("trace_replayTransaction", replay_transaction)])
+}
+
+fn replay_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<TraceResults> {
+    let mut params = params.sequence();
+    let txn_hash: B256 = params.next()?;
+    let txn_hash: Hash = txn_hash.into();
+    let trace_types: HashSet<TraceType> = params.next()?;
+
+    let trace = node
+        .lock()
+        .unwrap()
+        .trace_evm_transaction(txn_hash, &trace_types)?;
+
+    Ok(trace)
+}

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -774,7 +774,7 @@ impl Consensus {
         // Tell the transaction pool that the sender's nonce has been incremented.
         self.transaction_pool.mark_executed(&txn);
 
-        if !result.success {
+        if !result.success() {
             info!("Transaction was a failure...");
         }
 
@@ -2089,16 +2089,21 @@ impl Consensus {
             for address in inspector.touched {
                 self.db.add_touched_address(address, tx_hash)?;
             }
+            let success = result.success();
+            let contract_address = result.contract_address();
+            let gas_used = result.gas_used();
+            let accepted = result.accepted();
+            let (logs, errors, exceptions) = result.into_parts();
             let receipt = TransactionReceipt {
                 block_hash: block.hash(),
                 tx_hash,
-                success: result.success,
-                contract_address: result.contract_address,
-                logs: result.logs,
-                gas_used: result.gas_used,
-                accepted: result.accepted,
-                errors: result.errors,
-                exceptions: result.exceptions,
+                success,
+                contract_address,
+                logs,
+                gas_used,
+                accepted,
+                errors,
+                exceptions,
             };
             info!(?receipt, "applied transaction {:?}", receipt);
             block_receipts.push(receipt);

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -1,7 +1,7 @@
 //! Manages execution of transactions on state.
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     error::Error,
     fmt::{self, Display, Formatter},
     num::NonZeroU128,
@@ -18,7 +18,7 @@ use revm::{
         AccountInfo, BlockEnv, Bytecode, BytecodeState, ExecutionResult, HandlerCfg, Output,
         ResultAndState, SpecId, TransactTo, TxEnv, B256, KECCAK_EMPTY,
     },
-    Database, Evm, Inspector,
+    Database, DatabaseRef, Evm, Inspector,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -36,24 +36,115 @@ use crate::{
     state::{contract_addr, Account, Contract, ScillaValue, State},
     time::SystemTime,
     transaction::{
-        total_scilla_gas_price, EvmGas, Log, ScillaGas, ScillaParam, Transaction, TxZilliqa,
-        VerifiedTransaction, ZilAmount,
+        total_scilla_gas_price, EvmGas, EvmLog, Log, ScillaGas, ScillaLog, ScillaParam,
+        Transaction, TxZilliqa, VerifiedTransaction, ZilAmount,
     },
 };
 
 /// Data returned after applying a [Transaction] to [State].
-pub struct TransactionApplyResult {
+pub enum TransactionApplyResult {
+    Evm(ResultAndState),
+    Scilla(ScillaResult),
+}
+
+impl TransactionApplyResult {
+    pub fn output(&self) -> Option<&[u8]> {
+        match self {
+            TransactionApplyResult::Evm(ResultAndState { result, .. }) => {
+                result.output().map(|b| b.as_ref())
+            }
+            TransactionApplyResult::Scilla(_) => None,
+        }
+    }
+
+    pub fn success(&self) -> bool {
+        match self {
+            TransactionApplyResult::Evm(ResultAndState { result, .. }) => result.is_success(),
+            TransactionApplyResult::Scilla(ScillaResult { success, .. }) => *success,
+        }
+    }
+
+    pub fn contract_address(&self) -> Option<Address> {
+        match self {
+            TransactionApplyResult::Evm(ResultAndState {
+                result: ExecutionResult::Success { output, .. },
+                ..
+            }) => output.address().copied(),
+            TransactionApplyResult::Evm(_) => None,
+            TransactionApplyResult::Scilla(ScillaResult {
+                contract_address, ..
+            }) => *contract_address,
+        }
+    }
+
+    pub fn gas_used(&self) -> EvmGas {
+        match self {
+            TransactionApplyResult::Evm(ResultAndState { result, .. }) => EvmGas(result.gas_used()),
+            TransactionApplyResult::Scilla(ScillaResult { gas_used, .. }) => *gas_used,
+        }
+    }
+
+    pub fn accepted(&self) -> Option<bool> {
+        match self {
+            TransactionApplyResult::Evm(_) => None,
+            TransactionApplyResult::Scilla(ScillaResult { accepted, .. }) => *accepted,
+        }
+    }
+
+    pub fn exceptions(&self) -> &[ScillaException] {
+        match self {
+            TransactionApplyResult::Evm(_) => &[],
+            TransactionApplyResult::Scilla(ScillaResult { exceptions, .. }) => exceptions,
+        }
+    }
+
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<Log>,
+        BTreeMap<u64, Vec<ScillaError>>,
+        Vec<ScillaException>,
+    ) {
+        match self {
+            TransactionApplyResult::Evm(ResultAndState { result, .. }) => (
+                result
+                    .into_logs()
+                    .into_iter()
+                    .map(|l| {
+                        let (topics, data) = l.data.split();
+                        Log::Evm(EvmLog {
+                            address: l.address,
+                            topics,
+                            data: data.to_vec(),
+                        })
+                    })
+                    .collect(),
+                BTreeMap::new(),
+                Vec::new(),
+            ),
+            TransactionApplyResult::Scilla(ScillaResult {
+                logs,
+                errors,
+                exceptions,
+                ..
+            }) => (
+                logs.into_iter().map(Log::Scilla).collect(),
+                errors,
+                exceptions,
+            ),
+        }
+    }
+}
+
+pub struct ScillaResult {
     /// Whether the transaction succeeded and the resulting state changes were persisted.
     pub success: bool,
     /// If the transaction was a contract creation, the address of the resulting contract.
     pub contract_address: Option<Address>,
     /// The logs emitted by the transaction execution.
-    pub logs: Vec<Log>,
+    pub logs: Vec<ScillaLog>,
     /// The gas paid by the transaction
     pub gas_used: EvmGas,
-    /// The output of the transaction execution. Note that Scilla calls cannot return data, so the output will always
-    /// be empty.
-    pub output: TransactionOutput,
     /// If the transaction was a call to a Scilla contract, whether the called contract accepted the ZIL sent to it.
     pub accepted: Option<bool>,
     /// Errors from calls to Scilla contracts. Indexed by the call depth of erroring contract.
@@ -111,6 +202,26 @@ impl Database for &State {
     type Error = DatabaseError;
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
+        self.basic_ref(address)
+    }
+
+    fn code_by_hash(&mut self, code_hash: B256) -> Result<Bytecode, Self::Error> {
+        self.code_by_hash_ref(code_hash)
+    }
+
+    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+        self.storage_ref(address, index)
+    }
+
+    fn block_hash(&mut self, number: U256) -> Result<B256, Self::Error> {
+        self.block_hash_ref(number)
+    }
+}
+
+impl DatabaseRef for &State {
+    type Error = DatabaseError;
+
+    fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         if !self.has_account(address)? {
             return Ok(None);
         }
@@ -129,11 +240,11 @@ impl Database for &State {
         Ok(Some(account_info))
     }
 
-    fn code_by_hash(&mut self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
+    fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {
         unimplemented!()
     }
 
-    fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
+    fn storage_ref(&self, address: Address, index: U256) -> Result<U256, Self::Error> {
         let index = B256::new(index.to_be_bytes());
 
         let result = self.get_account_storage(address, index)?;
@@ -141,7 +252,7 @@ impl Database for &State {
         Ok(U256::from_be_bytes(result.0))
     }
 
-    fn block_hash(&mut self, _number: U256) -> Result<B256, Self::Error> {
+    fn block_hash_ref(&self, _number: U256) -> Result<B256, Self::Error> {
         // TODO
         Ok(B256::ZERO)
     }
@@ -194,7 +305,7 @@ impl State {
                     addr
                 };
 
-                self.apply_delta_evm(state)?;
+                self.apply_delta_evm(&state)?;
                 Ok(addr)
             }
             ExecutionResult::Success { .. } => {
@@ -284,7 +395,7 @@ impl State {
         current_block: BlockHeader,
         txn: TxZilliqa,
         inspector: impl ScillaInspector,
-    ) -> Result<TransactionApplyResult> {
+    ) -> Result<ScillaResult> {
         let code = self
             .get_account(txn.to_addr)?
             .contract
@@ -322,17 +433,16 @@ impl State {
         &mut self,
         addr: Address,
         amount: ZilAmount,
-    ) -> Result<Option<TransactionApplyResult>> {
+    ) -> Result<Option<ScillaResult>> {
         let caller = std::panic::Location::caller();
         self.mutate_account(addr, |acc| {
             let Some(balance) = acc.balance.checked_sub(amount.get()) else {
                 info!("insufficient balance: {caller}");
-                return Some(TransactionApplyResult {
+                return Some(ScillaResult {
                     success: false,
                     contract_address: None,
                     logs: vec![],
                     gas_used: ScillaGas(0).into(),
-                    output: TransactionOutput::Error,
                     accepted: None,
                     errors: [(0, vec![ScillaError::InsufficientBalance])]
                         .into_iter()
@@ -351,7 +461,7 @@ impl State {
         txn: TxZilliqa,
         current_block: BlockHeader,
         mut inspector: impl ScillaInspector,
-    ) -> Result<TransactionApplyResult> {
+    ) -> Result<ScillaResult> {
         if txn.data.is_empty() {
             return Err(anyhow!("contract creation without init data"));
         }
@@ -375,12 +485,11 @@ impl State {
 
         let Some(gas) = gas.checked_sub(SCILLA_INVOKE_CHECKER) else {
             warn!("not enough gas to invoke scilla checker");
-            return Ok(TransactionApplyResult {
+            return Ok(ScillaResult {
                 success: false,
                 contract_address: Some(contract_address),
                 logs: vec![],
                 gas_used: (txn.gas_limit - gas).into(),
-                output: TransactionOutput::Error,
                 accepted: Some(false),
                 errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
                 exceptions: vec![],
@@ -392,12 +501,11 @@ impl State {
             Err(e) => {
                 warn!(?e, "transaction failed");
                 let gas = gas.min(e.gas_remaining);
-                return Ok(TransactionApplyResult {
+                return Ok(ScillaResult {
                     success: false,
                     contract_address: Some(contract_address),
                     logs: vec![],
                     gas_used: (txn.gas_limit - gas).into(),
-                    output: TransactionOutput::Error,
                     accepted: Some(false),
                     errors: [(0, vec![ScillaError::CreateFailed])].into_iter().collect(),
                     exceptions: e.errors.into_iter().map(Into::into).collect(),
@@ -441,12 +549,11 @@ impl State {
 
         let Some(gas) = gas.checked_sub(SCILLA_INVOKE_RUNNER) else {
             warn!("not enough gas to invoke scilla runner");
-            return Ok(TransactionApplyResult {
+            return Ok(ScillaResult {
                 success: false,
                 contract_address: Some(contract_address),
                 logs: vec![],
                 gas_used: (txn.gas_limit - gas).into(),
-                output: TransactionOutput::Error,
                 accepted: Some(false),
                 errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
                 exceptions: vec![],
@@ -466,12 +573,11 @@ impl State {
             Err(e) => {
                 warn!(?e, "transaction failed");
                 let gas = gas.min(e.gas_remaining);
-                return Ok(TransactionApplyResult {
+                return Ok(ScillaResult {
                     success: false,
                     contract_address: Some(contract_address),
                     logs: vec![],
                     gas_used: (txn.gas_limit - gas).into(),
-                    output: TransactionOutput::Error,
                     accepted: Some(false),
                     errors: [(0, vec![ScillaError::CreateFailed])].into_iter().collect(),
                     exceptions: e.errors.into_iter().map(Into::into).collect(),
@@ -486,12 +592,11 @@ impl State {
 
         inspector.create(from_addr, contract_address, txn.amount.get());
 
-        Ok(TransactionApplyResult {
+        Ok(ScillaResult {
             success: true,
             contract_address: Some(contract_address),
             logs: vec![],
             gas_used: (txn.gas_limit - gas).into(),
-            output: TransactionOutput::Success(vec![]),
             accepted: None,
             errors: BTreeMap::new(),
             exceptions: vec![],
@@ -503,17 +608,16 @@ impl State {
         from_addr: Address,
         txn: TxZilliqa,
         mut inspector: impl ScillaInspector,
-    ) -> Result<TransactionApplyResult> {
+    ) -> Result<ScillaResult> {
         let gas = txn.gas_limit;
 
         let Some(gas) = gas.checked_sub(SCILLA_TRANSFER) else {
             warn!("not enough gas to make transfer");
-            return Ok(TransactionApplyResult {
+            return Ok(ScillaResult {
                 success: false,
                 contract_address: None,
                 logs: vec![],
                 gas_used: (txn.gas_limit - gas).into(),
-                output: TransactionOutput::Error,
                 accepted: Some(false),
                 errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
                 exceptions: vec![],
@@ -530,12 +634,11 @@ impl State {
 
         inspector.transfer(from_addr, txn.to_addr, txn.amount.get());
 
-        Ok(TransactionApplyResult {
+        Ok(ScillaResult {
             success: true,
             contract_address: None,
             logs: vec![],
             gas_used: (txn.gas_limit - gas).into(),
-            output: TransactionOutput::Success(vec![]),
             accepted: None,
             errors: BTreeMap::new(),
             exceptions: vec![],
@@ -547,7 +650,7 @@ impl State {
         from_addr: Address,
         txn: TxZilliqa,
         mut inspector: impl ScillaInspector,
-    ) -> Result<TransactionApplyResult> {
+    ) -> Result<ScillaResult> {
         // TODO: Interop
         let Contract::Scilla {
             code,
@@ -568,12 +671,11 @@ impl State {
         let gas = txn.gas_limit;
         let Some(gas) = gas.checked_sub(SCILLA_INVOKE_RUNNER) else {
             warn!("not enough gas to invoke scilla runner");
-            return Ok(TransactionApplyResult {
+            return Ok(ScillaResult {
                 success: false,
                 contract_address: None,
                 logs: vec![],
                 gas_used: (txn.gas_limit - gas).into(),
-                output: TransactionOutput::Error,
                 accepted: Some(false),
                 errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
                 exceptions: vec![],
@@ -594,12 +696,11 @@ impl State {
             Err(e) => {
                 warn!(?e, "transaction failed");
                 let gas = gas.min(e.gas_remaining);
-                return Ok(TransactionApplyResult {
+                return Ok(ScillaResult {
                     success: false,
                     contract_address: None,
                     logs: vec![],
                     gas_used: (txn.gas_limit - gas).into(),
-                    output: TransactionOutput::Error,
                     accepted: Some(false),
                     errors: [(0, vec![ScillaError::CallFailed])].into_iter().collect(),
                     exceptions: e.errors.into_iter().map(Into::into).collect(),
@@ -627,30 +728,28 @@ impl State {
         let logs = output
             .events
             .into_iter()
-            .map(|e| {
-                Log::scilla(
-                    txn.to_addr,
-                    e.event_name,
-                    e.params
-                        .into_iter()
-                        .map(|p| ScillaParam {
-                            ty: p.ty,
-                            value: p.value,
-                            name: p.name,
-                        })
-                        .collect(),
-                )
+            .map(|e| ScillaLog {
+                address: txn.to_addr,
+                event_name: e.event_name,
+                params: e
+                    .params
+                    .into_iter()
+                    .map(|p| ScillaParam {
+                        ty: p.ty,
+                        value: p.value,
+                        name: p.name,
+                    })
+                    .collect(),
             })
             .collect();
 
         inspector.call(from_addr, txn.to_addr, txn.amount.get());
 
-        Ok(TransactionApplyResult {
+        Ok(ScillaResult {
             success: true,
             contract_address: None,
             logs,
             gas_used: (txn.gas_limit - gas).into(),
-            output: TransactionOutput::Success(vec![]),
             accepted: Some(output.accepted),
             errors: BTreeMap::new(),
             exceptions: vec![],
@@ -671,7 +770,9 @@ impl State {
 
         let txn = txn.tx.into_transaction();
         if let Transaction::Zilliqa(txn) = txn {
-            self.apply_transaction_scilla(from_addr, current_block, txn, inspector)
+            Ok(TransactionApplyResult::Scilla(
+                self.apply_transaction_scilla(from_addr, current_block, txn, inspector)?,
+            ))
         } else {
             let ResultAndState { result, state } = self.apply_transaction_evm(
                 from_addr,
@@ -686,47 +787,21 @@ impl State {
                 inspector,
             )?;
 
-            self.apply_delta_evm(state)?;
+            self.apply_delta_evm(&state)?;
 
-            Ok(TransactionApplyResult {
-                success: result.is_success(),
-                contract_address: if let ExecutionResult::Success {
-                    output: Output::Create(_, c),
-                    ..
-                } = result
-                {
-                    c
-                } else {
-                    None
-                },
-                logs: result
-                    .logs()
-                    .iter()
-                    .map(|l| Log::evm(l.address, l.topics().to_vec(), l.data.data.to_vec()))
-                    .collect(),
-                gas_used: EvmGas(result.gas_used()),
-                output: match result {
-                    ExecutionResult::Success { output, .. } => {
-                        TransactionOutput::Success(output.into_data().to_vec())
-                    }
-                    ExecutionResult::Revert { output, .. } => {
-                        TransactionOutput::Revert(output.to_vec())
-                    }
-                    ExecutionResult::Halt { .. } => TransactionOutput::Error,
-                },
-                accepted: None,
-                errors: BTreeMap::new(),
-                exceptions: vec![],
-            })
+            Ok(TransactionApplyResult::Evm(ResultAndState {
+                result,
+                state,
+            }))
         }
     }
 
     /// Applies a state delta from an EVM execution to the state.
     pub(crate) fn apply_delta_evm(
         &mut self,
-        state: revm::primitives::HashMap<Address, revm::primitives::Account>,
+        state: &HashMap<Address, revm::primitives::Account>,
     ) -> Result<()> {
-        for (address, account) in state {
+        for (&address, account) in state {
             let mut storage = self.get_account_trie(address)?;
 
             for (index, value) in account.changed_storage_slots() {
@@ -744,6 +819,7 @@ impl State {
                     code: account
                         .info
                         .code
+                        .as_ref()
                         .map(|c| c.original_bytes().to_vec())
                         .unwrap_or_default(),
                     storage_root: if storage.iter().count() != 0 {
@@ -928,22 +1004,6 @@ impl State {
             ExecutionResult::Success { output, .. } => Ok(output.into_data().to_vec()),
             ExecutionResult::Revert { output, .. } => Ok(output.to_vec()),
             ExecutionResult::Halt { reason, .. } => Err(anyhow!("halted due to: {reason:?}")),
-        }
-    }
-}
-
-pub enum TransactionOutput {
-    Success(Vec<u8>),
-    Revert(Vec<u8>),
-    Error,
-}
-
-impl TransactionOutput {
-    pub fn into_vec(self) -> Vec<u8> {
-        match self {
-            TransactionOutput::Success(v) => v,
-            TransactionOutput::Revert(v) => v,
-            TransactionOutput::Error => vec![],
         }
     }
 }

--- a/zilliqa/src/inspector.rs
+++ b/zilliqa/src/inspector.rs
@@ -7,6 +7,7 @@ use revm::{
     primitives::CreateScheme,
     Database, EvmContext, Inspector,
 };
+use revm_inspectors::tracing::TracingInspector;
 
 use crate::api::types::ots::{Operation, OperationType, TraceEntry, TraceEntryType};
 
@@ -343,3 +344,5 @@ impl ScillaInspector for OtterscanOperationInspector {
         }
     }
 }
+
+impl ScillaInspector for TracingInspector {}

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -121,7 +121,7 @@ impl State {
             if !result.is_success() {
                 return Err(anyhow!("setting stake failed: {result:?}"));
             }
-            state.apply_delta_evm(result_state)?;
+            state.apply_delta_evm(&result_state)?;
         }
 
         Ok(state)

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -610,22 +610,6 @@ pub enum Log {
 }
 
 impl Log {
-    pub fn evm(address: Address, topics: Vec<B256>, data: Vec<u8>) -> Self {
-        Log::Evm(EvmLog {
-            address,
-            topics,
-            data,
-        })
-    }
-
-    pub fn scilla(address: Address, event_name: String, params: Vec<ScillaParam>) -> Self {
-        Log::Scilla(ScillaLog {
-            address,
-            event_name,
-            params,
-        })
-    }
-
     pub fn into_evm(self) -> Option<EvmLog> {
         match self {
             Log::Evm(l) => Some(l),


### PR DESCRIPTION
This mostly relies on the supporting code in alloy and `revm-inspectors`. I did have to do some work on our side to split the existing `TransactionApplyResult` into an `Evm` and `Scilla` variant, so we can get at the necessary data to build a replay for EVM transactions.

Support for Scilla transactions will come next.