### PR TITLE
Select nodes to request blocks from more intelligently

### DIFF
--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -109,7 +109,9 @@ pub fn process_blocks(c: &mut Criterion) {
         b.iter(|| {
             let proposal = proposals.next().unwrap();
             let view = proposal.view();
-            consensus.receive_block(black_box(proposal)).unwrap();
+            consensus
+                .receive_block(PeerId::random(), black_box(proposal))
+                .unwrap();
             consensus
                 .get_block_by_view(black_box(view))
                 .unwrap()

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -4,11 +4,7 @@ use alloy_primitives::{Address, U256};
 use anyhow::{anyhow, Context as _, Result};
 use bitvec::bitvec;
 use libp2p::PeerId;
-use rand::{
-    distributions::{Distribution, WeightedIndex},
-    prelude::IteratorRandom,
-    rngs::SmallRng,
-};
+use rand::distributions::{Distribution, WeightedIndex};
 use rand_chacha::ChaCha8Rng;
 use rand_core::SeedableRng;
 use revm::Inspector;
@@ -143,8 +139,6 @@ pub struct Consensus {
     db: Arc<Db>,
     /// Actions that act on newly created blocks
     transaction_pool: TransactionPool,
-    // PRNG - non-cryptographically secure, but we don't need that here
-    rng: SmallRng,
     /// Flag indicating that block creation should be postponed due to empty mempool
     create_next_block_on_timeout: bool,
     pub new_blocks: broadcast::Sender<BlockHeader>,
@@ -274,12 +268,6 @@ impl Consensus {
             state,
             db,
             transaction_pool: Default::default(),
-            // Seed the rng with the node's public key
-            rng: <SmallRng as rand_core::SeedableRng>::seed_from_u64(u64::from_be_bytes(
-                secret_key.node_public_key().as_bytes()[..8]
-                    .try_into()
-                    .unwrap(),
-            )),
             create_next_block_on_timeout: false,
             new_blocks: broadcast::Sender::new(4),
             receipts: broadcast::Sender::new(128),
@@ -290,7 +278,7 @@ impl Consensus {
         // If we're at genesis, add the genesis block.
         if latest_block_view == 0 {
             if let Some(genesis) = latest_block {
-                consensus.add_block(genesis.clone())?;
+                consensus.add_block(None, genesis.clone())?;
             }
             // treat genesis as finalized
             consensus.finalize(latest_block_hash, latest_block_view)?;
@@ -309,20 +297,6 @@ impl Consensus {
             .get_block_by_number(highest_block_number)
             .unwrap()
             .unwrap()
-    }
-
-    pub fn get_random_other_peer(&mut self) -> Option<PeerId> {
-        let stakers = self.state.get_stakers().unwrap();
-        let my_public_key = self.public_key();
-        let chosen = stakers
-            .into_iter()
-            .filter(|&v| v != my_public_key)
-            .choose(&mut self.rng)?;
-
-        let Ok(peer_id) = self.state.get_peer_id(chosen) else {
-            return None;
-        };
-        peer_id
     }
 
     pub fn timeout(&mut self) -> Result<Option<NetworkMessage>> {
@@ -470,6 +444,7 @@ impl Consensus {
 
     pub fn proposal(
         &mut self,
+        from: PeerId,
         proposal: Proposal,
         during_sync: bool,
     ) -> Result<Option<NetworkMessage>> {
@@ -503,8 +478,8 @@ impl Consensus {
             Err((e, temporary)) => {
                 // If this block could become valid in the future, buffer it.
                 if temporary {
-                    let random_peer = self.get_random_other_peer();
                     self.block_store.buffer_proposal(
+                        from,
                         Proposal::from_parts_with_hashes(
                             block,
                             transactions
@@ -515,7 +490,6 @@ impl Consensus {
                                 })
                                 .collect(),
                         ),
-                        random_peer,
                     )?;
                 }
                 warn!(?e, "invalid block proposal received!");
@@ -558,7 +532,9 @@ impl Consensus {
                 self.state.set_to_root(parent.state_root_hash().into());
             }
             let stakers = self.state.get_stakers()?;
-            self.execute_block(&block, transactions, &stakers)?;
+            // Only tell the block store where this block came from if it wasn't from ourselves.
+            let from = (self.peer_id() != from).then_some(from);
+            self.execute_block(from, &block, transactions, &stakers)?;
 
             if self.view.get_view() != proposal_view + 1 {
                 self.view.set_view(proposal_view + 1);
@@ -1630,7 +1606,7 @@ impl Consensus {
     // Optionally returns a proposal that should be sent as the result of this newly received block. This occurs when
     // the node has buffered votes for a block it doesn't know about and later receives that block, resulting in a new
     // block proposal.
-    pub fn receive_block(&mut self, proposal: Proposal) -> Result<Option<Proposal>> {
+    pub fn receive_block(&mut self, from: PeerId, proposal: Proposal) -> Result<Option<Proposal>> {
         trace!(
             "received block: {} number: {}, view: {}",
             proposal.hash(),
@@ -1638,7 +1614,7 @@ impl Consensus {
             proposal.view()
         );
 
-        let result = self.proposal(proposal, true)?;
+        let result = self.proposal(from, proposal, true)?;
         // Processing the received block can either result in:
         // * A `Proposal`, if we have buffered votes for this block which form a supermajority, meaning we can
         // propose the next block.
@@ -1649,11 +1625,11 @@ impl Consensus {
         Ok(result.and_then(|(_, message)| message.into_proposal()))
     }
 
-    fn add_block(&mut self, block: Block) -> Result<()> {
+    fn add_block(&mut self, from: Option<PeerId>, block: Block) -> Result<()> {
         let hash = block.hash();
-        debug!(?hash, ?block.header.view, ?block.header.number, "added block");
+        debug!(?from, ?hash, ?block.header.view, ?block.header.number, "added block");
         let _ = self.new_blocks.send(block.header);
-        if let Some(child_proposal) = self.block_store.process_block(block)? {
+        if let Some(child_proposal) = self.block_store.process_block(from, block)? {
             self.message_sender.send_external_message(
                 self.peer_id(),
                 ExternalMessage::BlockResponse(BlockResponse {
@@ -2008,7 +1984,7 @@ impl Consensus {
                 .map(|tx_hash| self.get_transaction_by_hash(*tx_hash).unwrap().unwrap().tx)
                 .collect();
             let committee = self.state.get_stakers_at_block(&block_pointer)?;
-            self.execute_block(&block_pointer, transactions, &committee)?;
+            self.execute_block(None, &block_pointer, transactions, &committee)?;
         }
 
         Ok(())
@@ -2016,6 +1992,7 @@ impl Consensus {
 
     fn execute_block(
         &mut self,
+        from: Option<PeerId>,
         block: &Block,
         transactions: Vec<SignedTransaction>,
         committee: &[NodePublicKey],
@@ -2095,7 +2072,7 @@ impl Consensus {
         // for example, this HAS to be after the deal with fork call
         if !self.db.contains_block(&block.hash())? {
             // If we were the proposer we would've already processed the block, hence the check
-            self.add_block(block.clone())?;
+            self.add_block(from, block.clone())?;
         }
         {
             // helper scope to shadow db, to avoid moving it into the closure
@@ -2127,8 +2104,7 @@ impl Consensus {
         }
 
         // Tell the block store to request more blocks if it can.
-        let random_peer = self.get_random_other_peer();
-        self.block_store.request_missing_blocks(random_peer)?;
+        self.block_store.request_missing_blocks()?;
 
         Ok(())
     }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -145,7 +145,7 @@ impl Node {
         debug!(%from, %to, %message, "handling message");
         match message {
             ExternalMessage::Proposal(m) => {
-                if let Some((to, message)) = self.consensus.proposal(m, false)? {
+                if let Some((to, message)) = self.consensus.proposal(from, m, false)? {
                     self.reset_timeout.send(DEFAULT_SLEEP_TIME_MS)?;
                     if let Some(to) = to {
                         self.message_sender.send_external_message(to, message)?;
@@ -793,14 +793,14 @@ impl Node {
         Ok(())
     }
 
-    fn handle_block_response(&mut self, _: PeerId, response: BlockResponse) -> Result<()> {
+    fn handle_block_response(&mut self, from: PeerId, response: BlockResponse) -> Result<()> {
         trace!(
             "Received blocks response of length {}",
             response.proposals.len()
         );
 
         for block in response.proposals {
-            let proposal = self.consensus.receive_block(block)?;
+            let proposal = self.consensus.receive_block(from, block)?;
             if let Some(proposal) = proposal {
                 self.message_sender
                     .broadcast_external_message(ExternalMessage::Proposal(proposal))?;


### PR DESCRIPTION
Previously, we requested missing blocks from a random node in the consensus committee. Now, we can request blocks from any node who has told us they have a block with at least that view.

In future, we can extend this logic by:
* Taking into account latency, bad responses, etc. when choosing peers.
* Extending the P2P protocol so that non-validator peers can share their 'best' block with each other, meaning we can download blocks from those non-validators.

Resolves #1097 since this was the only thing we used `get_random_peer` for.