### PR TITLE
Temporarily ignore new security advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -38,3 +38,6 @@ license-files = [
 
 [sources.allow-org]
 github = [ "zilliqa" ]
+
+[advisories]
+ignore = ["RUSTSEC-2024-0346"]


### PR DESCRIPTION
A new security advisory was just published today:
https://rustsec.org/advisories/RUSTSEC-2024-0346
This is flagged by our CI so all builds are failing.

The affected crate, `zerovec-derive`, is patched in version 0.10.4 but this hasn't been published on crates.io yet. Thus, add an exception to ignore the security advisory. The issue only becomes relevant with rust 1.80.0 which I don't believe we are using for deployment.


New issue created to revert the ignore once the crate gets updated: #1153 