### PR TITLE
Remove redundant `parent_hash` from `BlockHeader`

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -378,7 +378,6 @@ pub async fn convert_persistence(
                 block.block_num,
                 block.block_num,
                 qc,
-                parent_hash,
                 state.root_hash()?,
                 Hash(transactions_trie.root_hash()?.into()),
                 Hash(receipts_trie.root_hash()?.into()),
@@ -394,7 +393,7 @@ pub async fn convert_persistence(
             }
 
             zq2_db.set_canonical_block_number(block_number, block.hash())?;
-            zq2_db.set_high_qc(block.qc.clone())?;
+            zq2_db.set_high_qc(block.header.qc)?;
             blocks.push(block.clone());
             zq2_db.set_latest_finalized_view(block_number)?;
 

--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -100,7 +100,6 @@ pub fn process_blocks(c: &mut Criterion) {
             view,
             view,
             qc,
-            parent_hash,
             state.root_hash().unwrap(),
             empty_root_hash,
             empty_root_hash,

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -98,7 +98,7 @@ impl Block {
                 .map(|h| HashOrTransaction::Hash((*h).into()))
                 .collect(),
             uncles: vec![],
-            quorum_certificate: QuorumCertificate::from_qc(&block.qc),
+            quorum_certificate: QuorumCertificate::from_qc(&block.header.qc),
             aggregate_quorum_certificate: AggregateQc::from_agg(&block.agg),
         }
     }
@@ -156,7 +156,7 @@ impl Header {
             number: header.number,
             view: header.view,
             hash: header.hash.into(),
-            parent_hash: header.parent_hash.into(),
+            parent_hash: header.qc.block_hash.into(),
             mix_hash: B256::ZERO,
             nonce: [0; 8],
             sha_3_uncles: B256::ZERO,

--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -103,7 +103,7 @@ impl BlockStore {
     pub fn buffer_proposal(&mut self, from: PeerId, proposal: Proposal) -> Result<()> {
         let view = proposal.view();
 
-        self.buffered.push(proposal.header.parent_hash, proposal);
+        self.buffered.push(proposal.header.qc.block_hash, proposal);
 
         // If this is the highest block we've seen, remember its view.
         if view > self.highest_known_view {

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -419,7 +419,7 @@ impl Consensus {
 
         let new_view = NewView::new(
             self.secret_key,
-            self.high_qc.clone(),
+            self.high_qc,
             self.view.get_view(),
             self.secret_key.node_public_key(),
         );
@@ -528,7 +528,7 @@ impl Consensus {
             }
         }
 
-        self.update_high_qc_and_view(block.agg.is_some(), block.qc.clone())?;
+        self.update_high_qc_and_view(block.agg.is_some(), block.header.qc)?;
 
         let proposal_view = block.view();
         let parent = self
@@ -1118,7 +1118,6 @@ impl Consensus {
             self.view.get_view(),
             parent.header.number + 1,
             qc,
-            parent_hash,
             state.root_hash()?,
             Hash(transactions_trie.root_hash()?.into()),
             Hash(receipts_trie.root_hash()?.into()),
@@ -1273,7 +1272,7 @@ impl Consensus {
         new_view.verify(*public_key)?;
 
         // check if the sender's qc is higher than our high_qc or even higher than our view
-        self.update_high_qc_and_view(false, new_view.qc.clone())?;
+        self.update_high_qc_and_view(false, new_view.qc)?;
 
         let NewViewVote {
             mut signatures,
@@ -1350,9 +1349,8 @@ impl Consensus {
                         self.secret_key,
                         self.view.get_view(),
                         parent.header.number + 1,
-                        high_qc.clone(),
+                        high_qc,
                         agg,
-                        parent_hash,
                         self.state.root_hash()?,
                         empty_root_hash,
                         empty_root_hash,
@@ -1459,7 +1457,7 @@ impl Consensus {
 
         if self.high_qc.block_hash == Hash::ZERO {
             trace!("received high qc, self high_qc is currently uninitialized, setting to the new one.");
-            self.db.set_high_qc(new_high_qc.clone())?;
+            self.db.set_high_qc(new_high_qc)?;
             self.high_qc = new_high_qc;
         } else {
             let current_high_qc_view = self
@@ -1476,7 +1474,7 @@ impl Consensus {
                     new_high_qc_block_view + 1,
                     current_high_qc_view,
                 );
-                self.db.set_high_qc(new_high_qc.clone())?;
+                self.db.set_high_qc(new_high_qc)?;
                 self.high_qc = new_high_qc;
                 if new_high_qc_block_view >= self.view.get_view() {
                     self.view.set_view(new_high_qc_block_view + 1);
@@ -1531,8 +1529,8 @@ impl Consensus {
     }
 
     fn check_safe_block(&mut self, proposal: &Block, during_sync: bool) -> Result<bool> {
-        let Some(qc_block) = self.get_block(&proposal.qc.block_hash)? else {
-            trace!("could not get qc for block: {}", proposal.qc.block_hash);
+        let Some(qc_block) = self.get_block(&proposal.parent_hash())? else {
+            trace!("could not get qc for block: {}", proposal.parent_hash());
             return Ok(false);
         };
         // We don't vote on blocks older than our view
@@ -1592,9 +1590,9 @@ impl Consensus {
         // HotStuff). Then a replica can safely commit the parent of the
         // block pointed by the highQC.
 
-        let Some(qc_block) = self.get_block(&proposal.qc.block_hash)? else {
+        let Some(qc_block) = self.get_block(&proposal.parent_hash())? else {
             warn!("missing qc block when checking whether to finalize!");
-            return Err(MissingBlockError::from(proposal.qc.block_hash).into());
+            return Err(MissingBlockError::from(proposal.parent_hash()).into());
         };
 
         // If we don't have the parent (e.g. genesis, or pruned node), we can't finalize, so just exit
@@ -1742,7 +1740,7 @@ impl Consensus {
         }
 
         // Check if the co-signers of the block's QC represent the supermajority.
-        self.check_quorum_in_bits(&block.qc.cosigned, &committee)
+        self.check_quorum_in_bits(&block.header.qc.cosigned, &committee)
             .map_err(|e| (e, false))?;
 
         let committee: Vec<_> = committee
@@ -1752,7 +1750,7 @@ impl Consensus {
 
         // Verify the block's QC signature - note the parent should be the committee the QC
         // was signed over.
-        self.verify_qc_signature(&block.qc, committee.clone())
+        self.verify_qc_signature(&block.header.qc, committee.clone())
             .map_err(|e| (e, false))?;
         if let Some(agg) = &block.agg {
             // Check if the signers of the block's aggregate QC represent the supermajority
@@ -1906,18 +1904,18 @@ impl Consensus {
         )
     }
 
-    fn get_high_qc_from_block<'a>(&self, block: &'a Block) -> Result<&'a QuorumCertificate> {
+    fn get_high_qc_from_block(&self, block: &Block) -> Result<QuorumCertificate> {
         let Some(agg) = &block.agg else {
-            return Ok(&block.qc);
+            return Ok(block.header.qc);
         };
 
         let high_qc = self.get_highest_from_agg(agg)?;
 
-        if &block.qc != high_qc {
+        if block.header.qc != high_qc {
             return Err(anyhow!("qc mismatch"));
         }
 
-        Ok(&block.qc)
+        Ok(block.header.qc)
     }
 
     pub fn get_block(&self, key: &Hash) -> Result<Option<Block>> {
@@ -1956,7 +1954,7 @@ impl Consensus {
             .ok_or_else(|| anyhow!("No block at height {number}"))
     }
 
-    fn get_highest_from_agg<'a>(&self, agg: &'a AggregateQc) -> Result<&'a QuorumCertificate> {
+    fn get_highest_from_agg(&self, agg: &AggregateQc) -> Result<QuorumCertificate> {
         agg.qcs
             .iter()
             .map(|qc| (qc, self.get_block(&qc.block_hash)))
@@ -1973,7 +1971,7 @@ impl Consensus {
                 }
             })?
             .ok_or_else(|| anyhow!("no qcs in agg"))
-            .map(|(qc, _)| qc)
+            .map(|(qc, _)| *qc)
     }
 
     fn verify_qc_signature(
@@ -2298,7 +2296,7 @@ impl Consensus {
             }
         }
 
-        self.apply_rewards_raw(committee, &parent, block.view(), &block.qc.cosigned)?;
+        self.apply_rewards_raw(committee, &parent, block.view(), &block.header.qc.cosigned)?;
 
         let mut block_receipts = Vec::new();
         let mut cumulative_gas_used = EvmGas(0);

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -720,8 +720,8 @@ impl Node {
         }
 
         let parent = self
-            .get_block(header.parent_hash)?
-            .ok_or_else(|| anyhow!("missing parent: {}", header.parent_hash))?;
+            .get_block(header.qc.block_hash)?
+            .ok_or_else(|| anyhow!("missing parent: {}", header.qc.block_hash))?;
         let proposer = self
             .consensus
             .leader_at_block(&parent, header.view)


### PR DESCRIPTION
Instead we move the block's `QuorumCerticiate` into the `BlockHeader`. The `block_hash` in the `QuorumCertificate` is always the block's parent hash.