### PR TITLE
Fix underflow of requested block count

### DIFF
--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -196,7 +196,7 @@ impl BlockStore {
 
         if let Some(from) = from {
             let peer = self.peers.entry(from).or_default();
-            peer.requested_blocks -= 1;
+            peer.requested_blocks = peer.requested_blocks.saturating_sub(1);
             if block.view() > peer.highest_known_view {
                 trace!(%from, view = block.view(), "new highest known view for peer");
                 peer.highest_known_view = block.view();


### PR DESCRIPTION
`requested_blocks` is only incremented when we request missing blocks but decremented when we receive any block, including a new block proposal. This means underflow is possible.

As a temporary workaround, just use a saturating subtraction. This will mean we don't perfectly account for the current number of requested blocks when selecting a peer, but this code will soon change in my next PR.