### PR TITLE
Fail gracefully if we try to propose a block without any votes

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -818,10 +818,12 @@ impl Consensus {
                 // already at least 2 views behind the head of the chain, but keeping one extra vote in memory doesn't
                 // cost much and does make us more confident that we won't dispose of valid votes.
                 if block.view() < self.finalized_view.saturating_sub(1) {
+                    trace!(block_view = %block.view(), block_hash = %key, "cleaning vote");
                     self.votes.remove(&key);
                 }
             } else {
                 warn!("Missing block for vote (this shouldn't happen), removing from memory");
+                trace!(block_hash = %key, "cleaning vote");
                 self.votes.remove(&key);
             }
         }
@@ -998,17 +1000,12 @@ impl Consensus {
 
         let committee: Vec<_> = state.get_stakers_at_block_raw(&block)?;
 
-        let committee_size = committee.len();
-
-        let (signatures, cosigned, cosigned_weight, supermajority_reached) =
-            votes.get(&block_hash).cloned().unwrap_or_else(|| {
-                (
-                    Vec::new(),
-                    bitvec![u8, bitvec::order::Msb0; 0; committee_size],
-                    0,
-                    false,
-                )
-            });
+        let Some((signatures, cosigned, cosigned_weight, supermajority_reached)) =
+            votes.get(&block_hash).cloned()
+        else {
+            warn!(%block_hash, %block_view, "tried to create a proposal without any votes, this shouldn't happen");
+            return Ok(None);
+        };
 
         let qc = self.qc_from_bits(block_hash, &signatures, cosigned.clone(), block_view);
         let parent_hash = qc.block_hash;


### PR DESCRIPTION
I haven't worked out why this occurs in proto-testnet yet, but this means the whole node doesn't panic and we instead just log the problem.

I've also added logs when we cleanup votes in case that is the cause of the problem.