### PR TITLE
Support DNS resolution in libp2p

### DIFF
--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -50,7 +50,7 @@ hyper = "0.14.27"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.22.3", features = ["jsonrpsee-http-client", "server"] }
 k256 = {version = "0.13.3", features = ["serde", "pem"] }
-libp2p = { version = "0.53.2", features = ["cbor", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux"] }
+libp2p = { version = "0.53.2", features = ["cbor", "dns", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux"] }
 lru = "0.12"
 once_cell = "1.19.0"
 opentelemetry = { version = "0.23.0", features = ["metrics"] }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -5,6 +5,7 @@ use std::{collections::HashMap, iter, time::Duration};
 use anyhow::{anyhow, Result};
 use libp2p::{
     core::upgrade,
+    dns,
     futures::StreamExt,
     gossipsub::{self, IdentTopic, MessageAuthenticity, TopicHash},
     identify,
@@ -90,6 +91,7 @@ impl P2pNode {
             .authenticate(noise::Config::new(&key_pair)?)
             .multiplex(yamux::Config::default())
             .boxed();
+        let transport = dns::tokio::Transport::system(transport)?.boxed();
 
         let behaviour = Behaviour {
             request_response: request_response::cbor::Behaviour::new(


### PR DESCRIPTION
This lets us specify bootnode addresses with `/dns*` multiaddrs.