### PR TITLE
(feat): Create the docker image for zq2 node

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: docker
     env:
       GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
-      GCP_REGISTRY: asia-docker.pkg.dev/${{ secrets.GCP_PRD_REGISTRY_PROJECT_ID }}/zilliqa-public
+      GCP_REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public
     steps:
     - name: 'Checkout scm'
       uses: actions/checkout@v4
@@ -63,7 +63,7 @@ jobs:
       runs-on: docker
       env:
         GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
-        GCP_REGISTRY: asia-docker.pkg.dev/${{ secrets.GCP_PRD_REGISTRY_PROJECT_ID }}/zilliqa-private
+        GCP_REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private
       steps:
       - name: 'Checkout scm'
         uses: actions/checkout@v4

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -13,8 +13,8 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    if: ${{ github.ref_name != 'main' && github.ref_type == 'tag' }} 
-    runs-on: docker
+    if: ${{ github.ref_name != 'gh-issue-937' && github.ref_type == 'tag' }} 
+    runs-on: [ self-hosted, gcp]
     env:
       GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
       GCP_REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public
@@ -60,7 +60,7 @@ jobs:
         id-token: write
         contents: write
       if: ${{ github.ref_name == 'gh-issue-937' }} 
-      runs-on: docker
+      runs-on: [ self-hosted, gcp]
       env:
         GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
         GCP_REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,35 +1,28 @@
-name: "ZQ2 image release - public"
+name: "ZQ2 image release"
 
 on:
-  workflow_dispatch:
-    inputs:
-      commitOrTag:
-        description: 'Commit or tag'
-        required: false
-        default: ''
   push:
     branches:
+      - 'release/**'
       - 'gh-issue-937'
     tags:        
-      - release/v*
+      - v*
 
 jobs:
-  release-image:
+  release-pub-image:
     permissions:
       id-token: write
       contents: write
+    if: ${{ github.ref_name != 'main' && github.ref_type == 'tag' }} 
     runs-on: docker
     env:
       GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
       GCP_REGISTRY: asia-docker.pkg.dev/${{ secrets.GCP_PRD_REGISTRY_PROJECT_ID }}/zilliqa-public
     steps:
-    - name: 'Checkout scm ${{ inputs.commitOrTag }}'
+    - name: 'Checkout scm'
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
-        ref: ${{ inputs.commitOrTag }}
-    - name: show-payload
-      run: echo ${{ toJSON(github) }}
     - name: "Configure GCP Credentials"
       id: google-auth
       uses: "google-github-actions/auth@v2"
@@ -51,14 +44,58 @@ jobs:
     - name: Build ZQ2 Docker images
       run: DOCKER_BUILDKIT=1 docker build -t zilliqa/zq2:${{ github.ref_name }} -t ${{ env.GCP_REGISTRY }}/zq2:${{ github.ref_name }} -f Dockerfile .
       shell: bash
-    # - name: Login to the DockerHub
-    #   uses: docker/login-action@v2
-    #   with:
-    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
-    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-    # - name: Push Docker images to Dockerhub
-    #   run: docker push zilliqa/zq2:${{ github.ref_name}}
-    #   shell: bash
-    # - name: Push Docker images to GCP
-    #   run: docker push ${{ env.GCP_REGISTRY }}/zq2:${{ github.ref_name }}
-    #   shell: bash
+    - name: Login to the DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    - name: Push Docker images to Dockerhub
+      run: docker push zilliqa/zq2:${{ github.ref_name}}
+      shell: bash
+    - name: Push Docker images to GCP
+      run: docker push ${{ env.GCP_REGISTRY }}/zq2:${{ github.ref_name }}
+      shell: bash
+  release-private-image:
+      permissions:
+        id-token: write
+        contents: write
+      if: ${{ github.ref_name == 'gh-issue-937' }} 
+      runs-on: docker
+      env:
+        GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
+        GCP_REGISTRY: asia-docker.pkg.dev/${{ secrets.GCP_PRD_REGISTRY_PROJECT_ID }}/zilliqa-private
+      steps:
+      - name: 'Checkout scm'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get tag version - private image
+        id: set-tag
+        uses: Zilliqa/gh-actions-workflows/actions/generate-tag@v2
+        with:
+          tag: ${{ env.GCP_REGISTRY }}/zq2
+          length: 8
+      - name: "Configure GCP Credentials"
+        id: google-auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service_account: "${{ secrets.GCP_PRD_GITHUB_SA_DOCKER_REGISTRY }}"
+          create_credentials_file: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to the GCP registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.GCP_REGISTRY_DOMAIN }}
+          username: "oauth2accesstoken"
+          password: "${{ steps.google-auth.outputs.access_token }}"
+      - name: Build ZQ2 Docker images
+        run: DOCKER_BUILDKIT=1 docker build -t ${{ steps.set-tag.outputs.tags }} -f Dockerfile .
+        shell: bash
+      - name: Push Docker images to GCP
+        run: docker push ${{ steps.set-tag.outputs.tags }}
+        shell: bash

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -1,0 +1,64 @@
+name: "ZQ2 image release - public"
+
+on:
+  workflow_dispatch:
+    inputs:
+      commitOrTag:
+        description: 'Commit or tag'
+        required: false
+        default: ''
+  push:
+    branches:
+      - 'gh-issue-937'
+    tags:        
+      - release/v*
+
+jobs:
+  release-image:
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: docker
+    env:
+      GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
+      GCP_REGISTRY: asia-docker.pkg.dev/${{ secrets.GCP_PRD_REGISTRY_PROJECT_ID }}/zilliqa-public
+    steps:
+    - name: 'Checkout scm ${{ inputs.commitOrTag }}'
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.commitOrTag }}
+    - name: show-payload
+      run: echo ${{ toJSON(github) }}
+    - name: "Configure GCP Credentials"
+      id: google-auth
+      uses: "google-github-actions/auth@v2"
+      with:
+        token_format: "access_token"
+        workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+        service_account: "${{ secrets.GCP_PRD_GITHUB_SA_DOCKER_REGISTRY }}"
+        create_credentials_file: true
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Login to the GCP registry
+      uses: docker/login-action@v2
+      with:
+        registry: ${{ env.GCP_REGISTRY_DOMAIN }}
+        username: "oauth2accesstoken"
+        password: "${{ steps.google-auth.outputs.access_token }}"
+    - name: Build ZQ2 Docker images
+      run: DOCKER_BUILDKIT=1 docker build -t zilliqa/zq2:${{ github.ref_name }} -t ${{ env.GCP_REGISTRY }}/zq2:${{ github.ref_name }} -f Dockerfile .
+      shell: bash
+    # - name: Login to the DockerHub
+    #   uses: docker/login-action@v2
+    #   with:
+    #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+    #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
+    # - name: Push Docker images to Dockerhub
+    #   run: docker push zilliqa/zq2:${{ github.ref_name}}
+    #   shell: bash
+    # - name: Push Docker images to GCP
+    #   run: docker push ${{ env.GCP_REGISTRY }}/zq2:${{ github.ref_name }}
+    #   shell: bash

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -94,7 +94,7 @@ jobs:
           username: "oauth2accesstoken"
           password: "${{ steps.google-auth.outputs.access_token }}"
       - name: Build ZQ2 Docker images
