### PR TITLE
Clean up alloy dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
+name = "alloy"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45855eb65e9cc70294ebea1279f6d8ee0636bf2ed3897683ebbae2739975ae8c"
+dependencies = [
+ "alloy-consensus",
+ "alloy-core",
+ "alloy-eips",
+ "alloy-network",
+ "alloy-provider",
+ "alloy-rpc-types",
+ "alloy-serde",
+]
+
+[[package]]
+name = "alloy-chains"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1752d7d62e2665da650a36d84abbf239f812534475d51f072a49a533513b7cdd"
+dependencies = [
+ "num_enum",
+ "strum",
+]
+
+[[package]]
 name = "alloy-consensus"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +126,17 @@ dependencies = [
  "alloy-serde",
  "c-kzg",
  "serde",
+]
+
+[[package]]
+name = "alloy-core"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "529fc6310dc1126c8de51c376cbc59c79c7f662bd742be7dc67055d5421a81b4"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-sol-types",
 ]
 
 [[package]]
@@ -117,6 +153,39 @@ dependencies = [
  "once_cell",
  "serde",
  "sha2 0.10.8",
+]
+
+[[package]]
+name = "alloy-json-rpc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e76a9feec2352c78545d1a37415699817bae8dc41654bd1bfe57d6cdd5433bd"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-network"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3223d71dc78f464b2743418d0be8b5c894313e272105a6206ad5e867d67b3ce2"
+dependencies = [
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-primitives",
+ "alloy-rpc-types-eth",
+ "alloy-serde",
+ "alloy-signer",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "futures-utils-wasm",
+ "thiserror",
 ]
 
 [[package]]
