### PR TITLE
Add after optional parameter to GetSmartContractState for pagination

### DIFF
--- a/eth-trie.rs/src/nibbles.rs
+++ b/eth-trie.rs/src/nibbles.rs
@@ -1,6 +1,6 @@
 use std::cmp::min;
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord)]
 pub struct Nibbles {
     hex_data: Vec<u8>,
 }

--- a/eth-trie.rs/src/trie.rs
+++ b/eth-trie.rs/src/trie.rs
@@ -1560,10 +1560,10 @@ mod tests {
             });
             root1 = trie.root_hash().unwrap();
 
-            kv2.remove(&b"test".to_vec());
-            kv2.remove(&b"test1".to_vec());
-            kv2.remove(&b"test11".to_vec());
-            kv2.remove(&b"test14".to_vec());
+            kv2.remove(b"test".as_slice());
+            kv2.remove(b"test1".as_slice());
+            kv2.remove(b"test11".as_slice());
+            kv2.remove(b"test14".as_slice());
 
             trie.iter()
                 .for_each(|(k, v)| assert_eq!(kv.remove(&k).unwrap(), v));

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -135,7 +135,7 @@ fn build_errored_response_for_missing_block(
     }
 }
 
-fn expect_end_of_params(seq: &mut ParamsSequence, min: u32, max: u32) -> Result<()> {
+pub fn expect_end_of_params(seq: &mut ParamsSequence, min: u32, max: u32) -> Result<()> {
     // Styled after the geth error message.
     let msg = if min != max {
         format!("too many arguments, want at most {max}")

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -591,7 +591,7 @@ impl StateServer {
 // occur in Scilla values, but we include an assertion to make sure this remains true.
 
 // Separate each index with the ASCII unit separator byte.
-const SEPARATOR: u8 = 0x1F;
+pub const SEPARATOR: u8 = 0x1F;
 
 pub fn storage_key(var_name: &str, indices: &[Vec<u8>]) -> Bytes {
     let len = var_name.len() + indices.len() + indices.iter().map(|v| v.len()).sum::<usize>();


### PR DESCRIPTION
* Add implementation for `EthTrie::{iter_after, iter_after_by_prefix}`

* Efficiently traverse to first key in iterator

* Add after optional parameter to `GetSmartContractState`