### PR TITLE
Retry failed block requests

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'release/**'
       - 'main'
-      - fix-sync
+      - dl-retry
     tags:        
       - v*
 
@@ -60,7 +60,7 @@ jobs:
       permissions:
         id-token: write
         contents: write
-      if: ${{ github.ref_name == 'main' }} || ${{ github.ref_name == 'fix-sync' }}
+      if: ${{ github.ref_name == 'main' }} || ${{ github.ref_name == 'dl-retry' }}
       runs-on: [ self-hosted, gcp]
       env:
         GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev

--- a/z2/src/docgen.rs
+++ b/z2/src/docgen.rs
@@ -24,8 +24,8 @@ use zilliqa::{
     cfg::{
         allowed_timestamp_skew_default, block_request_batch_size_default,
         block_request_limit_default, consensus_timeout_default, disable_rpc_default,
-        empty_block_timeout_default, eth_chain_id_default, json_rpc_port_default,
-        local_address_default, max_blocks_in_flight_default,
+        empty_block_timeout_default, eth_chain_id_default, failed_request_sleep_duration_default,
+        json_rpc_port_default, local_address_default, max_blocks_in_flight_default,
         minimum_time_left_for_empty_block_default, scilla_address_default, scilla_lib_dir_default,
         Amount, ConsensusConfig, NodeConfig,
     },
@@ -328,6 +328,7 @@ pub fn get_implemented_jsonrpc_methods() -> Result<HashMap<ApiMethod, PageStatus
         block_request_limit: block_request_limit_default(),
         max_blocks_in_flight: max_blocks_in_flight_default(),
         block_request_batch_size: block_request_batch_size_default(),
+        failed_request_sleep_duration: failed_request_sleep_duration_default(),
     };
     let secret_key = SecretKey::new()?;
     let (s1, _) = tokio::sync::mpsc::unbounded_channel();

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -14,9 +14,10 @@ use zilliqa::{
     cfg::{
         allowed_timestamp_skew_default, block_request_batch_size_default,
         block_request_limit_default, consensus_timeout_default, disable_rpc_default,
-        empty_block_timeout_default, eth_chain_id_default, local_address_default,
-        max_blocks_in_flight_default, minimum_time_left_for_empty_block_default,
-        scilla_address_default, scilla_lib_dir_default, Amount, ConsensusConfig,
+        empty_block_timeout_default, eth_chain_id_default, failed_request_sleep_duration_default,
+        local_address_default, max_blocks_in_flight_default,
+        minimum_time_left_for_empty_block_default, scilla_address_default, scilla_lib_dir_default,
+        Amount, ConsensusConfig,
     },
     crypto::NodePublicKey,
     transaction::EvmGas,
@@ -227,6 +228,7 @@ impl Setup {
                 block_request_limit: block_request_limit_default(),
                 max_blocks_in_flight: max_blocks_in_flight_default(),
                 block_request_batch_size: block_request_batch_size_default(),
+                failed_request_sleep_duration: failed_request_sleep_duration_default(),
             };
             println!("Node {i} has RPC port {0}", node_config.json_rpc_port);
             let data_dir_name = format!("{0}{1}", DATADIR_PREFIX, i);

--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -11,7 +11,7 @@ use zilliqa::{
     crypto::{Hash, SecretKey},
     db::Db,
     message::{Block, Proposal, QuorumCertificate, Vote},
-    node::MessageSender,
+    node::{MessageSender, RequestId},
     time::SystemTime,
     transaction::EvmGas,
 };
@@ -34,6 +34,7 @@ pub fn process_blocks(c: &mut Criterion) {
         our_peer_id: PeerId::random(),
         outbound_channel: outbound_message_sender,
         local_channel: local_message_sender,
+        request_id: RequestId::default(),
     };
     let db = Db::new::<PathBuf>(None, 0).unwrap();
     let mut consensus = Consensus::new(

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -70,6 +70,10 @@ pub struct NodeConfig {
     /// The maximum number of blocks to request in a single message when syncing.
     #[serde(default = "block_request_batch_size_default")]
     pub block_request_batch_size: u64,
+    /// When a block request to a peer fails, do not send another request to this peer for this amount of time.
+    /// Defaults to 10 seconds.
+    #[serde(default = "failed_request_sleep_duration_default")]
+    pub failed_request_sleep_duration: Duration,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -129,6 +133,10 @@ pub fn max_blocks_in_flight_default() -> u64 {
 
 pub fn block_request_batch_size_default() -> u64 {
     100
+}
+
+pub fn failed_request_sleep_duration_default() -> Duration {
+    Duration::from_secs(10)
 }
 
 /// Wrapper for [u128] that (de)serializes with a string. `serde_toml` does not support `u128`s.

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -24,7 +24,7 @@ use crate::{
         AggregateQc, BitSlice, BitVec, Block, BlockHeader, BlockRef, BlockResponse,
         ExternalMessage, InternalMessage, NewView, Proposal, QuorumCertificate, Vote,
     },
-    node::{MessageSender, NetworkMessage},
+    node::{MessageSender, NetworkMessage, OutgoingMessageFailure},
     pool::{TransactionPool, TxPoolContent},
     state::State,
     time::SystemTime,
@@ -513,8 +513,9 @@ impl Consensus {
                                 .collect(),
                         ),
                     )?;
+                } else {
+                    warn!(?e, "invalid block proposal received!");
                 }
-                warn!(?e, "invalid block proposal received!");
                 return Ok(None);
             }
         }
