### PR TITLE
Change eth_getTransactionCount to respect the pending block number 

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -292,6 +292,11 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
     expect_end_of_params(&mut params, 3, 3)?;
 
     let node = node.lock().unwrap();
+
+    if matches!(block_id, BlockId::Number(BlockNumberOrTag::Pending)) {
+        return Ok(node.txpool_content().pending.len().to_hex());
+    }
+
     let block = node.get_block(block_id)?;
     let block = build_errored_response_for_missing_block(block_id, block)?;
 

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -299,10 +299,7 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
     let nonce = node.get_state(&block)?.get_account(address)?.nonce;
 
     if matches!(block_id, BlockId::Number(BlockNumberOrTag::Pending)) {
-        let pending_transaction_count =
-            node.pending_transaction_account_for_address(address) as u64;
-
-        Ok((nonce + pending_transaction_count).to_hex())
+        Ok(node.transaction_count_for_account(address).to_hex())
     } else {
         Ok(nonce.to_hex())
     }

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -294,7 +294,13 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
     let node = node.lock().unwrap();
 
     if matches!(block_id, BlockId::Number(BlockNumberOrTag::Pending)) {
-        return Ok(node.txpool_content().pending.len().to_hex());
+        return Ok(node
+            .txpool_content()
+            .pending
+            .iter()
+            .filter(|tx| tx.signer == address)
+            .count()
+            .to_hex());
     }
 
     let block = node.get_block(block_id)?;

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -299,7 +299,7 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
     let nonce = node.get_state(&block)?.get_account(address)?.nonce;
 
     if matches!(block_id, BlockId::Number(BlockNumberOrTag::Pending)) {
-        Ok(node.transaction_count_for_account(address).to_hex())
+        Ok(node.consensus.pending_transaction_count(address).to_hex())
     } else {
         Ok(nonce.to_hex())
     }

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -299,12 +299,8 @@ fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<Stri
     let nonce = node.get_state(&block)?.get_account(address)?.nonce;
 
     if matches!(block_id, BlockId::Number(BlockNumberOrTag::Pending)) {
-        let pending_transaction_count = node
-            .txpool_content()
-            .pending
-            .iter()
-            .filter(|tx| tx.signer == address)
-            .count() as u64;
+        let pending_transaction_count =
+            node.pending_transaction_account_for_address(address) as u64;
 
         Ok((nonce + pending_transaction_count).to_hex())
     } else {

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -739,6 +739,20 @@ impl Consensus {
         content
     }
 
+    pub fn pending_transaction_count_for_address(&self, address: Address) -> usize {
+        let content = self.transaction_pool.preview_content();
+
+        content
+            .pending
+            .iter()
+            .filter(|txn| {
+                let account_nonce = self.state.must_get_account(txn.signer).nonce;
+                txn.tx.nonce().unwrap() >= account_nonce
+            })
+            .filter(|txn| txn.signer == address)
+            .count()
+    }
+
     pub fn get_touched_transactions(&self, address: Address) -> Result<Vec<Hash>> {
         self.db.get_touched_transactions(address)
     }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -739,11 +739,11 @@ impl Consensus {
         content
     }
 
-    pub fn transaction_count_for_account(&self, account: Address) -> u64 {
+    pub fn pending_transaction_count(&self, account: Address) -> u64 {
         let current_nonce = self.state.must_get_account(account).nonce;
 
         self.transaction_pool
-            .transaction_count(account, current_nonce)
+            .pending_transaction_count(account, current_nonce)
     }
 
     pub fn get_touched_transactions(&self, address: Address) -> Result<Vec<Hash>> {

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -739,18 +739,11 @@ impl Consensus {
         content
     }
 
-    pub fn pending_transaction_count_for_address(&self, address: Address) -> usize {
-        let content = self.transaction_pool.preview_content();
+    pub fn transaction_count_for_account(&self, account: Address) -> u64 {
+        let current_nonce = self.state.must_get_account(account).nonce;
 
-        content
-            .pending
-            .iter()
-            .filter(|txn| {
-                let account_nonce = self.state.must_get_account(txn.signer).nonce;
-                txn.tx.nonce().unwrap() >= account_nonce
-            })
-            .filter(|txn| txn.signer == address)
-            .count()
+        self.transaction_pool
+            .transaction_count(account, current_nonce)
     }
 
     pub fn get_touched_transactions(&self, address: Address) -> Result<Vec<Hash>> {

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -777,9 +777,8 @@ impl Node {
         self.consensus.txpool_content()
     }
 
-    pub fn pending_transaction_account_for_address(&self, address: Address) -> usize {
-        self.consensus
-            .pending_transaction_count_for_address(address)
+    pub fn transaction_count_for_account(&self, account: Address) -> u64 {
+        self.consensus.transaction_count_for_account(account)
     }
 
     /// Convenience function to convert a block to a proposal (add full txs)

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -106,7 +106,7 @@ pub struct Node {
     peer_id: PeerId,
     message_sender: MessageSender,
     reset_timeout: UnboundedSender<Duration>,
-    consensus: Consensus,
+    pub consensus: Consensus,
 }
 
 const DEFAULT_SLEEP_TIME_MS: Duration = Duration::from_millis(5000);
@@ -775,10 +775,6 @@ impl Node {
 
     pub fn txpool_content(&self) -> TxPoolContent {
         self.consensus.txpool_content()
-    }
-
-    pub fn transaction_count_for_account(&self, account: Address) -> u64 {
-        self.consensus.transaction_count_for_account(account)
     }
 
     /// Convenience function to convert a block to a proposal (add full txs)

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -777,6 +777,11 @@ impl Node {
         self.consensus.txpool_content()
     }
 
+    pub fn pending_transaction_account_for_address(&self, address: Address) -> usize {
+        self.consensus
+            .pending_transaction_count_for_address(address)
+    }
+
     /// Convenience function to convert a block to a proposal (add full txs)
     /// NOTE: Includes intershard transactions. Should only be used for syncing history,
     /// not for consensus messages regarding new blocks.

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -187,7 +187,7 @@ impl TransactionPool {
         TxPoolContent { pending, queued }
     }
 
-    pub fn transaction_count(&self, account: Address, mut account_nonce: u64) -> u64 {
+    pub fn pending_transaction_count(&self, account: Address, mut account_nonce: u64) -> u64 {
         while self
             .transactions
             .contains_key(&TxIndex::Nonced(account, account_nonce))

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -187,6 +187,18 @@ impl TransactionPool {
         TxPoolContent { pending, queued }
     }
 
+    pub fn transaction_count(&self, account: Address, mut account_nonce: u64) -> u64 {
+        while self
+            .transactions
+            .get(&TxIndex::Nonced(account, account_nonce))
+            .is_some()
+        {
+            account_nonce += 1;
+        }
+
+        account_nonce
+    }
+
     pub fn insert_transaction(&mut self, txn: VerifiedTransaction, account_nonce: u64) -> bool {
         if txn.tx.nonce().is_some_and(|n| n < account_nonce) {
             // This transaction is permanently invalid, so there is nothing to do.

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -190,8 +190,7 @@ impl TransactionPool {
     pub fn transaction_count(&self, account: Address, mut account_nonce: u64) -> u64 {
         while self
             .transactions
-            .get(&TxIndex::Nonced(account, account_nonce))
-            .is_some()
+            .contains_key(&TxIndex::Nonced(account, account_nonce))
         {
             account_nonce += 1;
         }

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -250,6 +250,36 @@ async fn get_transaction_count_pending(mut network: Network) {
     assert_eq!(count, 2);
     let count = get_count(wallet_1.address(), provider, "latest").await;
     assert_eq!(count, 2);
+
+    // Send a transaction from wallet 1 to wallet 2.
+    let hash_3 = wallet_1
+        .send_transaction(
+            TransactionRequest::pay(wallet_2.address(), 10).nonce(3),
+            None,
+        )
+        .await
+        .unwrap()
+        .tx_hash();
+
+    // Wallet 1 should no longer have any pending transactions, and should have 2 transactions in the
+    // latest block, leading to 2 returned for both "pending" and "latest".
+    let count = get_count(wallet_1.address(), provider, "pending").await;
+    assert_eq!(count, 2);
+
+    // Send a transaction from wallet 1 to wallet 2.
+    let hash_4 = wallet_1
+        .send_transaction(
+            TransactionRequest::pay(wallet_2.address(), 10).nonce(2),
+            None,
+        )
+        .await
+        .unwrap()
+        .tx_hash();
+
+    // Wallet 1 should no longer have any pending transactions, and should have 2 transactions in the
+    // latest block, leading to 2 returned for both "pending" and "latest".
+    let count = get_count(wallet_1.address(), provider, "pending").await;
+    assert_eq!(count, 4);
 }
 
 #[zilliqa_macros::test]

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -245,9 +245,9 @@ async fn get_transaction_count_pending(mut network: Network) {
         .unwrap();
 
     // Wallet 1 should no longer have any pending transactions, and should have 2 transactions in the
-    // latest block.
+    // latest block, leading to 2 returned for both "pending" and "latest".
     let count = get_count(wallet_1.address(), provider, "pending").await;
-    assert_eq!(count, 0);
+    assert_eq!(count, 2);
     let count = get_count(wallet_1.address(), provider, "latest").await;
     assert_eq!(count, 2);
 }

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -187,7 +187,7 @@ async fn get_transaction_count_pending(mut network: Network) {
             .as_u64()
     }
 
-    // Both wallets should have no blocks pending.
+    // Both wallets should have no transactions pending.
     let count = get_count(wallet_1.address(), provider, "pending").await;
     assert_eq!(count, 0);
     let count = get_count(wallet_2.address(), provider, "pending").await;

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -252,14 +252,13 @@ async fn get_transaction_count_pending(mut network: Network) {
     assert_eq!(count, 2);
 
     // Send a transaction from wallet 1 to wallet 2.
-    let hash_3 = wallet_1
+    wallet_1
         .send_transaction(
             TransactionRequest::pay(wallet_2.address(), 10).nonce(3),
             None,
         )
         .await
-        .unwrap()
-        .tx_hash();
+        .unwrap();
 
     // Wallet 1 should no longer have any pending transactions, and should have 2 transactions in the
     // latest block, leading to 2 returned for both "pending" and "latest".
@@ -267,14 +266,13 @@ async fn get_transaction_count_pending(mut network: Network) {
     assert_eq!(count, 2);
 
     // Send a transaction from wallet 1 to wallet 2.
-    let hash_4 = wallet_1
+    wallet_1
         .send_transaction(
             TransactionRequest::pay(wallet_2.address(), 10).nonce(2),
             None,
         )
         .await
-        .unwrap()
-        .tx_hash();
+        .unwrap();
 
     // Wallet 1 should no longer have any pending transactions, and should have 2 transactions in the
     // latest block, leading to 2 returned for both "pending" and "latest".

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -170,8 +170,10 @@ async fn get_block_transaction_count(mut network: Network) {
 
 #[zilliqa_macros::test]
 async fn get_transaction_count_pending(mut network: Network) {
-    let wallet = network.genesis_wallet().await;
-    let provider = wallet.provider();
+    let wallet_1 = network.genesis_wallet().await;
+    let wallet_2 = network.random_wallet().await;
+
+    let provider = wallet_1.provider();
 
     async fn get_count<T: Debug + Serialize + Send + Sync>(
         address: H160,
@@ -185,26 +187,54 @@ async fn get_transaction_count_pending(mut network: Network) {
             .as_u64()
     }
 
-    let count = get_count(wallet.address(), provider, "pending").await;
+    // Both wallets should have no blocks pending.
+    let count = get_count(wallet_1.address(), provider, "pending").await;
+    assert_eq!(count, 0);
+    let count = get_count(wallet_2.address(), provider, "pending").await;
     assert_eq!(count, 0);
 
-    // Send a transaction.
-    let hash = wallet
-        .send_transaction(TransactionRequest::pay(H160::random(), 10), None)
+    // Send a transaction from wallet 1 to wallet 2.
+    let _hash_1 = wallet_1
+        .send_transaction(
+            TransactionRequest::pay(wallet_2.address(), 10).nonce(0),
+            None,
+        )
         .await
         .unwrap()
         .tx_hash();
 
-    let count = get_count(wallet.address(), provider, "pending").await;
+    // Wallet 1 should now have 1 transaction pending, and no transactions in the latest block.
+    let count = get_count(wallet_1.address(), provider, "pending").await;
     assert_eq!(count, 1);
-    let count = get_count(wallet.address(), provider, "latest").await;
+    let count = get_count(wallet_1.address(), provider, "latest").await;
     assert_eq!(count, 0);
 
+    // Send a transaction from wallet 1 to wallet 2.
+    let hash_2 = wallet_1
+        .send_transaction(
+            TransactionRequest::pay(wallet_2.address(), 10).nonce(1),
+            None,
+        )
+        .await
+        .unwrap()
+        .tx_hash();
+
+    // Wallet 1 should now have 2 transactions pending, and still no transactions in the latest block.
+    let count = get_count(wallet_1.address(), provider, "pending").await;
+    assert_eq!(count, 2);
+    let count = get_count(wallet_1.address(), provider, "latest").await;
+    assert_eq!(count, 0);
+
+    // Ensure transaction count is account specific.
+    let count = get_count(wallet_2.address(), provider, "pending").await;
+    assert_eq!(count, 0);
+
+    // Process pending transaction
     network
         .run_until_async(
             || async {
                 provider
-                    .get_transaction_receipt(hash)
+                    .get_transaction_receipt(hash_2)
                     .await
                     .unwrap()
                     .is_some()
@@ -214,12 +244,12 @@ async fn get_transaction_count_pending(mut network: Network) {
         .await
         .unwrap();
 
-    let count = get_count(wallet.address(), provider, "pending").await;
+    // Wallet 1 should no longer have any pending transactions, and should have 2 transactions in the
+    // latest block.
+    let count = get_count(wallet_1.address(), provider, "pending").await;
     assert_eq!(count, 0);
-    let count = get_count(wallet.address(), provider, "latest").await;
-    assert_eq!(count, 1);
-
-    panic!("This needs to fail");
+    let count = get_count(wallet_1.address(), provider, "latest").await;
+    assert_eq!(count, 2);
 }
 
 #[zilliqa_macros::test]


### PR DESCRIPTION
* Fixes https://github.com/Zilliqa/zq2/issues/902

* Add test for `eth_getTransactionCount` to verify that it respects the expected behavior when a block number of `pending` is passed