### PR TITLE
Flatten Scilla contract storage on disk

### DIFF
--- a/eth-trie.rs/src/trie.rs
+++ b/eth-trie.rs/src/trie.rs
@@ -242,6 +242,17 @@ where
         })
     }
 
+    pub fn remove_by_prefix(&mut self, prefix: &[u8]) -> TrieResult<()> {
+        // TODO(#1025): Optimise this
+        let keys: Vec<_> = self.iter_by_prefix(prefix)?.map(|(k, _)| k).collect();
+
+        for key in keys {
+            assert!(self.remove(&key)?);
+        }
+
+        Ok(())
+    }
+
     pub fn new(db: Arc<D>) -> Self {
         Self {
             root: Node::Empty,

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy};
+use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy, EMPTY_ROOT_HASH};
 use alloy_primitives::{Address, Parity, Signature, TxKind, B256, U256};
 use anyhow::{anyhow, Context, Result};
 use bitvec::bitvec;
@@ -33,7 +33,7 @@ use zilliqa::{
     inspector,
     message::{Block, BlockHeader, QuorumCertificate, Vote},
     schnorr,
-    state::{contract_addr, Account, Contract, State},
+    state::{contract_addr, Account, Code, State},
     time::SystemTime,
     transaction::{
         EvmGas, EvmLog, Log, ScillaGas, SignedTransaction, TransactionReceipt, TxZilliqa, ZilAmount,
@@ -95,14 +95,8 @@ pub async fn convert_persistence(
             let account = Account {
                 nonce: zq1_account.nonce,
                 balance: zq1_account.balance * 10u128.pow(6),
-                contract: Contract::Evm {
-                    code: zq1_account
-                        .contract
-                        .as_ref()
-                        .map(|_| zq1_db.get_contract_code(address).unwrap().unwrap())
-                        .unwrap_or_default(),
-                    storage_root: None,
-                },
+                code: Code::Evm(vec![]), // TODO: Convert contract code and state
+                storage_root: EMPTY_ROOT_HASH,
             };
 
             state.save_account(address, account)?;

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -169,7 +169,7 @@ fn get_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
         .lock()
         .unwrap()
         .get_account(address, block_number)?
-        .contract
+        .code
         .evm_code()
         .unwrap_or_default()
         .to_hex())

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -19,7 +19,6 @@ use crate::{
     inspector::{self, CreatorInspector, OtterscanOperationInspector, OtterscanTraceInspector},
     message::BlockNumber,
     node::Node,
-    state::Contract,
     time::SystemTime,
 };
 
@@ -231,15 +230,12 @@ fn has_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
     let address: Address = params.next()?;
     let block_number: BlockNumber = params.next()?;
 
-    let contract = node
+    let empty = node
         .lock()
         .unwrap()
         .get_account(address, block_number)?
-        .contract;
-    let empty = match contract {
-        Contract::Evm { code, .. } => code.is_empty(),
-        Contract::Scilla { code, .. } => code.is_empty(),
-    };
+        .code
+        .is_eoa();
 
     Ok(!empty)
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -619,7 +619,7 @@ impl Consensus {
             let stakers = self.state.get_stakers()?;
 
             if !stakers.iter().any(|v| *v == self.public_key()) {
-                info!(
+                trace!(
                     "can't vote for block proposal, we aren't in the committee of length {:?}",
                     stakers.len()
                 );

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -512,6 +512,11 @@ impl Node {
         self.consensus.head_block().header.number
     }
 
+    pub fn state_at(&self, block_number: BlockNumber) -> Result<State> {
+        self.consensus
+            .try_get_state_at(self.get_number(block_number))
+    }
+
     pub fn get_account(&self, address: Address, block_number: BlockNumber) -> Result<Account> {
         self.consensus
             .try_get_state_at(self.get_number(block_number))?

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -1,6 +1,7 @@
 //! Interface to the Scilla intepreter
 
 use std::{
+    collections::BTreeMap,
     net::{Ipv4Addr, SocketAddr},
     str,
     sync::{
@@ -14,6 +15,7 @@ use std::{
 use alloy_primitives::Address;
 use anyhow::{anyhow, Result};
 use base64::Engine;
+use bytes::{BufMut, Bytes, BytesMut};
 use jsonrpsee::{
     core::{client::ClientT, params::ObjectParams, ClientError},
     http_client::HttpClientBuilder,
@@ -31,10 +33,9 @@ use tokio::runtime;
 use tracing::trace;
 
 use crate::{
-    exec::PendingState,
-    scilla_proto::{Map, ProtoScillaQuery, ProtoScillaVal, ValType},
+    exec::{PendingState, StorageValue},
+    scilla_proto::{self, ProtoScillaQuery, ProtoScillaVal, ValType},
     serde_util::{bool_as_str, num_as_str},
-    state::ScillaValue,
     transaction::{ScillaGas, ZilAmount},
 };
 
@@ -388,7 +389,7 @@ pub struct ScillaEvent {
 pub struct ParamValue {
     #[serde(rename = "vname")]
     pub name: String,
-    pub value: String,
+    pub value: Value,
     #[serde(rename = "type")]
     pub ty: String,
 }
@@ -583,21 +584,32 @@ impl StateServer {
     }
 }
 
-fn convert_scilla_value(value: &ScillaValue) -> ProtoScillaVal {
-    match value {
-        ScillaValue::Bytes(bytes) => ProtoScillaVal {
-            val_type: Some(ValType::Bval(bytes.clone())),
-        },
-        ScillaValue::Map(map) => {
-            let m = map
-                .iter()
-                .map(|(k, v)| (k.clone(), convert_scilla_value(v)))
-                .collect();
-            ProtoScillaVal {
-                val_type: Some(ValType::Mval(Map { m })),
-            }
-        }
+// Scilla values are stored on disk in a flattened structure. We concatenate the indices that locate a given value.
+// Each index is separated by a `0x1F` (ASCII unit separator) byte. This is currently safe, because this byte cannot
+// occur in Scilla values, but we include an assertion to make sure this remains true.
+
+// Separate each index with the ASCII unit separator byte.
+const SEPARATOR: u8 = 0x1F;
+
+pub fn storage_key(var_name: &str, indices: &[Vec<u8>]) -> Bytes {
+    let len = var_name.len() + indices.len() + indices.iter().map(|v| v.len()).sum::<usize>();
+    let mut bytes = BytesMut::with_capacity(len);
+    bytes.extend_from_slice(var_name.as_bytes());
+    for index in indices {
+        assert!(!index.contains(&SEPARATOR));
+        bytes.put_u8(SEPARATOR);
+        bytes.extend_from_slice(index.as_slice());
     }
+    bytes.freeze()
+}
+
+pub fn split_storage_key(key: impl AsRef<[u8]>) -> Result<(String, Vec<Vec<u8>>)> {
+    let mut parts = key.as_ref().split(|b| *b == SEPARATOR);
+    let var_name = parts.next().expect("split always returns one element");
+    let var_name = String::from_utf8(var_name.to_vec())?;
+    let indices = parts.map(|s| s.to_vec()).collect();
+
+    Ok((var_name, indices))
 }
 
 #[derive(Debug)]
@@ -613,29 +625,54 @@ impl ActiveCall {
         name: String,
         indices: Vec<Vec<u8>>,
     ) -> Result<Option<(ProtoScillaVal, String)>> {
-        let account = self.state.load_account(addr)?;
-        let storage = account
-            .contract
-            .scilla_storage()
-            .ok_or_else(|| anyhow!("not a scilla contract"))?;
+        let (ty, depth) = self.state.load_var_info(addr, &name)?;
+        let ty = ty.to_owned();
 
-        let Some((value, ty)) = storage.get(&name) else {
-            return Ok(None);
-        };
-        let mut value = value;
-
-        for index in &indices {
-            let index = str::from_utf8(index)?;
-            let Some(map) = value.as_map() else {
-                return Err(anyhow!("not a map"));
-            };
-            let Some(inner) = map.get(index) else {
-                return Ok(None);
-            };
-            value = inner;
+        if indices.len() > depth as usize {
+            return Err(anyhow!("too many indices"));
         }
 
-        Ok(Some((convert_scilla_value(value), ty.clone())))
+        let value = if depth as usize == indices.len() {
+            let value = self.state.load_storage(addr, &name, &indices)?.clone();
+            let Some(value) = value else {
+                return Ok(None);
+            };
+            ProtoScillaVal {
+                val_type: Some(ValType::Bval(value.to_vec())),
+            }
+        } else {
+            let value = self.state.load_storage_by_prefix(addr, &name, &indices)?;
+
+            fn convert(value: BTreeMap<Vec<u8>, StorageValue>) -> ProtoScillaVal {
+                ProtoScillaVal::map(
+                    value
+                        .into_iter()
+                        .filter_map(|(k, v)| {
+                            let k = serde_json::from_slice(&k).ok()?;
+                            Some((
+                                k,
+                                match v {
+                                    StorageValue::Map { map, complete } => {
+                                        assert!(complete);
+                                        convert(map)
+                                    }
+                                    StorageValue::Value(Some(value)) => {
+                                        ProtoScillaVal::bytes(value.into())
+                                    }
+                                    StorageValue::Value(None) => {
+                                        return None;
+                                    }
+                                },
+                            ))
+                        })
+                        .collect(),
+                )
+            }
+
+            convert(value)
+        };
+
+        Ok(Some((value, ty)))
     }
 
     fn fetch_state_value(
@@ -663,12 +700,12 @@ impl ActiveCall {
         let account = self.state.load_account(addr)?;
         match name.as_str() {
             "_balance" => {
-                let balance = ZilAmount::from_amount(account.balance);
+                let balance = ZilAmount::from_amount(account.account.balance);
                 let val = scilla_val(format!("\"{balance}\"").into_bytes());
                 Ok(Some((val, "Uint128".to_owned())))
             }
             "_nonce" => {
-                let val = scilla_val(format!("\"{}\"", account.nonce + 1).into_bytes());
+                let val = scilla_val(format!("\"{}\"", account.account.nonce + 1).into_bytes());
                 Ok(Some((val, "Uint64".to_owned())))
             }
             "_this_address" => {
@@ -678,7 +715,7 @@ impl ActiveCall {
             "_codehash" => {
                 todo!()
             }
-            _ => self.fetch_value_inner(addr, name, indices),
+            _ => self.fetch_value_inner(addr, name.clone(), indices.clone()),
         }
     }
 
@@ -689,67 +726,48 @@ impl ActiveCall {
         ignore_value: bool,
         value: ProtoScillaVal,
     ) -> Result<()> {
-        let account = self.state.load_account(self.sender)?;
-        let storage = account
-            .contract
-            .scilla_storage_mut()
-            .ok_or_else(|| anyhow!("not a scilla contract"))?;
-        let Some((storage_slot, _)) = storage.get_mut(&name) else {
-            return Ok(());
-        };
+        let (_, depth) = self.state.load_var_info(self.sender, &name)?;
+        let depth = depth as usize;
+
+        if indices.len() > depth {
+            return Err(anyhow!("too many indices"));
+        }
 
         if ignore_value {
-            if indices.is_empty() {
-                return Err(anyhow!("indices cannot be empty"));
-            }
-
-            let Some(mut map) = storage_slot.as_map_mut() else {
-                return Err(anyhow!("not a map"));
+            // We only supporting deleting a single value of a map.
+            assert_eq!(indices.len(), depth);
+            let storage_slot = self.state.load_storage(self.sender, &name, &indices)?;
+            *storage_slot = None;
+        } else if indices.len() == depth {
+            let Some(ValType::Bval(value)) = value.val_type else {
+                return Err(anyhow!("invalid value"));
             };
-
-            for index in &indices[..(indices.len() - 1)] {
-                let index = str::from_utf8(index)?;
-                let Some(inner) = map.get_mut(index) else {
-                    return Ok(());
-                };
-                let Some(inner) = inner.as_map_mut() else {
-                    return Err(anyhow!("not a map"));
-                };
-                map = inner;
-            }
-
-            let last = &indices[indices.len() - 1];
-            let last = str::from_utf8(last)?;
-            map.remove(last);
+            let storage_slot = self.state.load_storage(self.sender, &name, &indices)?;
+            *storage_slot = Some(value.into());
         } else {
-            let mut storage_slot = storage_slot;
-            for index in &indices {
-                let index = str::from_utf8(index)?;
-                let Some(map) = storage_slot.as_map_mut() else {
-                    return Err(anyhow!("not a map"));
+            fn convert(value: ProtoScillaVal) -> Result<StorageValue> {
+                let Some(value) = value.val_type else {
+                    return Err(anyhow!("missing val_type"));
                 };
-                let inner = map.entry(index.to_owned()).or_insert_with(ScillaValue::map);
-                storage_slot = inner;
+                match value {
+                    ValType::Bval(bytes) => Ok(StorageValue::Value(Some(bytes.into()))),
+                    ValType::Mval(scilla_proto::Map { m }) => {
+                        let map = m
+                            .into_iter()
+                            .map(|(k, v)| Ok((k.into_bytes(), convert(v)?)))
+                            .collect::<Result<_>>()?;
+                        Ok(StorageValue::Map {
+                            map,
+                            // Note that we mark the map as complete here. The field has been fully overridden and any
+                            // existing values should be deleted.
+                            complete: true,
+                        })
+                    }
+                }
             }
 
-            fn convert(v: ProtoScillaVal) -> Result<ScillaValue> {
-                let Some(val_type) = v.val_type else {
-                    return Err(anyhow!("no val_type"));
-                };
-                let value = match val_type {
-                    ValType::Bval(bytes) => ScillaValue::Bytes(bytes),
-                    ValType::Mval(Map { m }) => ScillaValue::Map(
-                        m.into_iter()
-                            .map(|(k, v)| Ok((k, convert(v)?)))
-                            .collect::<Result<_>>()?,
-                    ),
-                };
-                Ok(value)
-            }
-
-            let value = convert(value)?;
-
-            *storage_slot = value;
+            self.state
+                .set_storage(self.sender, &name, &indices, convert(value)?)?;
         }
 
         Ok(())

--- a/zilliqa/src/scilla_proto.rs
+++ b/zilliqa/src/scilla_proto.rs
@@ -20,6 +20,20 @@ pub struct ProtoScillaVal {
     pub val_type: Option<ValType>,
 }
 
+impl ProtoScillaVal {
+    pub fn map(m: HashMap<String, ProtoScillaVal>) -> ProtoScillaVal {
+        ProtoScillaVal {
+            val_type: Some(ValType::Mval(Map { m })),
+        }
+    }
+
+    pub fn bytes(b: Vec<u8>) -> ProtoScillaVal {
+        ProtoScillaVal {
+            val_type: Some(ValType::Bval(b)),
+        }
+    }
+}
+
 #[derive(Clone, PartialEq, Eq, Oneof)]
 pub enum ValType {
     #[prost(bytes, tag = "1")]


### PR DESCRIPTION
Previously, we would serialise the full `BTreeMap` representing a Scilla contract's storage to disk and deserialise the same thing to memory whenever we needed it. Now, we flatten the map (concatenating the map indices) and store the values in a contract-specific trie. This is closer to how EVM contract storage works and means we can partially load/write a Scilla contract's storage. Also, it means the state deltas generated by our execution engine only need to store what was actually changed.

`Account` changes to always have a `storage_root` (since both EVM and Scilla contracts now store their state in a trie). `code` is now split into an enum which differentiates between EVM and Scilla contracts. Note that Scilla contracts also store their `init_data` and type information here.

I'm almost certainly missing some explanatory comments in places, so please complain if you find things hard to follow. I've been working on this for a while so I have some complexity blindness.

I made one other drive-by change to support arbitrary values in Scilla log parameters that are returned by the interpreter. Some of the example contracts on `ide.zilliqa.com` use these, so it was useful for testing.

Resolves #919 