@@ -143,6 +212,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-provider"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29da7457d853cb8199ec04b227d5d2ef598be3e59fc2bbad70c8be213292f32"
+dependencies = [
+ "alloy-chains",
+ "alloy-consensus",
+ "alloy-eips",
+ "alloy-json-rpc",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-rpc-client",
+ "alloy-rpc-types-eth",
+ "alloy-rpc-types-trace",
+ "alloy-transport",
+ "async-stream",
+ "async-trait",
+ "auto_impl",
+ "dashmap",
+ "futures",
+ "futures-utils-wasm",
+ "lru",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +261,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a9e609524fa31c2c70eb24c0da60796809193ad4787a6dfe6d0db0d3ac112d"
+dependencies = [
+ "alloy-json-rpc",
+ "alloy-transport",
+ "alloy-transport-http",
+ "futures",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tracing",
 ]
 
 [[package]]
@@ -217,6 +335,20 @@ dependencies = [
  "alloy-primitives",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "alloy-signer"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f10592696f4ab8b687d5a8ab55e998a14ea0ca5f8eb20ad74a96ad671bb54a"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "elliptic-curve",
+ "k256",
+ "thiserror",
 ]
 
 [[package]]
@@ -276,6 +408,35 @@ dependencies = [
  "alloy-sol-macro",
  "const-hex",
  "serde",
+]
+
+[[package]]
+name = "alloy-transport"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b44b0f6f4a2593b258fa7b6cae8968e6a4c404d9ef4f5bc74401f2d04fa23fa"
+dependencies = [
+ "alloy-json-rpc",
+ "base64 0.22.1",
+ "futures-util",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "alloy-transport-http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d8f1eefa8cb9e7550740ee330feba4fed303a77ad3085707546f9152a88c380"
+dependencies = [
+ "alloy-transport",
+ "url",
 ]
 
 [[package]]
@@ -2045,7 +2206,7 @@ dependencies = [
 name = "eth_trie"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy",
  "criterion",
  "hashbrown 0.14.5",
  "hex",
@@ -2694,6 +2855,12 @@ dependencies = [
  "pin-utils",
  "slab",
 ]
+
+[[package]]
+name = "futures-utils-wasm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42012b0f064e01aa58b545fe3727f90f7dd4020f4a3ea735b50344965f5a57e9"
 
 [[package]]
 name = "fxhash"
@@ -8841,9 +9008,7 @@ dependencies = [
 name = "z2"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
+ "alloy",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -8981,13 +9146,7 @@ dependencies = [
 name = "zilliqa"
 version = "0.1.0"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-primitives",
- "alloy-rlp",
- "alloy-rpc-types",
- "alloy-rpc-types-trace",
- "alloy-sol-types",
+ "alloy",
  "anyhow",
  "async-trait",
  "base64 0.22.1",

--- a/eth-trie.rs/Cargo.toml
+++ b/eth-trie.rs/Cargo.toml
@@ -9,14 +9,14 @@ readme = "README.md"
 keywords = ["patricia", "mpt", "evm", "trie", "ethereum"]
 
 [dependencies]
-alloy-primitives = { version = "0.7.2", features = ["rlp"] }
+alloy = { version = "0.2.0", default-features = false, features = ["rlp"] }
 hashbrown = "0.14.5"
 log = "0.4.22"
 parking_lot = "0.12.3"
 rlp = "0.5.2"
 
 [dev-dependencies]
-alloy-primitives = { version = "0.7.2", features = ["getrandom"] }
+alloy = { version = "0.2.0", default-features = false, features = ["getrandom"] }
 rand = "0.8.5"
 hex = "0.4.3"
 criterion = "0.5.1"

--- a/eth-trie.rs/src/errors.rs
+++ b/eth-trie.rs/src/errors.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, fmt};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use rlp::DecoderError;
 
 use crate::nibbles::Nibbles;

--- a/eth-trie.rs/src/node.rs
+++ b/eth-trie.rs/src/node.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 
 use crate::nibbles::Nibbles;
 

--- a/eth-trie.rs/src/trie.rs
+++ b/eth-trie.rs/src/trie.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, RwLock};
 
-use alloy_primitives::{keccak256, B256};
+use alloy::primitives::{keccak256, B256};
 use hashbrown::{HashMap, HashSet};
 use log::warn;
 use rlp::{Prototype, Rlp, RlpStream};
@@ -1038,7 +1038,7 @@ mod tests {
         sync::Arc,
     };
 
-    use alloy_primitives::{keccak256, B256};
+    use alloy::primitives::{keccak256, B256};
     use rand::{distributions::Alphanumeric, seq::SliceRandom, thread_rng, Rng};
 
     use super::{EthTrie, Trie};

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -21,9 +21,7 @@ test = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy-consensus = { version = "0.2.0", features = ["serde", "k256"]}
-alloy-eips = { version = "0.2.0", features = ["serde"]}
-alloy-primitives = {version = "0.7.7", features = ["rlp", "serde"]}
+alloy = { version = "0.2.0", default-features = false, features = ["consensus", "rlp", "serde"] }
 anyhow = "1.0.86"
 async-trait = "0.1.81"
 base64 = "0.22.0"

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, env, fmt};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, Result};
 use clap::{builder::ArgAction, Args, Parser, Subcommand};
 use z2lib::{components::Component, deployer, plumbing, validators};

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -9,8 +9,10 @@ use std::{
     time::Duration,
 };
 
-use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy, EMPTY_ROOT_HASH};
-use alloy_primitives::{Address, Parity, Signature, TxKind, B256, U256};
+use alloy::{
+    consensus::{TxEip1559, TxEip2930, TxLegacy, EMPTY_ROOT_HASH},
+    primitives::{Address, Parity, Signature, TxKind, B256, U256},
+};
 use anyhow::{anyhow, Context, Result};
 use bitvec::bitvec;
 use clap::{Parser, Subcommand};

--- a/z2/src/docgen.rs
+++ b/z2/src/docgen.rs
@@ -10,7 +10,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_primitives::{address, Address};
+use alloy::primitives::{address, Address};
 use anyhow::{anyhow, Context as _, Result};
 use libp2p::PeerId;
 use regex::Regex;

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -1,7 +1,7 @@
 #![allow(unused_imports)]
 use std::{collections::HashSet, env, path::PathBuf, str::FromStr};
 
-use alloy_primitives::B256;
+use alloy::primitives::B256;
 use anyhow::{anyhow, Result};
 use colored::Colorize;
 use tokio::{fs, process::Command};

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -1,7 +1,7 @@
 //use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
-use alloy_primitives::{address, Address};
+use alloy::primitives::{address, Address};
 use anyhow::{anyhow, Result};
 use k256::ecdsa::SigningKey;
 use libp2p::PeerId;

--- a/z2/src/zq1/db.rs
+++ b/z2/src/zq1/db.rs
@@ -5,7 +5,7 @@ use std::{
     string::FromUtf8Error, sync::Arc,
 };
 
-use alloy_primitives::{Address, B256};
+use alloy::primitives::{Address, B256};
 use anyhow::{anyhow, Result};
 use eth_trie::{EthTrie, Trie, DB};
 use hex::FromHex;
