### PR TITLE
Record panics with a `tracing` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Unreleased changes.
 
 - [#1174](https://github.com/Zilliqa/zq2/pull/1174): Limit the returned size of `GetSmartContractState` when the `state_rpc_limit` configuration is set.
+- [#1281](https://github.com/Zilliqa/zq2/pull/1281): Emit an `ERROR` level log when a node panics.
 
 ## [0.1.0] - 2024-08-01
 


### PR DESCRIPTION
This ensures that when a node panics, the panic message and backtrace is logged as JSON (if JSON logging is enabled) and thus we can see the panic in the node's logs (in GCP).

Example of output:
```
{"timestamp":"2024-08-12T18:10:57.077806Z","level":"ERROR","fields":{"thread_name":"main","message":"At least one shard must be configured","panic.file":"zilliqa/src/bin/zilliqa.rs","panic.line":94,"panic.column":5,"backtrace":"   0: zilliqa::main::{{closure}}::{{closure}}\n             at ./zilliqa/src/bin/zilliqa.rs:46:25\n   1: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/alloc/src/boxed.rs:2036:9\n   2: std::panicking::rust_panic_with_hook\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:799:13\n   3: std::panicking::begin_panic_handler::{{closure}}\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:656:13\n   4: std::sys_common::backtrace::__rust_end_short_backtrace\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:171:18\n   5: rust_begin_unwind\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:652:5\n   6: core::panicking::panic_fmt\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/panicking.rs:72:14\n   7: zilliqa::main::{{closure}}\n             at ./zilliqa/src/bin/zilliqa.rs:94:5\n   8: <core::pin::Pin<P> as core::future::future::Future>::poll\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/future/future.rs:123:9\n   9: tokio::runtime::park::CachedParkThread::block_on::{{closure}}\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/park.rs:281:63\n  10: tokio::runtime::coop::with_budget\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/coop.rs:107:5\n  11: tokio::runtime::coop::budget\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/coop.rs:73:5\n  12: tokio::runtime::park::CachedParkThread::block_on\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/park.rs:281:31\n  13: tokio::runtime::context::blocking::BlockingRegionGuard::block_on\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context/blocking.rs:66:9\n  14: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/multi_thread/mod.rs:87:13\n  15: tokio::runtime::context::runtime::enter_runtime\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/context/runtime.rs:65:16\n  16: tokio::runtime::scheduler::multi_thread::MultiThread::block_on\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/scheduler/multi_thread/mod.rs:86:9\n  17: tokio::runtime::runtime::Runtime::block_on_inner\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/runtime.rs:363:45\n  18: tokio::runtime::runtime::Runtime::block_on\n             at /home/james/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.39.2/src/runtime/runtime.rs:333:13\n  19: zilliqa::main\n             at ./zilliqa/src/bin/zilliqa.rs:120:5\n  20: core::ops::function::FnOnce::call_once\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:250:5\n  21: std::sys_common::backtrace::__rust_begin_short_backtrace\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/sys_common/backtrace.rs:155:18\n  22: std::rt::lang_start::{{closure}}\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:159:18\n  23: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/core/src/ops/function.rs:284:13\n  24: std::panicking::try::do_call\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40\n  25: std::panicking::try\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19\n  26: std::panic::catch_unwind\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14\n  27: std::rt::lang_start_internal::{{closure}}\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:141:48\n  28: std::panicking::try::do_call\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:559:40\n  29: std::panicking::try\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panicking.rs:523:19\n  30: std::panic::catch_unwind\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/panic.rs:149:14\n  31: std::rt::lang_start_internal\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:141:20\n  32: std::rt::lang_start\n             at /rustc/129f3b9964af4d4a709d1383930ade12dfe7c081/library/std/src/rt.rs:158:17\n  33: main\n  34: __libc_start_call_main\n             at ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16\n  35: __libc_start_main_impl\n             at ./csu/../csu/libc-start.c:392:3\n  36: _start\n"},"target":"zilliqa","line_number":66}
```