### PR TITLE
Encode P2P messages with CBOR instead of JSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cbor4ii"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b4c883b9cc4757b061600d39001d4d0232bece4a3174696cf8f58a14db107d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,6 +4013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6946e5456240b3173187cc37a17cb40c3cd1f7138c76e2c773e0d792a42a8de1"
 dependencies = [
  "async-trait",
+ "cbor4ii",
  "futures",
  "futures-bounded",
  "futures-timer",
@@ -4013,7 +4023,6 @@ dependencies = [
  "libp2p-swarm",
  "rand",
  "serde",
- "serde_json",
  "smallvec",
  "tracing",
  "void",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -50,7 +50,7 @@ hyper = "0.14.27"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.22.3", features = ["jsonrpsee-http-client", "server"] }
 k256 = {version = "0.13.3", features = ["serde", "pem"] }
-libp2p = { version = "0.53.2", features = ["gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "json", "kad", "identify", "serde", "yamux"] }
+libp2p = { version = "0.53.2", features = ["cbor", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux"] }
 lru = "0.12"
 once_cell = "1.19.0"
 opentelemetry = { version = "0.23.0", features = ["metrics"] }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -37,7 +37,7 @@ type DirectMessage = (u64, ExternalMessage);
 
 #[derive(NetworkBehaviour)]
 struct Behaviour {
-    request_response: request_response::json::Behaviour<DirectMessage, DirectMessage>,
+    request_response: request_response::cbor::Behaviour<DirectMessage, DirectMessage>,
     gossipsub: gossipsub::Behaviour,
     mdns: mdns::tokio::Behaviour,
     identify: identify::Behaviour,
@@ -92,7 +92,7 @@ impl P2pNode {
             .boxed();
 
         let behaviour = Behaviour {
-            request_response: request_response::json::Behaviour::new(
+            request_response: request_response::cbor::Behaviour::new(
                 iter::once((StreamProtocol::new("/zq2-message/1"), ProtocolSupport::Full)),
                 Default::default(),
             ),


### PR DESCRIPTION
It doesn't really make sense to use JSON given there isn't a convenient way for a human to read these messages anyway. And JSON payloads will be much larger than binary.