### PR TITLE
Update alloy and revm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,7 +92,7 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 [[package]]
 name = "alloy-consensus"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=07611cf#07611cfc9f277dc5bbfd7d21e9d70ad37b441a51"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "alloy-eips"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=07611cf#07611cfc9f277dc5bbfd7d21e9d70ad37b441a51"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -119,7 +119,7 @@ dependencies = [
 [[package]]
 name = "alloy-genesis"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=07611cf#07611cfc9f277dc5bbfd7d21e9d70ad37b441a51"
 dependencies = [
  "alloy-primitives",
  "alloy-serde",
@@ -129,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525448f6afc1b70dd0f9d0a8145631bf2f5e434678ab23ab18409ca264cae6b3"
+checksum = "db8aa973e647ec336810a9356af8aea787249c9d00b1525359f3db29a68d231b"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -175,7 +175,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=07611cf#07611cfc9f277dc5bbfd7d21e9d70ad37b441a51"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -193,7 +193,7 @@ dependencies = [
 [[package]]
 name = "alloy-rpc-types-trace"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=07611cf#07611cfc9f277dc5bbfd7d21e9d70ad37b441a51"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "alloy-serde"
 version = "0.1.0"
-source = "git+https://github.com/alloy-rs/alloy.git?rev=77c1240#77c1240533b411ed0eb5533f94396eba8d7f6ab6"
+source = "git+https://github.com/alloy-rs/alloy.git?rev=07611cf#07611cfc9f277dc5bbfd7d21e9d70ad37b441a51"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -214,9 +214,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c80a2cb97e7aa48611cbb63950336f9824a174cdf670527cc6465078a26ea1"
+checksum = "7dbd17d67f3e89478c8a634416358e539e577899666c927bc3d2b1328ee9b6ca"
+dependencies = [
+ "alloy-sol-macro-expander",
+ "alloy-sol-macro-input",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.63",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6da95adcf4760bb4b108fefa51d50096c5e5fdd29ee72fed3e86ee414f2e34"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -232,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c58894b58ac50979eeac6249661991ac40b9d541830d9a725f7714cc9ef08c23"
+checksum = "32c8da04c1343871fb6ce5a489218f9c85323c8340a36e9106b5fc98d4dd59d5"
 dependencies = [
  "const-hex",
  "dunce",
@@ -247,9 +261,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399287f68d1081ed8b1f4903c49687658b95b142207d7cb4ae2f4813915343ef"
+checksum = "40a64d2d2395c1ac636b62419a7b17ec39031d6b2367e66e9acbf566e6055e9c"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-macro",
@@ -951,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3130f3d8717cc02e668a896af24984d5d5d4e8bf12e278e982e0f1bd88a0f9af"
+checksum = "cdf100c4cea8f207e883ff91ca886d621d8a166cb04971dfaa9bb8fd99ed95df"
 dependencies = [
  "blst",
  "cc",
@@ -5319,7 +5333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19de2de2a00075bf566bee3bd4db014b11587e84184d3f7a791bc17f1a8e9e48"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.63",
@@ -5659,9 +5673,9 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "8.0.0"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a454c1c650b2b2e23f0c461af09e6c31e1d15e1cbebe905a701c46b8a50afc"
+checksum = "3a2c336f9921588e50871c00024feb51a521eca50ce6d01494bb9c50f837c8ed"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -5675,7 +5689,7 @@ dependencies = [
 [[package]]
 name = "revm-inspectors"
 version = "0.1.0"
-source = "git+https://github.com/paradigmxyz/evm-inspectors.git#3b6f81f2d1c16e559b0bd704f6b456ab9151ecdd"
+source = "git+https://github.com/paradigmxyz/evm-inspectors.git?rev=5c47bc8#5c47bc87d2bc7c633120ca9997a7c3c5ec8f1e4c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types",
@@ -5690,9 +5704,9 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d322f2730cd300e99d271a1704a2dfb8973d832428f5aa282aaa40e2473b5eec"
+checksum = "a58182c7454179826f9dad2ca577661963092ce9d0fd0c9d682c1e9215a72e70"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -5700,11 +5714,12 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "931f692f3f4fc72ec39d5d270f8e9d208c4a6008de7590ee96cf948e3b6d3f8d"
+checksum = "dc8af9aa737eef0509a50d9f3cc1a631557a00ef2e70a3aa8a75d9ee0ed275bb"
 dependencies = [
  "aurora-engine-modexp",
+ "blst",
  "c-kzg",
  "k256",
  "once_cell",
@@ -5717,9 +5732,9 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "3.1.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbc9640790cebcb731289afb7a7d96d16ad94afeb64b5d0b66443bd151e79d6"
+checksum = "b9bf5d465e64b697da6a111cb19e798b5b2ebb18e5faf2ad48e9e8d47c64add2"
 dependencies = [
  "alloy-primitives",
  "auto_impl",
@@ -6162,9 +6177,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1"
-version = "0.28.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
+checksum = "0e0cc0f1cf93f4969faf3ea1c7d8a9faed25918d96affa959720823dfe86d4f3"
 dependencies = [
  "rand",
  "secp256k1-sys",
@@ -6172,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.9.2"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+checksum = "1433bd67156263443f14d603720b082dd3121779323fce20cba2aa07b874bc1b"
 dependencies = [
  "cc",
 ]
@@ -6694,9 +6709,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa0cefd02f532035d83cfec82647c6eb53140b0485220760e669f4bad489e36"
+checksum = "b8db114c44cf843a8bacd37a146e37987a0b823a0e8bc4fdc610c9c72ab397a5"
 dependencies = [
  "paste",
  "proc-macro2",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -26,9 +26,9 @@ vergen = { version = "8.3.1", features = ["git", "git2"] }
 [dependencies]
 alloy-primitives = { version = "0.7.2", features = ["rlp", "serde"] }
 alloy-rlp = { version = "0.3.4", features = ["derive"] }
-alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "77c1240", features = ["serde", "k256"] }
-alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "77c1240", features = ["serde"] }
-alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy.git", rev = "77c1240" }
+alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf", features = ["serde", "k256"] }
+alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf", features = ["serde"] }
+alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf" }
 anyhow = { version = "1.0.83", features = ["backtrace"] }
 async-trait = "0.1.80"
 base64 = "0.22.1"
@@ -60,8 +60,8 @@ prost = "0.12.4"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
-revm = { version = "8.0.0", features = ["optional_balance_check"] }
-revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors.git", version = "0.1.0" }
+revm = { version = "9.0.0", features = ["optional_balance_check"] }
+revm-inspectors = { git = "https://github.com/paradigmxyz/evm-inspectors.git", rev = "5c47bc8" }
 serde = { version = "1.0.201", features = ["derive", "rc"] }
 serde_bytes = "0.11.14"
 serde_json = { version = "1.0.117", features = ["raw_value"] }

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -17,8 +17,8 @@ use libp2p::PeerId;
 use revm::{
     inspector_handle_register,
     primitives::{
-        AccountInfo, BlockEnv, Bytecode, BytecodeState, ExecutionResult, HandlerCfg, Output,
-        ResultAndState, SpecId, TransactTo, TxEnv, B256, KECCAK_EMPTY,
+        AccountInfo, BlockEnv, Bytecode, ExecutionResult, HandlerCfg, Output, ResultAndState,
+        SpecId, TransactTo, TxEnv, B256, KECCAK_EMPTY,
     },
     Database, DatabaseRef, Evm, Inspector,
 };
@@ -241,10 +241,9 @@ impl DatabaseRef for &State {
             balance: U256::from(account.balance),
             nonce: account.nonce,
             code_hash: KECCAK_EMPTY,
-            code: Some(Bytecode {
-                bytecode: account.contract.evm_code().unwrap_or_default().into(),
-                state: BytecodeState::Raw,
-            }),
+            code: Some(Bytecode::new_raw(
+                account.contract.evm_code().unwrap_or_default().into(),
+            )),
         };
 
         Ok(Some(account_info))
@@ -384,6 +383,8 @@ impl State {
                 gas_priority_fee: None,
                 blob_hashes: vec![],
                 max_fee_per_blob_gas: None,
+                eof_initcodes: vec![],
+                eof_initcodes_hashed: HashMap::new(),
             })
             .append_handler_register(|handler| {
                 let precompiles = handler.pre_execution.load_precompiles();


### PR DESCRIPTION
These crates share a large chunk of their dependencies, so it makes sense to update them all in tandem.

Version updates for:

* alloy-consensus
* alloy-eips
* alloy-genesis
* alloy-primitives
* alloy-rpc-types
* alloy-rpc-types-trace
* alloy-serde
* alloy-sol-macro
* alloy-sol-macro-expander
* alloy-sol-macro-input
* alloy-sol-types
* c-kzg
* revm
* revm-inspectors
* revm-interpreter
* revm-precompile
* revm-primitives
* secp256k1
* secp256k1-sys
* syn-solidity