### PR TITLE
Fix second location of apply_rewards happening after transaction execution

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -965,6 +965,8 @@ impl Consensus {
         let mut tx_index_in_block = 0;
         let mut applied_transactions = Vec::new();
 
+        self.apply_rewards(&committee, &parent, block_view + 1, &qc.cosigned)?;
+
         while let Some(tx) = self.transaction_pool.best_transaction() {
             let result = self.apply_transaction(tx.clone(), parent_header, inspector::noop())?;
 
@@ -1019,8 +1021,6 @@ impl Consensus {
 
         let applied_transaction_hashes: Vec<_> =
             applied_transactions.iter().map(|tx| tx.hash).collect();
-
-        self.apply_rewards(&committee, &parent, block_view + 1, &qc.cosigned)?;
 
         let proposal = Block::from_qc(
             self.secret_key,

--- a/zilliqa/src/contracts/mod.rs
+++ b/zilliqa/src/contracts/mod.rs
@@ -12,6 +12,8 @@ pub mod deposit {
         Lazy::new(|| CONTRACT.abi.constructor().unwrap().clone());
 
     pub static BYTECODE: Lazy<Vec<u8>> = Lazy::new(|| CONTRACT.bytecode.clone());
+    pub static TEMP_REMOVE_STAKER: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("tempRemoveStaker").unwrap().clone());
     pub static DEPOSIT: Lazy<Function> =
         Lazy::new(|| CONTRACT.abi.function("deposit").unwrap().clone());
     pub static SET_STAKE: Lazy<Function> =

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -219,11 +219,11 @@ impl SecretKey {
         Self::from_bytes(&bytes_vec)
     }
 
-    fn as_bls(&self) -> bls_signatures::PrivateKey {
+    pub fn as_bls(&self) -> bls_signatures::PrivateKey {
         bls_signatures::PrivateKey::new(self.bytes)
     }
 
-    fn as_ecdsa(&self) -> k256::ecdsa::SigningKey {
+    pub fn as_ecdsa(&self) -> k256::ecdsa::SigningKey {
         // `SigningKey::from_bytes` can fail for two reasons:
         // 1. The bytes represent a zero integer. However, we validate this is not the case on construction.
         // 2. The bytes represent an integer less than the curve's modulus. However for ECDSA, the curve's order is


### PR DESCRIPTION
Should now be the first state change that happens in every block. Fixes #1143.
Also adds a test for it.