### PR TITLE
Avoid waiting too long before attempting to propose an empty block

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -956,8 +956,14 @@ impl Consensus {
                         }
 
                         self.create_next_block_on_timeout = true;
-                        self.reset_timeout
-                            .send(self.config.consensus.empty_block_timeout)?;
+                        // Reset the timeout and wake up again once it has been at least `empty_block_timeout` since
+                        // the last view change. At this point we should be ready to produce a new empty block.
+                        self.reset_timeout.send(
+                            self.config
+                                .consensus
+                                .empty_block_timeout
+                                .saturating_sub(Duration::from_millis(time_since_last_view_change)),
+                        )?;
                         trace!("Empty transaction pool, will create new block on timeout");
                     }
                 }


### PR DESCRIPTION
Previously, we would always wait a full 1s after reaching a supermajority of votes, even if reaching that supermajority had taken a significant amount of time. This meant that block times were greater than the `empty_block_timeout`.