### PR TITLE
Specify external address in configuration

### DIFF
--- a/infra/tf/main.tf
+++ b/infra/tf/main.tf
@@ -101,8 +101,7 @@ module "bootstrap_node" {
   eth_chain_id = ${var.eth_chain_id}
   allowed_timestamp_skew = { secs = 60, nanos = 0 }
   data_dir = "/data"
-  consensus.consensus_timeout = { secs = 60, nanos = 0 }
-  consensus.genesis_accounts = [ ["${local.genesis_address}", "10_000_000_000_000_000_000_000_000"] ]
+  consensus.genesis_accounts = [ ["${local.genesis_address}", "21_000_000_000_000_000_000_000_000_000"] ]
   consensus.genesis_deposits = [ ["${local.bootstrap_public_key}", "${local.bootstrap_peer_id}", "10_000_000_000_000_000_000_000_000", "${local.genesis_address}"] ]
 
   # Reward parameters
@@ -133,14 +132,13 @@ module "node" {
 
   config          = <<-EOT
   p2p_port = 3333
-  bootstrap_address = [ "${local.bootstrap_peer_id}", "/ip4/${module.bootstrap_node.network_ip}/tcp/3333" ]
+  bootstrap_address = [ "${local.bootstrap_peer_id}", "/ip4/${data.google_compute_address.bootstrap.address}/tcp/3333" ]
 
   [[nodes]]
   eth_chain_id = ${var.eth_chain_id}
   allowed_timestamp_skew = { secs = 60, nanos = 0 }
   data_dir = "/data"
-  consensus.consensus_timeout = { secs = 60, nanos = 0 }
-  consensus.genesis_accounts = [ ["${local.genesis_address}", "10_000_000_000_000_000_000_000_000"] ]
+  consensus.genesis_accounts = [ ["${local.genesis_address}", "21_000_000_000_000_000_000_000_000_000"] ]
   consensus.genesis_deposits = [ ["${local.bootstrap_public_key}", "${local.bootstrap_peer_id}", "10_000_000_000_000_000_000_000_000", "${local.genesis_address}"] ]
 
   # Reward parameters

--- a/infra/tf/modules/node/scripts/node_provision.py.tpl
+++ b/infra/tf/modules/node/scripts/node_provision.py.tpl
@@ -42,6 +42,11 @@ def query_metadata_key(key: str) -> str:
         "Metadata-Flavor" : "Google" })
     return r.text
 
+def query_metadata_ext_ip() -> str:
+    url = f"http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip"
+    r = requests.get(url, headers = {
+        "Metadata-Flavor" : "Google" })
+    return r.text
 
 ZQ2_SCRIPT="""#!/bin/bash
 echo yes |  gcloud auth configure-docker asia-docker.pkg.dev,europe-docker.pkg.dev
@@ -88,6 +93,7 @@ WantedBy=multi-user.target
 """
 
 ZQ2_CONFIG="""
+external_address = "/ip4/""" + query_metadata_ext_ip() + """/tcp/3333"
 ${config}
 """
 

--- a/infra/tf/validators.tf
+++ b/infra/tf/validators.tf
@@ -50,14 +50,13 @@ module "validators" {
 
   config          = <<-EOT
   p2p_port = 3333
-  bootstrap_address = [ "${local.bootstrap_peer_id}", "/dns/bootstrap.${var.subdomain}/tcp/3333" ]
+  bootstrap_address = [ "${local.bootstrap_peer_id}", "/ipv4/${data.google_compute_address.bootstrap.address}/tcp/3333" ]
 
   [[nodes]]
   eth_chain_id = ${var.eth_chain_id}
   allowed_timestamp_skew = { secs = 60, nanos = 0 }
   data_dir = "/data"
-  consensus.consensus_timeout = { secs = 60, nanos = 0 }
-  consensus.genesis_accounts = [ ["${local.genesis_address}", "10_000_000_000_000_000_000_000_000"] ]
+  consensus.genesis_accounts = [ ["${local.genesis_address}", "21_000_000_000_000_000_000_000_000_000"] ]
   consensus.genesis_deposits = [ ["${local.bootstrap_public_key}", "${local.bootstrap_peer_id}", "10_000_000_000_000_000_000_000_000", "${local.genesis_address}"] ]
 
   # Reward parameters

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -193,6 +193,7 @@ impl Setup {
                 bootstrap_address: None,
                 nodes: Vec::new(),
                 p2p_port: 0,
+                external_address: None,
             };
             // @todo should pass this in!
             let mut node_config = cfg::NodeConfig {

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -17,6 +17,12 @@ pub struct Config {
     /// The port to listen for P2P messages on. Optional - If not provided a random port will be used.
     #[serde(default)]
     pub p2p_port: u16,
+    /// External address for this node. This is the address at which it can be reached by other nodes. This should
+    /// include the P2P port. If this is not provided, we will trust other nodes to tell us our external address.
+    /// However, be warned that this is insecure and unreliable in real-world networks and we will remove this
+    /// behaviour at some point in the future (#1101).
+    #[serde(default)]
+    pub external_address: Option<Multiaddr>,
     /// The address of another node to dial when this node starts. To join the network, a node must know about at least
     /// one other existing node in the network.
     #[serde(default)]


### PR DESCRIPTION
In the proto-testnet we are observing nodes learning about the
wrong external address for themselves, reporting the wrong thing
and thus other nodes failing to send messages to them.

I believe this is due to a bug in `libp2p-identify` where incoming
TCP ports are reported as the observed address of a node. However,
I think (and the documentation states) we shouldn't be relying on
other nodes to tell us our external address anyway since it is
easily exploitable by a malicious node.

So for now, we let configuration specify a nodes external address
and surpress the existing behaviour in this case.

In future, we can remove the configuration requirement by using
`libp2p-autonat` (https://github.com/Zilliqa/zq2/issues/1101).