### PR TITLE
Remove ECDSA methods from SecretKey.

### DIFF
--- a/infra/tf/locals.tf
+++ b/infra/tf/locals.tf
@@ -5,7 +5,7 @@
 locals {
   binary_location      = "${path.module}/../../target/x86_64-unknown-linux-gnu/release/zilliqa"
   labels               = merge(var.labels, { "zq2-network" = var.network_name })
-  bootstrap_public_key = data.external.bootstrap_key_converted.result.bsl_public_key
+  bootstrap_public_key = data.external.bootstrap_key_converted.result.bls_public_key
   bootstrap_peer_id    = data.external.bootstrap_key_converted.result.peer_id
   genesis_address      = data.external.genesis_key_converted.result.address
   network_name         = element(split("/", data.google_compute_subnetwork.default.network), length(split("/", data.google_compute_subnetwork.default.network)) - 1)

--- a/infra/tf/locals.tf
+++ b/infra/tf/locals.tf
@@ -5,7 +5,7 @@
 locals {
   binary_location      = "${path.module}/../../target/x86_64-unknown-linux-gnu/release/zilliqa"
   labels               = merge(var.labels, { "zq2-network" = var.network_name })
-  bootstrap_public_key = data.external.bootstrap_key_converted.result.public_key
+  bootstrap_public_key = data.external.bootstrap_key_converted.result.bsl_public_key
   bootstrap_peer_id    = data.external.bootstrap_key_converted.result.peer_id
   genesis_address      = data.external.genesis_key_converted.result.address
   network_name         = element(split("/", data.google_compute_subnetwork.default.network), length(split("/", data.google_compute_subnetwork.default.network)) - 1)

--- a/zilliqa/src/bin/convert-key.rs
+++ b/zilliqa/src/bin/convert-key.rs
@@ -1,9 +1,10 @@
 use std::io;
 
 use anyhow::Result;
+use crypto_bigint::generic_array::GenericArray;
 use serde::Deserialize;
 use serde_json::json;
-use zilliqa::crypto::SecretKey;
+use zilliqa::crypto::{SecretKey, TransactionPublicKey};
 
 #[derive(Deserialize)]
 struct Input {
@@ -18,10 +19,17 @@ fn main() -> Result<()> {
 
     let secret_key = SecretKey::from_hex(&input.secret_key)?;
 
+    let key_bytes = secret_key.as_bytes();
+    let ecdsa_key =
+        k256::ecdsa::SigningKey::from_bytes(GenericArray::from_slice(&key_bytes)).unwrap();
+
+    let tx_pubkey = TransactionPublicKey::Ecdsa(k256::ecdsa::VerifyingKey::from(&ecdsa_key), true);
+
     let output = json!({
-        "public_key": secret_key.node_public_key(),
+        "bls_public_key": secret_key.node_public_key(),
         "peer_id": secret_key.to_libp2p_keypair().public().to_peer_id(),
-        "address": secret_key.tx_ecdsa_public_key().into_addr(),
+        "tx_pubkey": tx_pubkey,
+        "address": tx_pubkey.into_addr(),
     });
 
     println!("{output}");

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -250,15 +250,6 @@ impl SecretKey {
         bls_signatures::PrivateKey::new(self.bytes)
     }
 
-    pub fn as_ecdsa(&self) -> k256::ecdsa::SigningKey {
-        // `SigningKey::from_bytes` can fail for two reasons:
-        // 1. The bytes represent a zero integer. However, we validate this is not the case on construction.
-        // 2. The bytes represent an integer less than the curve's modulus. However for ECDSA, the curve's order is
-        //    equal to its modulus, so this is impossible.
-        // Therefore, it is safe to unwrap here.
-        k256::ecdsa::SigningKey::from_bytes(&self.bytes.into()).unwrap()
-    }
-
     pub fn as_bytes(&self) -> Vec<u8> {
         self.bytes.to_vec()
     }
@@ -273,15 +264,6 @@ impl SecretKey {
 
     pub fn node_public_key(&self) -> NodePublicKey {
         NodePublicKey(self.as_bls().public_key())
-    }
-
-    pub fn tx_ecdsa_public_key(&self) -> TransactionPublicKey {
-        // Default to EIP155 signing
-        TransactionPublicKey::Ecdsa(k256::ecdsa::VerifyingKey::from(&self.as_ecdsa()), true)
-    }
-
-    pub fn tx_sign_ecdsa(&self, message: &[u8]) -> TransactionSignature {
-        TransactionSignature::Ecdsa(self.as_ecdsa().sign_prehash_recoverable(message).unwrap().0)
     }
 
     pub fn to_libp2p_keypair(&self) -> libp2p::identity::Keypair {

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -1,8 +1,9 @@
-use std::fs;
+use std::{fs, ops::DerefMut};
 
 use alloy_eips::BlockId;
 use ethabi::Token;
 use ethers::{providers::Middleware, types::TransactionRequest};
+use k256::ecdsa::SigningKey;
 use primitive_types::H160;
 use rand::Rng;
 use tracing::*;
@@ -112,7 +113,14 @@ async fn block_and_tx_data_persistence(mut network: Network) {
         max_blocks_in_flight: max_blocks_in_flight_default(),
         block_request_batch_size: block_request_batch_size_default(),
     };
-    let result = crate::node(config, SecretKey::new().unwrap(), 0, Some(dir));
+    let mut rng = network.rng.lock().unwrap();
+    let result = crate::node(
+        config,
+        SecretKey::new_from_rng(rng.deref_mut()).unwrap(),
+        SigningKey::random(rng.deref_mut()),
+        0,
+        Some(dir),
+    );
 
     // Sometimes, the dropping Arc<Node> (by dropping the TestNode above) does not actually drop
     // the underlying Node. See: https://github.com/Zilliqa/zq2/issues/299

--- a/zilliqa/tests/it/staking.rs
+++ b/zilliqa/tests/it/staking.rs
@@ -277,8 +277,8 @@ async fn validators_can_leave(mut network: Network) {
         .wallet_from_key(
             network
                 .get_node_raw(validator_sending_removal)
-                .secret_key
-                .as_ecdsa(),
+                .onchain_key
+                .clone(),
         )
         .await;
     fund_wallet(&mut network, &genesis_wallet, &wallet_sending_removal).await;


### PR DESCRIPTION
The key is intended to be a signing key for the physical node - and not tied to any on-chain account. In the test framework and in z2, a separate key is now generated for each validator's on-chain account.