### PR TITLE
Ignore advertised private addresses from other nodes

### DIFF
--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -271,13 +271,13 @@ impl P2pNode {
                         }
                         SwarmEvent::Behaviour(BehaviourEvent::Identify(identify::Event::Received { info: identify::Info { observed_addr, listen_addrs, .. }, peer_id })) => {
                             for addr in listen_addrs {
-                                // If the node is advertising a loopback address, ignore it.
-                                let is_loopback = addr.iter().any(|p| match p {
-                                    Protocol::Ip4(addr) => addr.is_loopback(),
+                                // If the node is advertising a non-global address, ignore it.
+                                let is_non_global = addr.iter().any(|p| match p {
+                                    Protocol::Ip4(addr) => addr.is_loopback() || addr.is_private(),
                                     Protocol::Ip6(addr) => addr.is_loopback(),
                                     _ => false,
                                 });
-                                if is_loopback {
+                                if is_non_global {
                                     continue;
                                 }
 


### PR DESCRIPTION
We already ignore loopback addresses, but since we've started deploying in Docker, nodes also now listen on 172.17.0.1 which is in one of the private address ranges (172.16.0.0/12). The behaviour of the Identify protocol is that a node advertises all addresses it could possibly be reached on and leaves it to the client to select the sensible ones. Therefore, we now ignore private addresses too.