### PR TITLE
Integrate Autonat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4269,6 +4269,7 @@ dependencies = [
  "futures-timer",
  "getrandom",
  "libp2p-allow-block-list",
+ "libp2p-autonat",
  "libp2p-connection-limits",
  "libp2p-core",
  "libp2p-dns",
@@ -4301,6 +4302,33 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "void",
+]
+
+[[package]]
+name = "libp2p-autonat"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
+dependencies = [
+ "async-trait",
+ "asynchronous-codec",
+ "bytes",
+ "either",
+ "futures",
+ "futures-bounded",
+ "futures-timer",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-request-response",
+ "libp2p-swarm",
+ "quick-protobuf",
+ "quick-protobuf-codec",
+ "rand",
+ "rand_core",
+ "thiserror",
+ "tracing",
+ "void",
+ "web-time",
 ]
 
 [[package]]

--- a/docker-compose-networking-test.yaml
+++ b/docker-compose-networking-test.yaml
@@ -1,0 +1,136 @@
+# docker-compsoe file for testing networking with static IPs
+version: "3"
+services:
+  node0:
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: zilliqa=info
+    image: zq2-node0
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: zilliqanode0
+    volumes:
+      - "./infra/config_networking_test.toml:/config.toml"
+    command:
+      - 65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227
+    ports:
+      - "4201:4201"
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.100
+
+  node1:
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: zilliqa=info
+    container_name: zilliqanode1
+    image: zq2-node0
+    volumes:
+      - "./infra/config_networking_test.toml:/config.toml"
+    command:
+      - 62070b1a3b5b30236e43b4f1bfd617e1af7474635558314d46127a708b9d302e
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.101
+
+  node2:
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: zilliqa=info
+    container_name: zilliqanode2
+    image: zq2-node0
+    volumes:
+      - "./infra/config_networking_test.toml:/config.toml"
+    command:
+      - 56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.102
+
+  node3:
+    environment:
+      RUST_BACKTRACE: 1
+      RUST_LOG: zilliqa=info
+    container_name: zilliqanode3
+    image: zq2-node0
+    volumes:
+      - "./infra/config_networking_test.toml:/config.toml"
+    command:
+      - db670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.103
+
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./infra/otel-collector-config.yaml:/etc/otel-collector-config.yaml
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.6
+
+  mimir:
+    image: grafana/mimir:latest
+    volumes:
+      - "./infra/mimir.yaml:/etc/mimir/config.yaml"
+    command:
+      - "./mimir"
+      - "--config.file"
+      - "/etc/mimir/config.yaml"
+    ports:
+      - "9009:9009"
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.7
+
+  grafana:
+    image: grafana/grafana-oss:latest
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+    ports:
+      - "3000:3000"
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.8
+
+  otterscan:
+    environment:
+      ERIGON_URL: http://localhost:4201
+    image: zilliqa/otterscan:develop
+    pull_policy: always
+    ports:
+      - "5100:80"
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.9
+
+  faucet:
+    depends_on:
+      - node0
+    image: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa/eth-spout:v1.3.72
+    environment:
+      RPC_URL: http://node0:4201
+      NATIVE_TOKEN_SYMBOL: ZIL
+      PRIVATE_KEY: 65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227
+      ETH_AMOUNT: 100
+      EXPLORER_URL: http://localhost:5200
+      MINIMUM_SECONDS_BETWEEN_REQUESTS: 60
+      BECH32_HRP: zil
+    ports:
+      - "5200:80"
+    # Fast shutdown - Don't gracefully close open connections.
+    stop_signal: SIGKILL
+    networks:
+      testnet:
+        ipv4_address: 198.51.100.10
+
+networks:
+  testnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 198.51.100.0/24
+          gateway: 198.51.100.1