@@ -640,7 +640,7 @@ enum FromHexError {
     #[error("invalid utf-8")]
     Utf8(#[from] FromUtf8Error),
     #[error("invalid hex encoding")]
-    Hex(#[from] alloy_primitives::hex::FromHexError),
+    Hex(#[from] alloy::primitives::hex::FromHexError),
 }
 
 fn address_from_hex(hex: Vec<u8>) -> Result<Address, FromHexError> {

--- a/z2/src/zq1/persistence.rs
+++ b/z2/src/zq1/persistence.rs
@@ -1,5 +1,7 @@
-use alloy_eips::eip2930::{AccessList, AccessListItem};
-use alloy_primitives::{Address, B256, B512};
+use alloy::{
+    eips::eip2930::{AccessList, AccessListItem},
+    primitives::{Address, B256, B512},
+};
 use anyhow::{anyhow, Result};
 use ethabi::Token;
 use k256::ecdsa::VerifyingKey;

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -24,12 +24,7 @@ anyhow = { version = "1.0.86", features = ["backtrace"] }
 vergen = { version = "8.3.1", features = ["git", "git2"] }
 
 [dependencies]
-alloy-primitives = { version = "0.7.7", features = ["rlp", "serde"] }
-alloy-rlp = { version = "0.3.7", features = ["derive"] }
-alloy-consensus = { version = "0.2.0", features = ["serde", "k256"]}
-alloy-eips = { version = "0.2.0", features = ["serde"]}
-alloy-rpc-types = "0.2.0"
-alloy-rpc-types-trace = "0.2.0"
+alloy = { version = "0.2.0", default-features = false, features = ["consensus", "eips", "k256", "rlp", "rpc-types", "rpc-types-trace", "serde", "sol-types"] }
 anyhow = { version = "1.0.86", features = ["backtrace"] }
 async-trait = "0.1.81"
 base64 = "0.22.1"
@@ -80,11 +75,10 @@ tower-http = { version = "0.4.4", features = ["cors"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 cbor4ii = "0.3.2"
-alloy-sol-types = "0.7.7"
 scilla-parser = "1.0.0"
 
 [dev-dependencies]
-alloy-primitives = { version = "0.7.7", features = ["rand"] }
+alloy = { version = "0.2.0", default-features = false, features = ["rand"] }
 async-trait = "0.1.81"
 criterion = "0.5.1"
 ethers = { version = "2.0.14", default-features = false, features = ["ethers-solc", "legacy"] }

--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -1,6 +1,6 @@
 use std::{path::PathBuf, sync::Arc, time::Duration};
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use bitvec::bitvec;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use eth_trie::{MemoryDB, Trie};

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -2,13 +2,15 @@
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
-use alloy_consensus::{TxEip1559, TxEip2930, TxLegacy};
-use alloy_eips::{eip2930::AccessList, BlockId, BlockNumberOrTag, RpcBlockHash};
-use alloy_primitives::{Address, Bytes, Parity, Signature, TxKind, B256, U256, U64};
-use alloy_rlp::{Decodable, Header};
-use alloy_rpc_types::{
-    pubsub::{self, SubscriptionKind},
-    FilteredParams,
+use alloy::{
+    consensus::{TxEip1559, TxEip2930, TxLegacy},
+    eips::{eip2930::AccessList, BlockId, BlockNumberOrTag, RpcBlockHash},
+    primitives::{Address, Bytes, Parity, Signature, TxKind, B256, U256, U64},
+    rlp::{Decodable, Header},
+    rpc::types::{
+        pubsub::{self, SubscriptionKind},
+        FilteredParams,
+    },
 };
 use anyhow::{anyhow, Result};
 use itertools::{Either, Itertools};
@@ -900,10 +902,10 @@ async fn subscribe(
                         continue 'outer;
                     }
 
-                    let log = alloy_rpc_types::Log {
-                        inner: alloy_primitives::Log {
+                    let log = alloy::rpc::types::Log {
+                        inner: alloy::primitives::Log {
                             address: log.address,
-                            data: alloy_primitives::LogData::new_unchecked(
+                            data: alloy::primitives::LogData::new_unchecked(
                                 log.topics,
                                 log.data.into(),
                             ),

--- a/zilliqa/src/api/ots.rs
+++ b/zilliqa/src/api/ots.rs
@@ -3,8 +3,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_eips::BlockId;
-use alloy_primitives::{Address, B256};
+use alloy::{
+    eips::BlockId,
+    primitives::{Address, B256},
+};
 use anyhow::{anyhow, Result};
 use ethabi::Token;
 use jsonrpsee::{types::Params, RpcModule};

--- a/zilliqa/src/api/to_hex.rs
+++ b/zilliqa/src/api/to_hex.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B128, B256, B512, U128, U256, U512};
+use alloy::primitives::{Address, B128, B256, B512, U128, U256, U512};
 
 use crate::transaction::{EvmGas, ScillaGas};
 
@@ -116,7 +116,7 @@ serde_impl!(U512);
 mod tests {
     use std::assert_eq;
 
-    use alloy_primitives::U128;
+    use alloy::primitives::U128;
 
     use super::ToHex;
 

--- a/zilliqa/src/api/trace.rs
+++ b/zilliqa/src/api/trace.rs
@@ -3,11 +3,13 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_eips::BlockNumberOrTag;
-use alloy_primitives::B256;
-use alloy_rpc_types_trace::{
-    geth::{GethDebugTracingOptions, TraceResult},
-    parity::{TraceResults, TraceType},
+use alloy::{
+    eips::BlockNumberOrTag,
+    primitives::B256,
+    rpc::types::trace::{
+        geth::{GethDebugTracingOptions, TraceResult},
+        parity::{TraceResults, TraceType},
+    },
 };
 use anyhow::Result;
 use jsonrpsee::{types::Params, RpcModule};

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -1,7 +1,9 @@
 use std::collections::HashMap;
 
-use alloy_consensus::TxEip1559;
-use alloy_primitives::{Address, B256, U128, U256, U64};
+use alloy::{
+    consensus::TxEip1559,
+    primitives::{Address, B256, U128, U256, U64},
+};
 use serde::{
     de::{self, Unexpected},
     Deserialize, Deserializer, Serialize,
@@ -443,7 +445,7 @@ pub struct TxPoolContent {
 
 #[cfg(test)]
 mod tests {
-    use alloy_primitives::B256;
+    use alloy::primitives::B256;
 
     use super::Log;
 

--- a/zilliqa/src/api/types/mod.rs
+++ b/zilliqa/src/api/types/mod.rs
@@ -1,7 +1,6 @@
 use std::fmt::Display;
 
-use alloy_eips::BlockId;
-use alloy_primitives::B256;
+use alloy::{eips::BlockId, primitives::B256};
 use serde::{ser::SerializeSeq, Serializer};
 
 use super::to_hex::ToHex;

--- a/zilliqa/src/api/types/ots.rs
+++ b/zilliqa/src/api/types/ots.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::{Address, B256};
+use alloy::primitives::{Address, B256};
 use serde::Serialize;
 
 use super::{eth, hex, option_hex};

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -1,7 +1,9 @@
 use std::collections::BTreeMap;
 
-use alloy_consensus::SignableTransaction;
-use alloy_primitives::{Address, B256, B512};
+use alloy::{
+    consensus::SignableTransaction,
+    primitives::{Address, B256, B512},
+};
 use anyhow::Result;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use serde::Serialize;

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -6,8 +6,10 @@ use std::{
     sync::{Arc, Mutex},
 };
 
-use alloy_eips::BlockId;
-use alloy_primitives::{Address, B256};
+use alloy::{
+    eips::BlockId,
+    primitives::{Address, B256},
+};
 use anyhow::{anyhow, Result};
 use jsonrpsee::{types::Params, RpcModule};
 use serde::{Deserialize, Deserializer};

--- a/zilliqa/src/blockhooks.rs
+++ b/zilliqa/src/blockhooks.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use anyhow::Result;
 use ethabi::{Event, Log, RawLog, Token};
 use tracing::warn;

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,6 +1,6 @@
 use std::{ops::Deref, str::FromStr, time::Duration};
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use libp2p::{Multiaddr, PeerId};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2,7 +2,7 @@ use std::{
     cell::RefCell, collections::BTreeMap, error::Error, fmt::Display, sync::Arc, time::Duration,
 };
 
-use alloy_primitives::{Address, U256};
+use alloy::primitives::{Address, U256};
 use anyhow::{anyhow, Result};
 use bitvec::bitvec;
 use eth_trie::{MemoryDB, Trie};

--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -6,7 +6,7 @@
 
 use std::fmt::Display;
 
-use alloy_primitives::{Address, B256};
+use alloy::primitives::{Address, B256};
 use anyhow::{anyhow, Result};
 use bls12_381::{G1Projective, G2Affine};
 use bls_signatures::Serialize as BlsSerialize;

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -8,7 +8,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use anyhow::{anyhow, Result};
 use eth_trie::{EthTrie, Trie};
 use itertools::Either;
@@ -897,7 +897,7 @@ impl eth_trie::DB for TrieStorage {
 mod tests {
     use std::ops::Deref;
 
-    use alloy_consensus::EMPTY_ROOT_HASH;
+    use alloy::consensus::EMPTY_ROOT_HASH;
     use rand::{
         distributions::{Distribution, Uniform},
         Rng, SeedableRng,

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -9,7 +9,7 @@ use std::{
     sync::{Arc, MutexGuard},
 };
 
-use alloy_primitives::{hex, Address, U256};
+use alloy::primitives::{hex, Address, U256};
 use anyhow::{anyhow, Result};
 use bytes::Bytes;
 use eth_trie::{EthTrie, Trie};

--- a/zilliqa/src/inspector.rs
+++ b/zilliqa/src/inspector.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use alloy_primitives::{Address, U256};
+use alloy::primitives::{Address, U256};
 use revm::{
     inspectors::NoOpInspector,
     interpreter::{CallInputs, CallOutcome, CallScheme, CreateInputs, CreateOutcome},

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -4,7 +4,7 @@ use std::{
     path::Path,
 };
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use anyhow::{anyhow, Result};
 use bitvec::{bitvec, order::Msb0};
 use itertools::Either;
@@ -446,7 +446,7 @@ impl Default for BlockHeader {
             hash: Hash::ZERO,
             parent_hash: Hash::ZERO,
             signature: NodeSignature::identity(),
-            state_root_hash: Hash(Keccak256::digest([alloy_rlp::EMPTY_STRING_CODE]).into()),
+            state_root_hash: Hash(Keccak256::digest([alloy::rlp::EMPTY_STRING_CODE]).into()),
             transactions_root_hash: Hash::ZERO,
             receipts_root_hash: Hash::ZERO,
             timestamp: SystemTime::UNIX_EPOCH,

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1,13 +1,15 @@
 use std::{collections::HashSet, fmt::Debug, sync::Arc, time::Duration};
 
-use alloy_eips::{BlockId, BlockNumberOrTag, RpcBlockHash};
-use alloy_primitives::Address;
-use alloy_rpc_types_trace::{
-    geth::{
-        FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType, GethDebugTracingOptions,
-        GethTrace, NoopFrame, TraceResult,
+use alloy::{
+    eips::{BlockId, BlockNumberOrTag, RpcBlockHash},
+    primitives::Address,
+    rpc::types::trace::{
+        geth::{
+            FourByteFrame, GethDebugBuiltInTracerType, GethDebugTracerType,
+            GethDebugTracingOptions, GethTrace, NoopFrame, TraceResult,
+        },
+        parity::{TraceResults, TraceType},
     },
-    parity::{TraceResults, TraceType},
 };
 use anyhow::{anyhow, Result};
 use libp2p::{request_response::OutboundFailure, PeerId};

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -3,7 +3,7 @@ use std::{
     collections::{BTreeMap, BinaryHeap, HashSet},
 };
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 
 use crate::{
     crypto::Hash,
@@ -289,8 +289,10 @@ impl TransactionPool {
 
 #[cfg(test)]
 mod tests {
-    use alloy_consensus::TxLegacy;
-    use alloy_primitives::{Address, Bytes, Parity, Signature, TxKind, U256};
+    use alloy::{
+        consensus::TxLegacy,
+        primitives::{Address, Bytes, Parity, Signature, TxKind, U256},
+    };
     use rand::{seq::SliceRandom, thread_rng};
 
     use super::TransactionPool;

--- a/zilliqa/src/precompiles/mod.rs
+++ b/zilliqa/src/precompiles/mod.rs
@@ -3,7 +3,7 @@ mod scilla_read;
 
 use std::sync::Arc;
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use erc20::ERC20Precompile;
 use revm::ContextPrecompile;
 use scilla_read::ScillaRead;

--- a/zilliqa/src/precompiles/scilla_read.rs
+++ b/zilliqa/src/precompiles/scilla_read.rs
@@ -1,5 +1,7 @@
-use alloy_primitives::{I256, U256};
-use alloy_sol_types::{abi::Decoder, SolValue};
+use alloy::{
+    primitives::{I256, U256},
+    sol_types::{abi::Decoder, SolValue},
+};
 use anyhow::{anyhow, Result};
 use eth_trie::{EthTrie, Trie};
 use revm::{

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -12,7 +12,7 @@ use std::{
     time::Duration,
 };
 
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use anyhow::{anyhow, Result};
 use base64::Engine;
 use bytes::{BufMut, Bytes, BytesMut};

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -3,8 +3,10 @@ use std::{
     sync::{Arc, Mutex, MutexGuard, OnceLock},
 };
 
-use alloy_consensus::EMPTY_ROOT_HASH;
-use alloy_primitives::{Address, B256};
+use alloy::{
+    consensus::EMPTY_ROOT_HASH,
+    primitives::{Address, B256},
+};
 use anyhow::{anyhow, Result};
 use eth_trie::{EthTrie as PatriciaTrie, Trie};
 use ethabi::Token;
@@ -245,7 +247,7 @@ impl State {
 }
 
 pub mod contract_addr {
-    use alloy_primitives::Address;
+    use alloy::primitives::Address;
 
     /// For intershard transactions, call this address
     pub const INTERSHARD_BRIDGE: Address = Address::new(*b"\0\0\0\0\0\0\0\0ZQINTERSHARD");

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -6,9 +6,11 @@ use std::{
     str::FromStr,
 };
 
-use alloy_consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy};
-use alloy_primitives::{keccak256, Address, Signature, TxKind, B256, U256};
-use alloy_rlp::{Encodable, Header, EMPTY_STRING_CODE};
+use alloy::{
+    consensus::{SignableTransaction, TxEip1559, TxEip2930, TxLegacy},
+    primitives::{keccak256, Address, Signature, TxKind, B256, U256},
+    rlp::{Encodable, Header, EMPTY_STRING_CODE},
+};
 use anyhow::{anyhow, Result};
 use bytes::{BufMut, BytesMut};
 use itertools::Itertools;
@@ -76,7 +78,7 @@ pub enum SignedTransaction {
 mod ser_rlp {
     use std::marker::PhantomData;
 
-    use alloy_rlp::{Decodable, Encodable};
+    use alloy::rlp::{Decodable, Encodable};
     use serde::{de, Deserializer, Serializer};
 
     pub fn serialize<T, S>(value: &T, serializer: S) -> Result<S::Ok, S::Error>
@@ -837,13 +839,13 @@ impl AddAssign for EvmGas {
     }
 }
 
-impl alloy_rlp::Decodable for EvmGas {
-    fn decode(buf: &mut &[u8]) -> alloy_rlp::Result<Self> {
-        Ok(EvmGas(<u64 as alloy_rlp::Decodable>::decode(buf)?))
+impl alloy::rlp::Decodable for EvmGas {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        Ok(EvmGas(<u64 as alloy::rlp::Decodable>::decode(buf)?))
     }
 }
 
-impl alloy_rlp::Encodable for EvmGas {
+impl alloy::rlp::Encodable for EvmGas {
     fn encode(&self, out: &mut dyn BufMut) {
         self.0.encode(out);
     }

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -1,4 +1,4 @@
-use alloy_eips::BlockId;
+use alloy::eips::BlockId;
 use ethabi::Token;
 use ethers::{
     abi::FunctionExt, prelude::DeploymentTxFactory, providers::Middleware,

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, ops::DerefMut};
 
-use alloy_primitives::{hex, Address};
+use alloy::primitives::{hex, Address};
 use ethabi::{ethereum_types::U64, Token};
 use ethers::{
     abi::FunctionExt,

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1,4 +1,4 @@
-use alloy_primitives::Address;
+use alloy::primitives::Address;
 use ethers::{
     abi::Tokenize,
     providers::{Middleware, PubsubClient},

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -1,6 +1,6 @@
 use std::{fs, ops::DerefMut};
 
-use alloy_eips::BlockId;
+use alloy::eips::BlockId;
 use ethabi::Token;
 use ethers::{providers::Middleware, types::TransactionRequest};
 use k256::ecdsa::SigningKey;


### PR DESCRIPTION
Instead of depending on the alloy subcrates individually, we just depend on the supercrate and enable the features we need. This means dependency updates only touch one version. Thanks @yaron-zilliqa for pointing out that this was possible.