### PR TITLE
Change GetSmartContractCode to return EVM code

### DIFF
--- a/docs/api/zilliqa/getsmartcontractcode.doc.md
+++ b/docs/api/zilliqa/getsmartcontractcode.doc.md
@@ -8,7 +8,7 @@ contract,smart contract,code,get,address
 
 # Description
 
-Returns the Scilla code associated with a smart contract address. This is represented as a `String`.
+Returns the Scilla or EVM code associated with a smart contract address. Scilla code is represented as a `String` for the code, EVM code is returned as a hex representation of the compiled bytes. 
 
 # Curl
 
@@ -68,7 +68,8 @@ func GetSmartContractCode() {
   "id": "1",
   "jsonrpc": "2.0",
   "result": {
-    "code": "scilla_version 0\n\n    (* HelloWorld contract *)\n    \n    import ListUtils\n    \n    (***************************************************)\n    (*               Associated library                *)\n    (***************************************************)\n    library HelloWorld\n    \n    let one_msg = \n      fun (msg : Message) => \n      let nil_msg = Nil {Message} in\n      Cons {Message} msg nil_msg\n    \n    let not_owner_code = Int32 1\n    let set_hello_code = Int32 2\n    \n    (***************************************************)\n    (*             The contract definition             *)\n    (***************************************************)\n    \n    contract HelloWorld\n    (owner: ByStr20)\n    \n    field welcome_msg : `String` = \"\"\n    \n    transition setHello (msg : `String`)\n      is_owner = builtin eq owner _sender;\n      match is_owner with\n      | False =>\n        msg = {_tag : \"Main\"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};\n        msgs = one_msg msg;\n        send msgs\n      | True =>\n        welcome_msg := msg;\n        msg = {_tag : \"Main\"; _recipient : _sender; _amount : Uint128 0; code : set_hello_code};\n        msgs = one_msg msg;\n        send msgs\n      end\n    end\n    \n    \n    transition getHello ()\n        r <- welcome_msg;\n        e = {_eventname: \"getHello()\"; msg: r};\n        event e\n    end"
+    "code": "scilla_version 0\n\n    (* HelloWorld contract *)\n    \n    import ListUtils\n    \n    (***************************************************)\n    (*               Associated library                *)\n    (***************************************************)\n    library HelloWorld\n    \n    let one_msg = \n      fun (msg : Message) => \n      let nil_msg = Nil {Message} in\n      Cons {Message} msg nil_msg\n    \n    let not_owner_code = Int32 1\n    let set_hello_code = Int32 2\n    \n    (***************************************************)\n    (*             The contract definition             *)\n    (***************************************************)\n    \n    contract HelloWorld\n    (owner: ByStr20)\n    \n    field welcome_msg : `String` = \"\"\n    \n    transition setHello (msg : `String`)\n      is_owner = builtin eq owner _sender;\n      match is_owner with\n      | False =>\n        msg = {_tag : \"Main\"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};\n        msgs = one_msg msg;\n        send msgs\n      | True =>\n        welcome_msg := msg;\n        msg = {_tag : \"Main\"; _recipient : _sender; _amount : Uint128 0; code : set_hello_code};\n        msgs = one_msg msg;\n        send msgs\n      end\n    end\n    \n    \n    transition getHello ()\n        r <- welcome_msg;\n        e = {_eventname: \"getHello()\"; msg: r};\n        event e\n    end",
+    "language": "scilla"
   }
 }
 ```

--- a/docs/api/zilliqa/getsmartcontractcode.doc.md
+++ b/docs/api/zilliqa/getsmartcontractcode.doc.md
@@ -69,7 +69,7 @@ func GetSmartContractCode() {
   "jsonrpc": "2.0",
   "result": {
     "code": "scilla_version 0\n\n    (* HelloWorld contract *)\n    \n    import ListUtils\n    \n    (***************************************************)\n    (*               Associated library                *)\n    (***************************************************)\n    library HelloWorld\n    \n    let one_msg = \n      fun (msg : Message) => \n      let nil_msg = Nil {Message} in\n      Cons {Message} msg nil_msg\n    \n    let not_owner_code = Int32 1\n    let set_hello_code = Int32 2\n    \n    (***************************************************)\n    (*             The contract definition             *)\n    (***************************************************)\n    \n    contract HelloWorld\n    (owner: ByStr20)\n    \n    field welcome_msg : `String` = \"\"\n    \n    transition setHello (msg : `String`)\n      is_owner = builtin eq owner _sender;\n      match is_owner with\n      | False =>\n        msg = {_tag : \"Main\"; _recipient : _sender; _amount : Uint128 0; code : not_owner_code};\n        msgs = one_msg msg;\n        send msgs\n      | True =>\n        welcome_msg := msg;\n        msg = {_tag : \"Main\"; _recipient : _sender; _amount : Uint128 0; code : set_hello_code};\n        msgs = one_msg msg;\n        send msgs\n      end\n    end\n    \n    \n    transition getHello ()\n        r <- welcome_msg;\n        e = {_eventname: \"getHello()\"; msg: r};\n        event e\n    end",
-    "language": "scilla"
+    "type": "scilla"
   }
 }
 ```

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -342,12 +342,12 @@ fn get_smart_contract_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<Va
         .get_state(&block)?
         .get_account(smart_contract_address)?;
 
