### PR TITLE
Implement EIP-1898

### DIFF
--- a/docs/api/eth/eth_call.doc.md
+++ b/docs/api/eth/eth_call.doc.md
@@ -14,7 +14,7 @@ Given a transaction and a block number, executes a new message call immediately,
 
 {{ macro_transaction }}
 
-{{ macro_blocknumber }}
+{{ macro_blockid }}
 
 # Curl
 
@@ -47,4 +47,3 @@ Given a transaction and a block number, executes a new message call immediately,
 | `jsonrpc` | string | Required | `"2.0"`                                            |
 | `method`  | string | Required | `"eth_call"`                                       |
 | `params`  | array  | Requred  | `[ transaction ]` or `[transaction, block_number]` |
-

--- a/docs/api/eth/eth_getBalance.doc.md
+++ b/docs/api/eth/eth_getBalance.doc.md
@@ -16,7 +16,7 @@ Balances are maintained in `Wei` in Zilliqa 2. Because 1 wei = 10^6 ZIL, this va
 
 {{ macro_address }}
 
-{{ macro_blocknumber }}
+{{ macro_blockid }}
 
 # Curl
 

--- a/docs/api/eth/eth_getCode.doc.md
+++ b/docs/api/eth/eth_getCode.doc.md
@@ -16,7 +16,7 @@ Following the Zilliqa 1 behaviour, if you call `eth_getCode()` on a Scilla contr
 
 {{ macro_address }}
 
-{{ macro_blocknumber }}
+{{ macro_blockid }}
 
 # Curl
 

--- a/docs/api/eth/eth_getStorageAt.doc.md
+++ b/docs/api/eth/eth_getStorageAt.doc.md
@@ -26,7 +26,7 @@ Return the value of a storage location at a given address.
 
 A hex encoded 256-bit unsigned integer which determines the storage slot to inspect.
 
-{{ macro_blocknumber }}
+{{ macro_blockid }}
 
 # Curl
 
@@ -53,6 +53,3 @@ curl -d '{
 | `jsonrpc` | string | Required | `"2.0"`                   |
 | `method`  | string | Required | `"eth_getStorageAt"`              |
 | `params`  | array  | Required | `[address, storage_slot, block_number]` |
-
-
-

--- a/docs/api/eth/eth_getTransactionCount.doc.md
+++ b/docs/api/eth/eth_getTransactionCount.doc.md
@@ -13,7 +13,7 @@ Return the number of transactions sent from an address at a particular block. Th
 ## Parameters
 
 {{ macro_address }}
-{{ macro_blocknumber }}
+{{ macro_blockid }}
 
 # Curl
 
@@ -40,6 +40,3 @@ curl -d '{
 | `jsonrpc` | string | Required | `"2.0"`                     |
 | `method`  | string | Required | `"eth_getTransactionCount"` |
 | `params`  | array  | Requred  | `[ address, block_number]`  |
-
-
-

--- a/evm_scilla_js_tests/test/rpc/eth_getBlockByNumber.ts
+++ b/evm_scilla_js_tests/test/rpc/eth_getBlockByNumber.ts
@@ -129,32 +129,6 @@ describe("Calling " + METHOD, function () {
     });
   });
 
