### PR TITLE
Fix response size limiter for `GetSmartContractState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Unreleased changes.
 
+- [#1174](https://github.com/Zilliqa/zq2/pull/1174): Limit the returned size of `GetSmartContractState` when the `state_rpc_limit` configuration is set.
+
 ## [0.1.0] - 2024-08-01
 
 Initial release of Zilliqa 2.

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -315,14 +315,7 @@ fn get_smart_contract_state(params: Params, node: &Arc<Mutex<Node>>) -> Result<V
 
     let is_scilla = account.code.scilla_code_and_init_data().is_some();
     if is_scilla {
-        // The configuration variable contains maximum size in KiB
         let limit = node.config.state_rpc_limit;
-        let limit = if limit == 0 {
-            limit
-        } else {
-            /* This field being set to 0 corresponds to no limit */
-            usize::MAX
-        };
 
         let trie = state.get_account_trie(address)?;
         for (i, (k, v)) in trie.iter().enumerate() {

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -70,7 +70,7 @@ pub struct NodeConfig {
     /// The maximum number of blocks to request in a single message when syncing.
     #[serde(default = "block_request_batch_size_default")]
     pub block_request_batch_size: u64,
-    /// The maximum number of key value pairs allowed to be returned withing the response of the `GetSmartContractState` RPC.
+    /// The maximum number of key value pairs allowed to be returned withing the response of the `GetSmartContractState` RPC. Defaults to no limit.
     #[serde(default = "state_rpc_limit_default")]
     pub state_rpc_limit: usize,
     /// When a block request to a peer fails, do not send another request to this peer for this amount of time.
@@ -139,7 +139,7 @@ pub fn block_request_batch_size_default() -> u64 {
 }
 
 pub fn state_rpc_limit_default() -> usize {
-    1024
+    usize::MAX
 }
 
 pub fn failed_request_sleep_duration_default() -> Duration {


### PR DESCRIPTION
I fixed a small bug in the `if` condition which would cause the limit to be ignored. Instead we just represent the unlimited size directly in `cfg.rs`. Also, the default behaviour is now that no limit is set, to match the existing behaviour of ZQ1.

I also added a changelog entry for the change.