-    let (code, language) = match account.code {
+    let (code, type_) = match account.code {
         Code::Evm(ref bytes) => (hex::encode(bytes), "evm".to_string()),
         Code::Scilla { code, .. } => (code, "scilla".to_string()),
     };
 
-    Ok(json!({ "code": code, "lanuage": language }))
+    Ok(json!({ "code": code, "type": type_ }))
 }
 
 fn get_smart_contract_init(params: Params, node: &Arc<Mutex<Node>>) -> Result<Value> {

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -342,16 +342,12 @@ fn get_smart_contract_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<Va
         .get_state(&block)?
         .get_account(smart_contract_address)?;
 
-    let code = match account.code {
-        Code::Evm(ref bytes) => {
-            "EVM".to_string()
-                + &String::from_utf16(&bytes.into_iter().map(|v| *v as u16).collect::<Vec<_>>())
-                    .unwrap()
-        }
-        Code::Scilla { code, .. } => code,
+    let (code, language) = match account.code {
+        Code::Evm(ref bytes) => (hex::encode(bytes), "evm".to_string()),
+        Code::Scilla { code, .. } => (code, "scilla".to_string()),
     };
 
-    Ok(json!({ "code": code }))
+    Ok(json!({ "code": code, "lanuage": language }))
 }
 
 fn get_smart_contract_init(params: Params, node: &Arc<Mutex<Node>>) -> Result<Value> {

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -343,8 +343,8 @@ fn get_smart_contract_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<Va
         .get_account(smart_contract_address)?;
 
     let (code, type_) = match account.code {
-        Code::Evm(ref bytes) => (hex::encode(bytes), "evm".to_string()),
-        Code::Scilla { code, .. } => (code, "scilla".to_string()),
+        Code::Evm(ref bytes) => (hex::encode(bytes), "evm"),
+        Code::Scilla { code, .. } => (code, "scilla"),
     };
 
     Ok(json!({ "code": code, "type": type_ }))

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -24,6 +24,7 @@ use crate::{
     node::Node,
     schnorr,
     scilla::split_storage_key,
+    state::Code,
     transaction::{ScillaGas, SignedTransaction, TxZilliqa, ZilAmount, EVM_GAS_PER_SCILLA_GAS},
 };
 
@@ -341,8 +342,13 @@ fn get_smart_contract_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<Va
         .get_state(&block)?
         .get_account(smart_contract_address)?;
 
-    let Some((code, _)) = account.code.scilla_code_and_init_data() else {
-        return Err(anyhow!("Address not contract address"));
+    let code = match account.code {
+        Code::Evm(ref bytes) => {
+            "EVM".to_string()
+                + &String::from_utf16(&bytes.into_iter().map(|v| *v as u16).collect::<Vec<_>>())
+                    .unwrap()
+        }
+        Code::Scilla { code, .. } => code,
     };
 
     Ok(json!({ "code": code }))


### PR DESCRIPTION
* Fixes https://github.com/Zilliqa/zq2/issues/1027

* Return EVM code from `GetSmartContractCode` by encoding the bytecode as hexadecimal