### PR TITLE
Implement intra-contract Scilla calls

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -266,6 +266,7 @@ pub async fn convert_persistence(
                                     }))
                                 })
                                 .collect::<Result<_>>()?,
+                            transitions: vec![],
                             accepted: None,
                             errors: BTreeMap::new(),
                             exceptions: vec![],
@@ -328,6 +329,7 @@ pub async fn convert_persistence(
                                     }))
                                 })
                                 .collect::<Result<_>>()?,
+                            transitions: vec![],
                             accepted: None,
                             errors: BTreeMap::new(),
                             exceptions: vec![],

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2103,7 +2103,7 @@ impl Consensus {
             let gas_used = result.gas_used();
             cumulative_gas_used += gas_used;
             let accepted = result.accepted();
-            let (logs, errors, exceptions) = result.into_parts();
+            let (logs, transitions, errors, exceptions) = result.into_parts();
             let receipt = TransactionReceipt {
                 block_hash: block.hash(),
                 tx_hash,
@@ -2111,6 +2111,7 @@ impl Consensus {
                 success,
                 contract_address,
                 logs,
+                transitions,
                 gas_used,
                 cumulative_gas_used,
                 accepted,

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -107,10 +107,12 @@ impl TransactionApplyResult {
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn into_parts(
         self,
     ) -> (
         Vec<Log>,
+        Vec<ScillaTransition>,
         BTreeMap<u64, Vec<ScillaError>>,
         Vec<ScillaException>,
     ) {
@@ -128,12 +130,14 @@ impl TransactionApplyResult {
                         })
                     })
                     .collect(),
+                Vec::new(),
                 BTreeMap::new(),
                 Vec::new(),
             ),
             TransactionApplyResult::Scilla((
                 ScillaResult {
                     logs,
+                    transitions,
                     errors,
                     exceptions,
                     ..
@@ -141,11 +145,28 @@ impl TransactionApplyResult {
                 _,
             )) => (
                 logs.into_iter().map(Log::Scilla).collect(),
+                transitions,
                 errors,
                 exceptions,
             ),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ScillaTransition {
+    /// The address of the Scilla contract which initiated the transition.
+    pub from: Address,
+    /// The recipient of the transition.
+    pub to: Address,
+    /// The call depth of the transition.
+    pub depth: u64,
+    /// The value passed with the transition.
+    pub amount: ZilAmount,
+    /// The tag of the transition. If the recipient is a Scilla contract, this is the method that will be called.
+    pub tag: String,
+    /// Any parameters passed with the transition.
+    pub params: String,
 }
 
 pub struct ScillaResult {
@@ -157,6 +178,8 @@ pub struct ScillaResult {
     pub logs: Vec<ScillaLog>,
     /// The gas paid by the transaction
     pub gas_used: EvmGas,
+    /// Scilla transitions executed by the transaction execution.
+    pub transitions: Vec<ScillaTransition>,
     /// If the transaction was a call to a Scilla contract, whether the called contract accepted the ZIL sent to it.
     pub accepted: Option<bool>,
     /// Errors from calls to Scilla contracts. Indexed by the call depth of erroring contract.
@@ -410,11 +433,6 @@ impl State {
     ) -> Result<ScillaResultAndState> {
         let mut state = PendingState::new(self.try_clone()?);
 
-        let has_code = matches!(
-            state.load_account(txn.to_addr)?.account.code,
-            Code::Scilla { .. }
-        );
-
         let deposit = total_scilla_gas_price(txn.gas_limit, txn.gas_price);
         if let Some(result) = state.deduct_from_account(from_addr, deposit)? {
             return Ok((result, state.finalize()));
@@ -432,8 +450,6 @@ impl State {
                 current_block,
                 inspector,
             )
-        } else if !has_code {
-            scilla_transfer_to_eoa(state, from_addr, txn, inspector)
         } else {
             scilla_call(state, self.scilla(), from_addr, txn, inspector)
         }?;
@@ -1090,6 +1106,7 @@ impl PendingState {
                 contract_address: None,
                 logs: vec![],
                 gas_used: ScillaGas(0).into(),
+                transitions: vec![],
                 accepted: None,
                 errors: [(0, vec![ScillaError::InsufficientBalance])]
                     .into_iter()
@@ -1185,6 +1202,7 @@ fn scilla_create(
                 contract_address: Some(contract_address),
                 logs: vec![],
                 gas_used: (txn.gas_limit - gas).into(),
+                transitions: vec![],
                 accepted: Some(false),
                 errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
                 exceptions: vec![],
@@ -1204,6 +1222,7 @@ fn scilla_create(
                     contract_address: Some(contract_address),
                     logs: vec![],
                     gas_used: (txn.gas_limit - gas).into(),
+                    transitions: vec![],
                     accepted: Some(false),
                     errors: [(0, vec![ScillaError::CreateFailed])].into_iter().collect(),
                     exceptions: e.errors.into_iter().map(Into::into).collect(),
@@ -1240,6 +1259,7 @@ fn scilla_create(
                 contract_address: Some(contract_address),
                 logs: vec![],
                 gas_used: (txn.gas_limit - gas).into(),
+                transitions: vec![],
                 accepted: Some(false),
                 errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
                 exceptions: vec![],
@@ -1267,6 +1287,7 @@ fn scilla_create(
                     contract_address: Some(contract_address),
                     logs: vec![],
                     gas_used: (txn.gas_limit - gas).into(),
+                    transitions: vec![],
                     accepted: Some(false),
                     errors: [(0, vec![ScillaError::CreateFailed])].into_iter().collect(),
                     exceptions: e.errors.into_iter().map(Into::into).collect(),
@@ -1288,53 +1309,7 @@ fn scilla_create(
             contract_address: Some(contract_address),
             logs: vec![],
             gas_used: (txn.gas_limit - gas).into(),
-            accepted: None,
-            errors: BTreeMap::new(),
-            exceptions: vec![],
-        },
-        state,
-    ))
-}
-
-fn scilla_transfer_to_eoa(
-    mut state: PendingState,
-    from_addr: Address,
-    txn: TxZilliqa,
-    mut inspector: impl ScillaInspector,
-) -> Result<(ScillaResult, PendingState)> {
-    let gas = txn.gas_limit;
-
-    let Some(gas) = gas.checked_sub(SCILLA_TRANSFER) else {
-        warn!("not enough gas to make transfer");
-        return Ok((
-            ScillaResult {
-                success: false,
-                contract_address: None,
-                logs: vec![],
-                gas_used: (txn.gas_limit - gas).into(),
-                accepted: Some(false),
-                errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
-                exceptions: vec![],
-            },
-            state,
-        ));
-    };
-
-    if let Some(result) = state.deduct_from_account(from_addr, txn.amount)? {
-        return Ok((result, state));
-    }
-
-    let to = state.load_account(txn.to_addr)?;
-    to.account.balance += txn.amount.get();
-
-    inspector.transfer(from_addr, txn.to_addr, txn.amount.get());
-
-    Ok((
-        ScillaResult {
-            success: true,
-            contract_address: None,
-            logs: vec![],
-            gas_used: (txn.gas_limit - gas).into(),
+            transitions: vec![],
             accepted: None,
             errors: BTreeMap::new(),
             exceptions: vec![],
@@ -1344,117 +1319,203 @@ fn scilla_transfer_to_eoa(
 }
 
 fn scilla_call(
-    mut state: PendingState,
+    state: PendingState,
     scilla: MutexGuard<'_, Scilla>,
     from_addr: Address,
     txn: TxZilliqa,
     mut inspector: impl ScillaInspector,
 ) -> Result<(ScillaResult, PendingState)> {
-    // TODO: Interop
-    let Code::Scilla {
-        code, init_data, ..
-    } = &state.load_account(txn.to_addr)?.account.code
-    else {
-        return Err(anyhow!("Scilla call to a non-Scilla contract"));
-    };
-    let init_data: Vec<Value> = serde_json::from_str(init_data)?;
+    let mut gas = txn.gas_limit;
 
-    // TODO: Better parsing here
-    let mut message: Value = serde_json::from_str(&txn.data)?;
-    message["_amount"] = txn.amount.to_string().into();
-    message["_sender"] = format!("{from_addr:#x}").into();
-    message["_origin"] = format!("{from_addr:#x}").into();
-
-    let gas = txn.gas_limit;
-    let Some(gas) = gas.checked_sub(SCILLA_INVOKE_RUNNER) else {
-        warn!("not enough gas to invoke scilla runner");
-        return Ok((
-            ScillaResult {
-                success: false,
-                contract_address: None,
-                logs: vec![],
-                gas_used: (txn.gas_limit - gas).into(),
-                accepted: Some(false),
-                errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
-                exceptions: vec![],
-            },
-            state,
-        ));
+    let message = if !txn.data.is_empty() {
+        let mut m: Value = serde_json::from_str(&txn.data)?;
+        m["_amount"] = txn.amount.to_string().into();
+        m["_sender"] = format!("{from_addr:#x}").into();
+        m["_origin"] = format!("{from_addr:#x}").into();
+        Some(m)
+    } else {
+        None
     };
 
-    let code = code.clone();
-    let (output, mut state) = scilla.invoke_contract(
-        state,
-        txn.to_addr,
-        &code,
-        txn.gas_limit,
-        txn.amount,
-        &init_data,
-        &message,
-    )?;
-    let output = match output {
-        Ok(o) => o,
-        Err(e) => {
-            warn!(?e, "transaction failed");
-            let gas = gas.min(e.gas_remaining);
-            return Ok((
-                ScillaResult {
-                    success: false,
-                    contract_address: None,
-                    logs: vec![],
-                    gas_used: (txn.gas_limit - gas).into(),
-                    accepted: Some(false),
-                    errors: [(0, vec![ScillaError::CallFailed])].into_iter().collect(),
-                    exceptions: e.errors.into_iter().map(Into::into).collect(),
-                },
-                state,
-            ));
-        }
-    };
+    let mut call_stack = vec![(0, from_addr, txn.to_addr, txn.amount, message)];
+    let mut logs = vec![];
+    let mut transitions = vec![];
+    let mut root_contract_accepted = false;
 
-    info!(?output);
+    let mut state = Some(state);
 
-    let gas = gas.min(output.gas_remaining);
+    while let Some((depth, sender, to_addr, amount, message)) = call_stack.pop() {
+        let mut current_state = state.take().expect("missing state");
 
-    if output.accepted {
-        if let Some(result) = state.deduct_from_account(from_addr, txn.amount)? {
-            return Ok((result, state));
-        }
+        let code_and_data = match &current_state.load_account(to_addr)?.account.code {
+            // Both EOAs and EVM contracts are represented by [Code::Evm]. For now we handle them all as EOAs.
+            Code::Evm(_) => None,
+            Code::Scilla {
+                code, init_data, ..
+            } => Some((code, init_data)),
+        };
 
-        let to = state.load_account(txn.to_addr)?;
-        to.account.balance += txn.amount.get();
-    }
+        if let Some((code, init_data)) = code_and_data {
+            // The `to_addr` is a Scilla contract, so we are going to invoke the Scilla interpreter.
 
-    // TODO: Handle `output.messages` for multi-contract calls.
+            let Some(g) = gas.checked_sub(SCILLA_INVOKE_RUNNER) else {
+                warn!("not enough gas to invoke scilla runner");
+                return Ok((
+                    ScillaResult {
+                        success: false,
+                        contract_address: None,
+                        logs: vec![],
+                        gas_used: (txn.gas_limit - gas).into(),
+                        transitions: vec![],
+                        accepted: Some(false),
+                        errors: [(depth, vec![ScillaError::OutOfGas])].into_iter().collect(),
+                        exceptions: vec![],
+                    },
+                    current_state,
+                ));
+            };
+            gas = g;
 
-    let logs = output
-        .events
-        .into_iter()
-        .map(|e| {
-            Ok(ScillaLog {
-                address: txn.to_addr,
-                event_name: e.event_name,
-                params: e
-                    .params
-                    .into_iter()
-                    .map(|p| {
-                        Ok(ScillaParam {
-                            ty: p.ty,
-                            // If the value is a JSON string, don't double encode it.
-                            value: if let Value::String(v) = p.value {
-                                v
-                            } else {
-                                serde_json::to_string(&p.value)?
-                            },
-                            name: p.name,
+            let code = code.clone();
+            let init_data = serde_json::from_str::<Vec<_>>(init_data)?;
+
+            let (output, mut new_state) = scilla.invoke_contract(
+                current_state,
+                to_addr,
+                &code,
+                gas,
+                amount,
+                &init_data,
+                message
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("call to a Scilla contract without a message"))?,
+            )?;
+            inspector.call(sender, to_addr, amount.get(), depth);
+
+            let output = match output {
+                Ok(o) => o,
+                Err(e) => {
+                    warn!(?e, "transaction failed");
+                    let gas = gas.min(e.gas_remaining);
+                    return Ok((
+                        ScillaResult {
+                            success: false,
+                            contract_address: None,
+                            logs: vec![],
+                            gas_used: (txn.gas_limit - gas).into(),
+                            transitions: vec![],
+                            accepted: Some(false),
+                            errors: [(0, vec![ScillaError::CallFailed])].into_iter().collect(),
+                            exceptions: e.errors.into_iter().map(Into::into).collect(),
+                        },
+                        new_state,
+                    ));
+                }
+            };
+
+            info!(?output);
+
+            gas = gas.min(output.gas_remaining);
+
+            if output.accepted {
+                if let Some(result) = new_state.deduct_from_account(sender, amount)? {
+                    return Ok((result, new_state));
+                }
+
+                let to = new_state.load_account(to_addr)?;
+                to.account.balance += txn.amount.get();
+
+                if depth == 0 {
+                    root_contract_accepted = true;
+                }
+            }
+
+            transitions.reserve(output.messages.len());
+            call_stack.reserve(output.messages.len());
+            for message in output.messages {
+                transitions.push(ScillaTransition {
+                    from: to_addr,
+                    to: message.recipient,
+                    depth: depth + 1,
+                    amount: message.amount,
+                    tag: message.tag.clone(),
+                    params: serde_json::to_string(&message.params)?,
+                });
+
+                let next_message = json!({
+                    "_tag": message.tag,
+                    "_amount": message.amount.to_string(),
+                    "_sender": format!("{to_addr:#x}"),
+                    "_origin": format!("{from_addr:#x}"),
+                    "params": message.params,
+                });
+                call_stack.push((
+                    depth + 1,
+                    to_addr,
+                    message.recipient,
+                    message.amount,
+                    Some(next_message),
+                ));
+            }
+
+            logs.reserve(output.events.len());
+            for event in output.events {
+                let log = ScillaLog {
+                    address: to_addr,
+                    event_name: event.event_name,
+                    params: event
+                        .params
+                        .into_iter()
+                        .map(|p| {
+                            Ok(ScillaParam {
+                                ty: p.ty,
+                                // If the value is a JSON string, don't double encode it.
+                                value: if let Value::String(v) = p.value {
+                                    v
+                                } else {
+                                    serde_json::to_string(&p.value)?
+                                },
+                                name: p.name,
+                            })
                         })
-                    })
-                    .collect::<Result<_>>()?,
-            })
-        })
-        .collect::<Result<_>>()?;
+                        .collect::<Result<_>>()?,
+                };
+                logs.push(log);
+            }
 
-    inspector.call(from_addr, txn.to_addr, txn.amount.get());
+            state = Some(new_state);
+        } else {
+            // The `to_addr` is an EOA.
+            let Some(g) = gas.checked_sub(SCILLA_TRANSFER) else {
+                warn!("not enough gas to make transfer");
+                return Ok((
+                    ScillaResult {
+                        success: false,
+                        contract_address: None,
+                        logs: vec![],
+                        gas_used: (txn.gas_limit - gas).into(),
+                        transitions: vec![],
+                        accepted: Some(false),
+                        errors: [(0, vec![ScillaError::OutOfGas])].into_iter().collect(),
+                        exceptions: vec![],
+                    },
+                    current_state,
+                ));
+            };
+            gas = g;
+
+            if let Some(result) = current_state.deduct_from_account(from_addr, txn.amount)? {
+                return Ok((result, current_state));
+            }
+
+            let to = current_state.load_account(txn.to_addr)?;
+            to.account.balance += txn.amount.get();
+
+            inspector.transfer(from_addr, txn.to_addr, txn.amount.get(), depth);
+
+            state = Some(current_state);
+        }
+    }
 
     Ok((
         ScillaResult {
@@ -1462,10 +1523,11 @@ fn scilla_call(
             contract_address: None,
             logs,
             gas_used: (txn.gas_limit - gas).into(),
-            accepted: Some(output.accepted),
+            transitions,
+            accepted: Some(root_contract_accepted),
             errors: BTreeMap::new(),
             exceptions: vec![],
         },
-        state,
+        state.take().expect("missing state"),
     ))
 }

--- a/zilliqa/src/inspector.rs
+++ b/zilliqa/src/inspector.rs
@@ -18,15 +18,17 @@ pub trait ScillaInspector {
         let _ = creator;
         let _ = amount;
     }
-    fn transfer(&mut self, from: Address, to: Address, amount: u128) {
+    fn transfer(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
         let _ = amount;
         let _ = to;
         let _ = from;
+        let _ = depth;
     }
-    fn call(&mut self, from: Address, to: Address, amount: u128) {
+    fn call(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
         let _ = to;
         let _ = from;
         let _ = amount;
+        let _ = depth;
     }
 }
 
@@ -35,12 +37,12 @@ impl<T: ScillaInspector> ScillaInspector for &mut T {
         (*self).create(creator, contract_address, amount);
     }
 
-    fn transfer(&mut self, from: Address, to: Address, amount: u128) {
-        (*self).transfer(from, to, amount)
+    fn transfer(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
+        (*self).transfer(from, to, amount, depth)
     }
 
-    fn call(&mut self, from: Address, to: Address, amount: u128) {
-        (*self).call(from, to, amount)
+    fn call(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
+        (*self).call(from, to, amount, depth)
     }
 }
 
@@ -88,12 +90,12 @@ impl ScillaInspector for TouchedAddressInspector {
         self.touched.insert(contract_address);
     }
 
-    fn transfer(&mut self, from: Address, to: Address, _: u128) {
+    fn transfer(&mut self, from: Address, to: Address, _: u128, _: u64) {
         self.touched.insert(from);
         self.touched.insert(to);
     }
 
-    fn call(&mut self, from: Address, to: Address, _: u128) {
+    fn call(&mut self, from: Address, to: Address, _: u128, _: u64) {
         self.touched.insert(from);
         self.touched.insert(to);
     }
@@ -213,10 +215,10 @@ impl<DB: Database> Inspector<DB> for OtterscanTraceInspector {
 }
 
 impl ScillaInspector for OtterscanTraceInspector {
-    fn call(&mut self, from: Address, to: Address, amount: u128) {
+    fn call(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
         self.entries.push(TraceEntry {
             ty: TraceEntryType::Call,
-            depth: 0, // TODO: Track Scilla depth
+            depth,
             from,
             to,
             value: Some(amount),
@@ -235,10 +237,10 @@ impl ScillaInspector for OtterscanTraceInspector {
         })
     }
 
-    fn transfer(&mut self, from: Address, to: Address, amount: u128) {
+    fn transfer(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
         self.entries.push(TraceEntry {
             ty: TraceEntryType::Call,
-            depth: 0,
+            depth,
             from,
             to,
             value: Some(amount),
@@ -310,10 +312,9 @@ impl<DB: Database> Inspector<DB> for OtterscanOperationInspector {
     }
 }
 
-// TODO: Filter depth=0 Scilla calls once we can track the depth.
 impl ScillaInspector for OtterscanOperationInspector {
-    fn call(&mut self, from: Address, to: Address, amount: u128) {
-        if amount != 0 {
+    fn call(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
+        if depth != 0 && amount != 0 {
             self.entries.push(Operation {
                 ty: OperationType::Transfer,
                 from,
@@ -323,17 +324,8 @@ impl ScillaInspector for OtterscanOperationInspector {
         }
     }
 
-    fn create(&mut self, creator: Address, contract_address: Address, amount: u128) {
-        self.entries.push(Operation {
-            ty: OperationType::Create,
-            from: creator,
-            to: contract_address,
-            value: amount,
-        });
-    }
-
-    fn transfer(&mut self, from: Address, to: Address, amount: u128) {
-        if amount != 0 {
+    fn transfer(&mut self, from: Address, to: Address, amount: u128, depth: u64) {
+        if depth != 0 && amount != 0 {
             self.entries.push(Operation {
                 ty: OperationType::Transfer,
                 from,
@@ -342,6 +334,8 @@ impl ScillaInspector for OtterscanOperationInspector {
             });
         }
     }
+
+    // Creates are always ignored because they are always at depth=0 for Scilla transactions.
 }
 
 impl ScillaInspector for TracingInspector {}

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -398,8 +398,8 @@ pub struct ParamValue {
 pub struct Message {
     #[serde(rename = "_tag")]
     pub tag: String,
-    #[serde(rename = "_amount")]
-    pub amount: String,
+    #[serde(rename = "_amount", with = "num_as_str")]
+    pub amount: ZilAmount,
     #[serde(rename = "_recipient")]
     pub recipient: Address,
     pub params: Value,

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -24,7 +24,7 @@ use sha3::{
 
 use crate::{
     crypto,
-    exec::{ScillaError, ScillaException},
+    exec::{ScillaError, ScillaException, ScillaTransition},
     schnorr,
     zq1_proto::{Code, Data, Nonce, ProtoTransactionCoreInfo},
 };
@@ -730,6 +730,7 @@ pub struct TransactionReceipt {
     pub cumulative_gas_used: EvmGas,
     pub contract_address: Option<Address>,
     pub logs: Vec<Log>,
+    pub transitions: Vec<ScillaTransition>,
     pub accepted: Option<bool>,
     pub errors: BTreeMap<u64, Vec<ScillaError>>,
     pub exceptions: Vec<ScillaException>,


### PR DESCRIPTION
We maintain a call stack of Scilla contract calls. When the interpreter returns a message, we add it to the end of the call stack. We also keep track of all calls so we can add them to the transaction receipt.

Resolves #920 