### PR TITLE
Update Rust version to 1.79.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78.0-slim-bullseye as builder
+FROM rust:1.79.0-slim-bullseye as builder
 
 ARG is_release=false
 RUN apt update -y && \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.79.0"
 components = [ "rustfmt", "clippy" ]
 profile = "minimal"


### PR DESCRIPTION
Required by new `revm` versions