### PR TITLE
Merge configuration files if more than one is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Run:
 docker-compose up
 ```
 
+## Node configuration
+
+Nodes are configured by TOML files.
+Pass the path to configuration files on the command line with `-c` or `--config-file`.
+If multiple configuration files are provided, they will be merged together.
+If a configuration key occurs in more than one configuration file, the process will exit with an error.
+
 ## Testing
 
 The tests can be run with `cargo test`.


### PR DESCRIPTION
After some discussion with Mauro, we realised that node configuration can be split broadly into two categories:

* Stuff that never changes and should have the same values across all nodes in a network - e.g. configuration for the genesis block.
* Stuff that is specific to each node - e.g. port configuration, enabled APIs.

We decided that a simple way to handle this split was to allow multiple configuration files which get merged by the application.

We deliberately ban configuration keys from occurring in more than one file. Therefore, no inheritance or overriding occurs when merging.