### PR TITLE
Replace JSON with CBOR for broadcasts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9034,6 +9034,7 @@ dependencies = [
  "bls12_381",
  "bs58",
  "bytes",
+ "cbor4ii",
  "clap",
  "criterion",
  "crypto-bigint",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -79,6 +79,7 @@ tower = "0.4.13"
 tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
+cbor4ii = "0.3.2"
 
 [dev-dependencies]
 alloy-primitives = { version = "0.7.2", features = ["rand"] }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -296,7 +296,7 @@ impl P2pNode {
                             }, ..
                         })) => {
                             let source = source.expect("message should have a source");
-                            let message = serde_json::from_slice::<ExternalMessage>(&data).unwrap();
+                            let message = cbor4ii::serde::from_slice::<ExternalMessage>(&data).unwrap();
                             let message_type = message.name();
                             let to = self.peer_id;
                             debug!(%source, %to, message_type, "broadcast recieved");
@@ -349,7 +349,7 @@ impl P2pNode {
                 message = self.outbound_message_receiver.next() => {
                     let (dest, shard_id, message) = message.expect("message stream should be infinite");
                     let message_type = message.name();
-                    let data = serde_json::to_vec(&message).unwrap();
+                    let data = cbor4ii::serde::to_vec(Vec::new(), &message).unwrap();
                     let from = self.peer_id;
 
                     let topic = Self::shard_id_to_topic(shard_id);


### PR DESCRIPTION
The changes in #992 should have done this, but I missed that broadcasts use a separate code path and thus still use JSON. This change switches to CBOR for everything.