### PR TITLE
Fix transaction deserialization

### DIFF
--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -100,6 +100,21 @@ mod ser_rlp {
             {
                 T::decode(&mut v).map_err(de::Error::custom)
             }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                // Limit the length we preallocate.
+                let len = seq.size_hint().unwrap_or(0).min(4096);
+                let mut bytes = Vec::with_capacity(len);
+
+                while let Some(byte) = seq.next_element()? {
+                    bytes.push(byte);
+                }
+
+                T::decode(&mut bytes.as_slice()).map_err(de::Error::custom)
+            }
         }
 
         deserializer.deserialize_bytes(Visitor(PhantomData))


### PR DESCRIPTION
The changes in #1061 fixed (de)serialization for CBOR, but broke it for JSON. This is because `serde_json` serialises bytes as an array by default. At deserialisation, it does not know this array represents bytes and so `visit_seq` is called. Previously, our visitor returned an error here, because it was only expecting `visit_bytes` to be called. Now we accept both.

Fixes #1076 