@@ -2321,5 +2322,12 @@ impl Consensus {
             errors,
             exceptions,
         }
+    }
+
+    pub fn report_outgoing_message_failure(
+        &mut self,
+        failure: OutgoingMessageFailure,
+    ) -> Result<()> {
+        self.block_store.report_outgoing_message_failure(failure)
     }
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -10,7 +10,7 @@ use alloy_rpc_types_trace::{
     parity::{TraceResults, TraceType},
 };
 use anyhow::{anyhow, Result};
-use libp2p::PeerId;
+use libp2p::{request_response::OutboundFailure, PeerId};
 use revm::Inspector;
 use revm_inspectors::tracing::{
     js::{JsInspector, TransactionContext},
@@ -38,12 +38,23 @@ use crate::{
     },
 };
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+pub struct RequestId(u64);
+
+#[derive(Debug)]
+pub struct OutgoingMessageFailure {
+    pub peer: PeerId,
+    pub request_id: RequestId,
+    pub error: OutboundFailure,
+}
+
 #[derive(Debug, Clone)]
 pub struct MessageSender {
     pub our_shard: u64,
     pub our_peer_id: PeerId,
     pub outbound_channel: UnboundedSender<OutboundMessageTuple>,
     pub local_channel: UnboundedSender<LocalMessageTuple>,
+    pub request_id: RequestId,
 }
 
 impl MessageSender {
@@ -65,12 +76,23 @@ impl MessageSender {
         Ok(())
     }
 
+    pub fn next_request_id(&mut self) -> RequestId {
+        let request_id = self.request_id;
+        self.request_id.0 = self.request_id.0.wrapping_add(1);
+        request_id
+    }
+
     /// Send a message to a remote node of the same shard.
-    pub fn send_external_message(&self, peer: PeerId, message: ExternalMessage) -> Result<()> {
+    pub fn send_external_message(
+        &mut self,
+        peer: PeerId,
+        message: ExternalMessage,
+    ) -> Result<RequestId> {
         debug!("sending {message} from {} to {}", self.our_peer_id, peer);
+        let request_id = self.next_request_id();
         self.outbound_channel
-            .send((Some(peer), self.our_shard, message))?;
-        Ok(())
+            .send((Some((peer, request_id)), self.our_shard, message))?;
+        Ok(request_id)
     }
 
     /// Broadcast to the entire network of this shard
@@ -125,6 +147,7 @@ impl Node {
             our_peer_id: peer_id,
             outbound_channel: message_sender_channel,
             local_channel: local_sender_channel,
+            request_id: RequestId::default(),
         };
         let db = Arc::new(Db::new(config.data_dir.as_ref(), config.eth_chain_id)?);
         let node = Node {
@@ -139,9 +162,22 @@ impl Node {
     }
 
     // TODO: Multithreading - `&mut self` -> `&self`
-    pub fn handle_network_message(&mut self, from: PeerId, message: ExternalMessage) -> Result<()> {
+    pub fn handle_network_message(
+        &mut self,
+        from: PeerId,
+        message: Result<ExternalMessage, OutgoingMessageFailure>,
+    ) -> Result<()> {
         let to = self.peer_id;
         let to_self = from == to;
+        let message = match message {
+            Ok(message) => message,
+            Err(failure) => {
+                debug!(?failure, "handling message failure");
+                self.consensus.report_outgoing_message_failure(failure)?;
+
+                return Ok(());
+            }
+        };
         debug!(%from, %to, %message, "handling message");
         match message {
             ExternalMessage::Proposal(m) => {

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -24,7 +24,7 @@ use crate::{
     crypto::SecretKey,
     health::HealthLayer,
     message::{ExternalMessage, InternalMessage},
-    node,
+    node::{self, OutgoingMessageFailure},
     p2p_node::{LocalMessageTuple, OutboundMessageTuple},
 };
 
@@ -34,9 +34,11 @@ pub struct NodeLauncher {
     pub rpc_module: RpcModule<Arc<Mutex<Node>>>,
     /// The following two message streams are used for networked messages.
     /// The sender is provided to the p2p coordinator, to forward messages to the node.
-    pub inbound_message_sender: UnboundedSender<(PeerId, ExternalMessage)>,
+    pub inbound_message_sender:
+        UnboundedSender<(PeerId, Result<ExternalMessage, OutgoingMessageFailure>)>,
     /// The corresponding receiver is handled here, forwarding messages to the node struct.
-    pub inbound_message_receiver: UnboundedReceiverStream<(PeerId, ExternalMessage)>,
+    pub inbound_message_receiver:
+        UnboundedReceiverStream<(PeerId, Result<ExternalMessage, OutgoingMessageFailure>)>,
     /// The following two message streams are used for local messages.
     /// The sender is provided to the p2p coordinator, to forward cross-shard messages to the node.
     pub local_inbound_message_sender: UnboundedSender<(u64, InternalMessage)>,
@@ -114,7 +116,9 @@ impl NodeLauncher {
         })
     }
 
-    pub fn message_input(&self) -> UnboundedSender<(PeerId, ExternalMessage)> {
+    pub fn message_input(
+        &self,
+    ) -> UnboundedSender<(PeerId, Result<ExternalMessage, OutgoingMessageFailure>)> {
         self.inbound_message_sender.clone()
     }
 

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -61,9 +61,10 @@ use zilliqa::{
     cfg::{
         allowed_timestamp_skew_default, block_request_batch_size_default,
         block_request_limit_default, disable_rpc_default, eth_chain_id_default,
-        json_rpc_port_default, local_address_default, max_blocks_in_flight_default,
-        minimum_time_left_for_empty_block_default, scilla_address_default, scilla_lib_dir_default,
-        Amount, Checkpoint, ConsensusConfig, NodeConfig,
+        failed_request_sleep_duration_default, json_rpc_port_default, local_address_default,
+        max_blocks_in_flight_default, minimum_time_left_for_empty_block_default,
+        scilla_address_default, scilla_lib_dir_default, Amount, Checkpoint, ConsensusConfig,
+        NodeConfig,
     },
     crypto::{NodePublicKey, SecretKey},
     db,
@@ -290,6 +291,7 @@ impl Network {
             block_request_limit: block_request_limit_default(),
             max_blocks_in_flight: max_blocks_in_flight_default(),
             block_request_batch_size: block_request_batch_size_default(),
+            failed_request_sleep_duration: failed_request_sleep_duration_default(),
         };
 
         let (nodes, external_receivers, local_receivers): (Vec<_>, Vec<_>, Vec<_>) = keys
@@ -389,6 +391,7 @@ impl Network {
             block_request_limit: block_request_limit_default(),
             max_blocks_in_flight: max_blocks_in_flight_default(),
             block_request_batch_size: block_request_batch_size_default(),
+            failed_request_sleep_duration: failed_request_sleep_duration_default(),
         };
         let (node, receiver, local_receiver) =
             node(config, secret_key, self.nodes.len(), None).unwrap();
@@ -483,6 +486,7 @@ impl Network {
                     block_request_limit: block_request_limit_default(),
                     max_blocks_in_flight: max_blocks_in_flight_default(),
                     block_request_batch_size: block_request_batch_size_default(),
+                    failed_request_sleep_duration: failed_request_sleep_duration_default(),
                 };
 
                 node(config, key, i, Some(new_data_dir)).unwrap()

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -10,7 +10,7 @@ use zilliqa::{
     cfg::{
         allowed_timestamp_skew_default, block_request_batch_size_default,
         block_request_limit_default, consensus_timeout_default, eth_chain_id_default,
-        json_rpc_port_default, max_blocks_in_flight_default,
+        failed_request_sleep_duration_default, json_rpc_port_default, max_blocks_in_flight_default,
         minimum_time_left_for_empty_block_default, scilla_address_default, scilla_lib_dir_default,
         Checkpoint,
     },
@@ -111,6 +111,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
         block_request_limit: block_request_limit_default(),
         max_blocks_in_flight: max_blocks_in_flight_default(),
         block_request_batch_size: block_request_batch_size_default(),
+        failed_request_sleep_duration: failed_request_sleep_duration_default(),
     };
     let result = crate::node(config, SecretKey::new().unwrap(), 0, Some(dir));
 


### PR DESCRIPTION
This required quite a lot of additional machinery in order to inform the `BlockStore` of request failures, so it can retry.

Now, whenever we send a direct external message in `node.rs`, we remember a `request_id` which is returned to the caller. One level up, we keep a correspondence of our generated `request_id` to libp2p's request ID. When a request succeds or fails, we can look up the `request_id` in this map and pass it back down the stack to inform the initial caller of the result.

We've also changed the type which gets sent from the network layer to the `node.rs` layer from an `ExternalMessage` to a `Result<ExternalMessage, OutgoingMessageFailure>`. The `Err` half is how failed messages are passed down.