### PR TITLE
Enforce block gas limit and keep track of cumulative gas used

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -258,6 +258,7 @@ pub async fn convert_persistence(
                             tx_hash: Hash(txn_hash.0),
                             success: transaction.receipt.success,
                             gas_used: EvmGas(transaction.receipt.cumulative_gas),
+                            cumulative_gas_used: EvmGas(transaction.receipt.cumulative_gas),
                             contract_address,
                             logs: transaction
                                 .receipt
@@ -318,6 +319,7 @@ pub async fn convert_persistence(
                             tx_hash: Hash(txn_hash.0),
                             success: transaction.receipt.success,
                             gas_used: EvmGas(transaction.receipt.cumulative_gas),
+                            cumulative_gas_used: EvmGas(transaction.receipt.cumulative_gas),
                             contract_address,
                             logs: transaction
                                 .receipt

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -545,7 +545,7 @@ pub(super) fn get_transaction_receipt_inner(
         block_number: block.number(),
         from,
         to: transaction.to_addr(),
-        cumulative_gas_used: EvmGas(0),
+        cumulative_gas_used: receipt.cumulative_gas_used,
         effective_gas_price: transaction.max_fee_per_gas(),
         gas_used: receipt.gas_used,
         contract_address: receipt.contract_address,

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -181,7 +181,7 @@ impl GetTxResponse {
                 amount: tx.amount,
                 signature: sig,
                 receipt: GetTxResponseReceipt {
-                    cumulative_gas: receipt.gas_used.into(),
+                    cumulative_gas: receipt.cumulative_gas_used.into(),
                     epoch_num: block_number,
                     event_logs: receipt
                         .logs


### PR DESCRIPTION
When filling a block with transactions from the mempool, we stop taking transactions once the block gas limit is reached.

Resolves #967 