--- a/infra/config_networking_test.toml
+++ b/infra/config_networking_test.toml
@@ -1,0 +1,79 @@
+otlp_collector_endpoint = "http://otel-collector:4317"
+bootstrap_address = [
+    "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
+    "/ip4/198.51.100.103/tcp/5643",
+]
+p2p_port = 5643
+
+[[nodes]]
+# These (public key, peerId, stake, rewardAddress) tuples correspond to the private keys of all four nodes in `docker-compose.yaml`.
+consensus.genesis_deposits = [
+    [
+        "b27aebb3b54effd7af87c4a064a711554ee0f3f5abf56ca910b46422f2b21603bc383d42eb3b927c4c3b0b8381ca30a3",
+        "12D3KooWESMZ2ttSxDwjfnNe23sHCqsJf6sNEKwgHkdgtCHDsbWU",
+        "10000000000000000000000000",
+        "7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+    ],
+    [
+        "b37fd66aef29ca78a82d519a284789d59c2bb3880698b461c6c732d094534707d50e345128db372a1e0a4c5d5c42f49c",
+        "12D3KooWJc2nBgNiSi14GcYaGmU8FoQsRkmhfMnaB1mHmPiBPZHd",
+        "10000000000000000000000000",
+        "2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
+    ],
+    [
+        "ab035d6cd3321c3b57d14ea09a4f3860899542d2187b5ec87649b1f40980418a096717a671cf62b73880afac252fc5dc",
+        "12D3KooWLA4xVjiGszqmYJmt8E1NTurVeCujDi17FoSzSDDDKUjT",
+        "10000000000000000000000000",
+        "6813Eb9362372EEF6200f3b1dbC3f819671cBA69",
+    ],
+    [
+        "985e3a4d367cbfc966d48710806612cc00f6bfd06aa759340cfe13c3990d26a7ddde63f64468cdba5b2ff132a4639a7f",
+        "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
+        "10000000000000000000000000",
+        "1efF47bc3a10a45D4B230B5d10E37751FE6AA718",
+    ],
+]
+consensus.genesis_accounts = [
+    # Accounts with private key 0x2, 0x3, 0x4.
+    # Don't use account with priv key = 0x1 since it's also used for voting rewards
+    [
+        "2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
+        "5000000000000000000000",
+    ],
+    [
+        "6813Eb9362372EEF6200f3b1dbC3f819671cBA69",
+        "5000000000000000000000",
+    ],
+    [
+        "1efF47bc3a10a45D4B230B5d10E37751FE6AA718",
+        "5000000000000000000000",
+    ],
+    [
+        "29e562f73488c8a2bB9Dbc5700b361D54b9B0554",
+        "5000000000000000000000",
+    ],
+    [
+        "8D393a22E4476fF8212DE13fE1939De2a236F0A7",
+        "5000000000000000000000",
+    ],
+    [
+        "9cB422D2Fabe9622ed706ad5D9d3fFd2cDd1C001",
+        "5000000000000000000000",
+    ],
+    [
+        "AcE5F1e883d3e02A1b2C78F6909a8C0430C6Fb12",
+        "5000000000000000000000",
+    ],
+    [
+        "1958b2f7b5c476F5e8FeBdEFeba5EC39E2f20288",
+        "5000000000000000000000",
+    ],
+]
+
+# Reward parameters
+consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"
+consensus.blocks_per_hour = 3600
+consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
+# Gas parameters
+consensus.eth_block_gas_limit = 84000000
+consensus.gas_price = "4_761_904_800_000"

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -43,7 +43,7 @@ itertools = "0.13.0"
 jsonrpsee = {version = "0.22.4", features = ["client"]}
 k256 = "0.13.3"
 lazy_static = "1.5.0"
-libp2p = {version = "0.54.0", features = ["identify", "autonat"]}
+libp2p = {version = "0.54.0", features = ["identify"]}
 octocrab = "0.39.0"
 primitive-types = "0.12.2"
 prost = "0.13.1"

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -43,7 +43,7 @@ itertools = "0.13.0"
 jsonrpsee = {version = "0.22.4", features = ["client"]}
 k256 = "0.13.3"
 lazy_static = "1.5.0"
-libp2p = {version = "0.54.0", features = ["identify"]}
+libp2p = {version = "0.54.0", features = ["identify", "autonat"]}
 octocrab = "0.39.0"
 primitive-types = "0.12.2"
 prost = "0.13.1"

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -43,7 +43,7 @@ hyper = "0.14.27"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.22.3", features = ["jsonrpsee-http-client", "server"] }
 k256 = {version = "0.13.3", features = ["serde", "pem"] }
-libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux"] }
+libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux", "autonat"] }
 lru = "0.12"
 once_cell = "1.19.0"
 opentelemetry = { version = "0.24.0", features = ["metrics"] }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -117,10 +117,12 @@ impl P2pNode {
             autonat: autonat::Behaviour::new(
                 peer_id,
                 autonat::Config {
+                    // Config changes to speed up autonat initialization.
                     retry_interval: Duration::from_secs(10),
                     refresh_interval: Duration::from_secs(30),
                     boot_delay: Duration::from_secs(5),
                     throttle_server_period: Duration::ZERO,
+                    // Don't attempt to reach IPs that are known to be at a private.
                     only_global_ips: false,
                     ..Default::default()
                 },

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -117,13 +117,11 @@ impl P2pNode {
             autonat: autonat::Behaviour::new(
                 peer_id,
                 autonat::Config {
-                    // Config changes to speed up autonat initialization.
+                    // Config changes to speed up autonat initialization. Set back to default if too aggressive.
                     retry_interval: Duration::from_secs(10),
                     refresh_interval: Duration::from_secs(30),
                     boot_delay: Duration::from_secs(5),
                     throttle_server_period: Duration::ZERO,
-                    // Don't attempt to reach IPs that are known to be at a private.
-                    only_global_ips: false,
                     ..Default::default()
                 },
             ),
@@ -322,7 +320,7 @@ impl P2pNode {
                             match new {
                                 autonat::NatStatus::Public(_) => (), // Autonat will add this automatically
                                 autonat::NatStatus::Private => {
-                                    let external_addresses: Vec<_> = self.swarm.external_addresses().map(|x|x.clone()).collect();
+                                    let external_addresses: Vec<_> = self.swarm.external_addresses().cloned().collect();
                                     for addr in external_addresses {
                                         self.swarm.remove_external_address(&addr);
                                     }


### PR DESCRIPTION
- Plus docker compose file and config file used for testing
- Using autonat v1 since v2 didn't seem super mature yet

Closes #1101

The docker compose file is used for testing the network without mDNS. I actually just commented out mDNS for testing, we could try to block it in the compose file if we need that capability in future.