-  it("should get full transactions objects by its block number", async function () {
-    let blockNumber = 0x1;
-
-    await sendJsonRpcRequest(METHOD, 2, [blockNumber, true], (result, status) => {
-      logDebug(result);
-
-      assert.equal(status, 200, "has status code");
-      // validate all returned fields
-      TestResponse(result);
-      assert.equal(+result.result.number, blockNumber, `Block number is not ${blockNumber}`);
-    });
-  });
-
-  it("should get only the hashes of transactions objects by its block number", async function () {
-    let blockNumber = 0x1;
-
-    await sendJsonRpcRequest(METHOD, 2, [blockNumber, false], (result, status) => {
-      logDebug(result);
-
-      assert.equal(status, 200, "has status code");
-      // validate all returned fields
-      TestResponse(result);
-      assert.equal(+result.result.number, blockNumber, `Block number is not ${blockNumber}`);
-    });
-  });
-
   it("should get full transactions objects by its block number, even if number is specified as a string", async function () {
     let blockNumber = "0x1";
 

--- a/z2/resources/api_macros.tera.md
+++ b/z2/resources/api_macros.tera.md
@@ -58,6 +58,12 @@ The block number can be:
 
 If the block number is not provided, `latest` is assumed.
 
+# blockid
+
+### Block ID
+
+A block identifier, as specified by https://eips.ethereum.org/EIPS/eip-1898.
+
 # hydrated
 
 ### Hydrated
@@ -166,5 +172,3 @@ Examples (from Erigon):
 | `address`          | string | required | The address from which this log was emitted                                               |
 | `data`             | string | required | Hex string; the data associated with this log entry                                       |
 | `topics`           | string | required | An array containing the topics associated with this log entry, as an array of hex strings |
-
-

--- a/zilliqa/src/api/erigon.rs
+++ b/zilliqa/src/api/erigon.rs
@@ -4,17 +4,17 @@ use anyhow::Result;
 use jsonrpsee::{types::Params, RpcModule};
 
 use super::types::eth;
-use crate::{message::BlockNumber, node::Node};
+use crate::node::Node;
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     super::declare_module!(node, [("erigon_getHeaderByNumber", get_header_by_number)])
 }
 
 fn get_header_by_number(params: Params, node: &Arc<Mutex<Node>>) -> Result<Option<eth::Block>> {
-    let block: BlockNumber = params.one()?;
+    let block: u64 = params.one()?;
 
     // Erigon headers are a subset of the full block response. We choose to just return the full block.
-    let Some(ref block) = node.lock().unwrap().get_block_by_blocknum(block)? else {
+    let Some(ref block) = node.lock().unwrap().get_block(block)? else {
         return Ok(None);
     };
 

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use alloy_eips::{BlockId, BlockNumberOrTag};
 use alloy_primitives::{Address, B256};
 use anyhow::{anyhow, Result};
 use ethabi::Token;
@@ -17,7 +18,6 @@ use crate::{
     api::to_hex::ToHex,
     crypto::Hash,
     inspector::{self, CreatorInspector, OtterscanOperationInspector, OtterscanTraceInspector},
-    message::BlockNumber,
     node::Node,
     time::SystemTime,
 };
@@ -51,9 +51,9 @@ pub fn get_otterscan_api_level(_: Params, _: &Arc<Mutex<Node>>) -> Result<u64> {
 }
 
 fn get_block_details(params: Params, node: &Arc<Mutex<Node>>) -> Result<Option<ots::BlockDetails>> {
-    let block: u64 = params.one()?;
+    let block_number: BlockNumberOrTag = params.one()?;
 
-    let Some(ref block) = node.lock().unwrap().get_block_by_number(block)? else {
+    let Some(ref block) = node.lock().unwrap().get_block(block_number)? else {
         return Ok(None);
     };
     let miner = node
@@ -75,7 +75,7 @@ fn get_block_details_by_hash(
 ) -> Result<Option<ots::BlockDetails>> {
     let block_hash: B256 = params.one()?;
 
-    let Some(ref block) = node.lock().unwrap().get_block_by_hash(Hash(block_hash.0))? else {
+    let Some(ref block) = node.lock().unwrap().get_block(block_hash)? else {
         return Ok(None);
     };
     let miner = node
@@ -95,13 +95,13 @@ fn get_block_transactions(
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<ots::BlockTransactions>> {
     let mut params = params.sequence();
-    let block_num: u64 = params.next()?;
+    let block_number: BlockNumberOrTag = params.next()?;
     let page_number: usize = params.next()?;
     let page_size: usize = params.next()?;
 
     let node = node.lock().unwrap();
 
-    let Some(block) = node.get_block_by_number(block_num)? else {
+    let Some(block) = node.get_block(block_number)? else {
         return Ok(None);
     };
     let miner = node.get_proposer_reward_address(block.header)?;
@@ -228,12 +228,13 @@ fn get_transaction_error(params: Params, node: &Arc<Mutex<Node>>) -> Result<Cow<
 fn has_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
     let mut params = params.sequence();
     let address: Address = params.next()?;
-    let block_number: BlockNumber = params.next()?;
+    let block_id: BlockId = params.optional_next()?.unwrap_or_default();
 
     let empty = node
         .lock()
         .unwrap()
-        .get_account(address, block_number)?
+        .get_state(block_id)?
+        .get_account(address)?
         .code
         .is_eoa();
 
@@ -291,7 +292,7 @@ fn search_transactions_inner(
         let timestamp = node
             .lock()
             .unwrap()
-            .get_block_by_hash(Hash(txn.block_hash.unwrap_or_default().0))?
+            .get_block(txn.block_hash.unwrap_or_default())?
             .unwrap()
             .timestamp();
 

--- a/zilliqa/src/api/trace.rs
+++ b/zilliqa/src/api/trace.rs
@@ -3,6 +3,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use alloy_eips::BlockNumberOrTag;
 use alloy_primitives::B256;
 use alloy_rpc_types_trace::{
     geth::{GethDebugTracingOptions, TraceResult},
@@ -11,7 +12,7 @@ use alloy_rpc_types_trace::{
 use anyhow::Result;
 use jsonrpsee::{types::Params, RpcModule};
 
-use crate::{crypto::Hash, message::BlockNumber, node::Node};
+use crate::{crypto::Hash, node::Node};
 
 pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
     super::declare_module!(
@@ -42,10 +43,10 @@ fn debug_trace_block_by_number(
     node: &Arc<Mutex<Node>>,
 ) -> Result<Vec<TraceResult>> {
     let mut params = params.sequence();
-    let block_number: BlockNumber = params.next()?;
+    let block_number: BlockNumberOrTag = params.next()?;
     let trace_type: Option<GethDebugTracingOptions> = params.next()?;
 
     node.lock()
         .unwrap()
-        .debug_trace_block_by_number(block_number, trace_type.unwrap_or_default())
+        .debug_trace_block(block_number, trace_type.unwrap_or_default())
 }

--- a/zilliqa/src/api/types/mod.rs
+++ b/zilliqa/src/api/types/mod.rs
@@ -1,8 +1,11 @@
 use std::fmt::Display;
 
+use alloy_eips::BlockId;
+use alloy_primitives::B256;
 use serde::{ser::SerializeSeq, Serializer};
 
 use super::to_hex::ToHex;
+use crate::crypto;
 
 pub mod eth;
 pub mod ots;
@@ -56,4 +59,10 @@ where
     S: Serializer,
 {
     serializer.collect_str(value)
+}
+
+impl From<crypto::Hash> for BlockId {
+    fn from(hash: crypto::Hash) -> Self {
+        BlockId::from(B256::from(hash))
+    }
 }

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -2,13 +2,12 @@ use std::{
     collections::HashSet,
     fmt,
     fmt::{Display, Formatter},
-    str::FromStr,
 };
 
 use alloy_primitives::Address;
 use anyhow::{anyhow, Result};
 use bitvec::{bitvec, order::Msb0};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
 use crate::{
@@ -424,94 +423,6 @@ impl Default for BlockHeader {
             state_root_hash: Hash(Keccak256::digest([alloy_rlp::EMPTY_STRING_CODE]).into()),
             timestamp: SystemTime::UNIX_EPOCH,
             gas_used: EvmGas(0),
-        }
-    }
-}
-
-#[derive(Copy, Clone, Debug)]
-pub enum BlockNumber {
-    Number(u64),
-    Earliest,
-    Latest,
-    Safe,
-    Finalized,
-    Pending,
-}
-
-impl Display for BlockNumber {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                Self::Number(num) => num.to_string(),
-                Self::Earliest => "earliest".to_string(),
-                Self::Latest => "latest".to_string(),
-                Self::Safe => "safe".to_string(),
-                Self::Finalized => "finalized".to_string(),
-                Self::Pending => "pending".to_string(),
-            }
-        )
-    }
-}
-
-impl From<u64> for BlockNumber {
-    fn from(num: u64) -> Self {
-        Self::Number(num)
-    }
-}
-
-impl<'de> Deserialize<'de> for BlockNumber {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        struct Visitor;
-
-        impl<'de> serde::de::Visitor<'de> for Visitor {
-            type Value = BlockNumber;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(formatter, "a non-negative integer or a string")
-            }
-
-            fn visit_u64<E>(self, val: u64) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(BlockNumber::Number(val))
-            }
-
-            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                v.parse().map_err(serde::de::Error::custom)
-            }
-        }
-
-        deserializer.deserialize_any(Visitor)
-    }
-}
-
-impl FromStr for BlockNumber {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "earliest" => Ok(BlockNumber::Earliest),
-            "latest" => Ok(BlockNumber::Latest),
-            "safe" => Ok(BlockNumber::Safe),
-            "finalized" => Ok(BlockNumber::Finalized),
-            "pending" => Ok(BlockNumber::Pending),
-            number => {
-                if let Some(number) = number.strip_prefix("0x") {
-                    let number = u64::from_str_radix(number, 16)?;
-                    Ok(BlockNumber::Number(number))
-                } else {
-                    Err(anyhow!("invalid block number: {s}"))
-                }
-            }
         }
     }
 }

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -1,3 +1,4 @@
+use alloy_eips::BlockId;
 use ethabi::Token;
 use ethers::{
     abi::FunctionExt, prelude::DeploymentTxFactory, providers::Middleware,
@@ -94,7 +95,7 @@ async fn block_production(mut network: Network) {
             |n| {
                 let index = n.random_index();
                 n.get_node(index)
-                    .get_latest_block()
+                    .get_block(BlockId::latest())
                     .unwrap()
                     .map_or(0, |b| b.number())
                     >= 5
@@ -111,7 +112,7 @@ async fn block_production(mut network: Network) {
         .run_until(
             |n| {
                 n.node_at(index)
-                    .get_latest_block()
+                    .get_block(BlockId::latest())
                     .unwrap()
                     .map_or(0, |b| b.number())
                     >= 10


### PR DESCRIPTION
We now support a `BlockId` for the following APIs:
* `eth_call`
* `eth_getBalance`
* `eth_getCode`
* `eth_getStorageAt`
* `eth_getTransactionCount`

I couldn't resist making a few related changes at the same time:
* We've deleted our `BlockNumber` and now use alloy's `BlockNumberOrTag` instead.
* `Node` is now much pickier about how blocks and state are accessed. Previously, there were many overlapping ways of getting the same blocks or state. Now, everything goes through `get_block` or `get_state`. A load of unused methods have also been removed thanks to this change.