### PR TITLE
Attempt to remove the contracts.json from git diff linecounts.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+zilliqa/src/contracts/compiled.json -diff


### PR DESCRIPTION
It's a generated file so can effectively be treated as binary - specifically, we pretty much never need an explicit line-by-line diff. Thus this is set in the .gitattributes file. Hopefully, this should make diffs on pull requests display relevant linecounts, rather than exploding into the tens of thousands whenever contracts are recompiled and thus hiding the true change size.

If this works, this could also be added to Cargo.lock files, though their impact on diffs is usually minor so I left that for now.