### PR TITLE
Log at debug level if we receive a proposal we cannot vote on

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -601,7 +601,7 @@ impl Consensus {
             let stakers = self.state.get_stakers()?;
 
             if !stakers.iter().any(|v| *v == self.public_key()) {
-                trace!(
+                debug!(
                     "can't vote for block proposal, we aren't in the committee of length {:?}",
                     stakers.len()
                 );


### PR DESCRIPTION
A debug log for this case seems quite reasonable, given it will only output once per block and is quite useful for debugging.