### PR TITLE
Implement `eth_subscribe` for `logs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8141,6 +8141,7 @@ dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
+ "alloy-rpc-types",
  "alloy-rpc-types-trace",
  "anyhow",
  "async-trait",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -28,6 +28,7 @@ alloy-primitives = { version = "0.7.2", features = ["rlp", "serde"] }
 alloy-rlp = { version = "0.3.4", features = ["derive"] }
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf", features = ["serde", "k256"] }
 alloy-eips = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf", features = ["serde"] }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf" }
 alloy-rpc-types-trace = { git = "https://github.com/alloy-rs/alloy.git", rev = "07611cf" }
 anyhow = { version = "1.0.83", features = ["backtrace"] }
 async-trait = "0.1.80"

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -491,6 +491,11 @@ impl Node {
         self.consensus.new_blocks.subscribe()
     }
 
+    /// Returns a stream of pairs of (receipt, index of transaction in block)
+    pub fn subscribe_to_receipts(&self) -> broadcast::Receiver<(TransactionReceipt, usize)> {
+        self.consensus.receipts.subscribe()
+    }
+
     pub fn get_chain_id(&self) -> u64 {
         self.config.eth_chain_id // using eth as a universal ID for now
     }


### PR DESCRIPTION
Similar to the existing implementation for `newHeads` - We add a new `broadcast::Sender` to `Consensus` for transaction receipts and subscribe to it when an `eth_subscribe` request is made.