### PR TITLE
Add a changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## [Unreleased]
+
+Unreleased changes.
+
+## [0.1.0] - 2024-08-01
+
+Initial release of Zilliqa 2.
+
+[unreleased]: https://github.com/zilliqa/zq2/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/zilliqa/zq2/releases/tag/v0.1.0


### PR DESCRIPTION
Since we are starting to share Zilliqa 2 networks externally, we should start assigning our releases version names and documenting the changes we make.

`CHANGELOG.md` is where we will document and keep track of changes. Relevant PRs should add changelog entries under the 'Unreleased' section. When we are ready to create a new release, a new heading will be added to name that release.

This is broadly based on https://keepachangelog.com/en/1.1.0/.