### PR TITLE
Fix panic in eth_getLogs when called with future blocks

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -423,14 +423,21 @@ fn get_logs(params: Params, node: &Arc<Mutex<Node>>) -> Result<Vec<eth::Log>> {
             .get_block(block_hash)?
             .ok_or_else(|| anyhow!("block not found"))?))),
         (None, from, to) => {
-            let from = node
+            let Some(from) = node
                 .resolve_block_number(from.unwrap_or(BlockNumberOrTag::Latest))?
-                .unwrap()
-                .number();
-            let to = node
+                .as_ref()
+                .map(Block::number)
+            else {
+                return Ok(vec![]);
+            };
+
+            let Some(to) = node
                 .resolve_block_number(to.unwrap_or(BlockNumberOrTag::Latest))?
-                .unwrap()
-                .number();
+                .as_ref()
+                .map(Block::number)
+            else {
+                return Ok(vec![]);
+            };
 
             if from > to {
                 return Err(anyhow!("`from` is greater than `to` ({from} > {to})"));

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -431,12 +431,15 @@ fn get_logs(params: Params, node: &Arc<Mutex<Node>>) -> Result<Vec<eth::Log>> {
                 return Ok(vec![]);
             };
 
-            let Some(to) = node
+            let to = match node
                 .resolve_block_number(to.unwrap_or(BlockNumberOrTag::Latest))?
                 .as_ref()
-                .map(Block::number)
-            else {
-                return Ok(vec![]);
+            {
+                Some(block) => block.number(),
+                None => node
+                    .resolve_block_number(BlockNumberOrTag::Latest)?
+                    .unwrap()
+                    .number(),
             };
 
             if from > to {


### PR DESCRIPTION
* Fixes https://github.com/Zilliqa/zq2/issues/1171

* Return an empty list when eth_getLogs is called with future blocks, matching behaviour of other EVM based chains