### PR TITLE
Fix `to` parameter of block requests

### DIFF
--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'release/**'
       - 'main'
+      - fix-sync
     tags:        
       - v*
 
@@ -59,7 +60,7 @@ jobs:
       permissions:
         id-token: write
         contents: write
-      if: ${{ github.ref_name == 'main' }} 
+      if: ${{ github.ref_name == 'main' }} || ${{ github.ref_name == 'fix-sync' }}
       runs-on: [ self-hosted, gcp]
       env:
         GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev

--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, collections::HashMap, num::NonZeroUsize, sync::Arc};
+use std::{cell::RefCell, cmp, collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use libp2p::PeerId;
@@ -133,7 +133,10 @@ impl BlockStore {
                     <= (self.max_blocks_in_flight - self.batch_size)
             {
                 let from = self.requested_view + 1;
-                let to = (self.requested_view + self.batch_size).max(self.highest_known_view);
+                let to = cmp::min(
+                    self.requested_view + self.batch_size,
+                    self.highest_known_view,
+                );
                 trace!(from, to, "requesting blocks");
                 let message = ExternalMessage::BlockRequest(BlockRequest {
                     from_view: from,


### PR DESCRIPTION
`max` instead of `min` meant we would send a request for a very high view, only a few of the requests blocks would actually get sent and we would get stuck. Oops :)