-        run: DOCKER_BUILDKIT=1 docker build -t ${{ steps.set-tag.outputs.tags }} -f Dockerfile .
+        run: DOCKER_BUILDKIT=1 docker build --build-arg="is_ci=true" -t ${{ steps.set-tag.outputs.tags }} -f Dockerfile .
         shell: bash
       - name: Push Docker images to GCP
         run: docker push ${{ steps.set-tag.outputs.tags }}

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - 'release/**'
-      - 'gh-issue-937'
+      - 'main'
     tags:        
       - v*
 
@@ -13,7 +13,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    if: ${{ github.ref_name != 'gh-issue-937' && github.ref_type == 'tag' }} 
+    if: ${{ github.ref_name != 'main' && github.ref_type == 'tag' }} 
     runs-on: [ self-hosted, gcp]
     env:
       GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
@@ -59,7 +59,7 @@ jobs:
       permissions:
         id-token: write
         contents: write
-      if: ${{ github.ref_name == 'gh-issue-937' }} 
+      if: ${{ github.ref_name == 'main' }} 
       runs-on: [ self-hosted, gcp]
       env:
         GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -94,7 +94,7 @@ jobs:
           username: "oauth2accesstoken"
           password: "${{ steps.google-auth.outputs.access_token }}"
       - name: Build ZQ2 Docker images
-        run: DOCKER_BUILDKIT=1 docker build --build-arg="is_ci=true" -t ${{ steps.set-tag.outputs.tags }} -f Dockerfile .
+        run: DOCKER_BUILDKIT=1 docker build --build-arg="is_release=true" -t ${{ steps.set-tag.outputs.tags }} -f Dockerfile .
         shell: bash
       - name: Push Docker images to GCP
         run: docker push ${{ steps.set-tag.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM rust:1.78.0-slim-bullseye as builder
 
-ARG is_ci=false
+ARG is_release=false
 RUN apt update -y && \
     apt upgrade -y && \
     apt install -y protobuf-compiler
@@ -15,7 +15,7 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/target \
-    if [ "${is_ci}" != "true " ] ; then \
+    if [ "${is_release}" != "true " ] ; then \
         cargo build --bin zilliqa && \
         mv ./target/debug/zilliqa ./build/ ;\
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM rust:1.78.0-slim-bullseye as builder
 
+ARG is_ci=false
 RUN apt update -y && \
     apt upgrade -y && \
     apt install -y protobuf-compiler
@@ -14,9 +15,19 @@ COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/target \
+    if [ "${is_ci}" != "true " ] ; then \
     cargo build --bin zilliqa && \
-    mv ./target/debug/zilliqa ./build/
+    mv ./target/debug/zilliqa ./build/ ;\
+    fi
 
+RUN if [ "${is_ci}" == "true " ]; then \
+    cargo test --release --all-targets --all-features ;\
+    fi
+
+RUN if [ "${is_ci}" == "true " ]; then \
+    cargo build --release --bin zilliqa && \
+    mv ./target/release/zilliqa ./build/ ;\
+    fi
 
 FROM ubuntu:22.04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,13 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/target \
     if [ "${is_ci}" != "true " ] ; then \
-    cargo build --bin zilliqa && \
-    mv ./target/debug/zilliqa ./build/ ;\
+        cargo build --bin zilliqa && \
+        mv ./target/debug/zilliqa ./build/ ;\
+    else \
+        cargo build --release --bin zilliqa && \
+        mv ./target/release/zilliqa ./build/ ;\
     fi
 
-RUN if [ "${is_ci}" == "true " ]; then \
-    cargo test --release --all-targets --all-features ;\
-    fi
-
-RUN if [ "${is_ci}" == "true " ]; then \
-    cargo build --release --bin zilliqa && \
-    mv ./target/release/zilliqa ./build/ ;\
-    fi
 
 FROM ubuntu:22.04
 


### PR DESCRIPTION
Rudimentary process to build and push the zq2 docker images as per issue #937 defines.

Will open follow-up issues for:
1. add an image test step
2. export the version as env variable so the software can use it as input for specifying the version
3. use the image to run the tests
