### PR TITLE
Accept bech32 address in some APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1610,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5286a0843c21f8367f7be734f89df9b822e0321d8bcce8d6e735aadff7d74979"
 dependencies = [
  "base64 0.21.7",
- "bech32",
+ "bech32 0.9.1",
  "bs58",
  "digest 0.10.7",
  "generic-array 0.14.7",
@@ -9452,6 +9458,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "bech32 0.11.0",
  "bincode",
  "bitvec",
  "blsful",
@@ -9529,7 +9536,7 @@ checksum = "235cdca5900eef94aef07daab70f4706313a6dbdaa6862b116bf3cc8f4675b17"
 dependencies = [
  "anyhow",
  "async-trait",
- "bech32",
+ "bech32 0.9.1",
  "convert_case 0.6.0",
  "eth-keystore",
  "hex",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -75,6 +75,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json"] }
 cbor4ii = "0.3.2"
 scilla-parser = "1.0.0"
 blsful = "2.5.7"
+bech32 = "0.11.0"
 
 [dev-dependencies]
 alloy = { version = "0.2.1", default-features = false, features = ["rand"] }


### PR DESCRIPTION
- Fixes https://github.com/Zilliqa/zq2/issues/1241

- Accept bech32 address in APIs:
  - `GetBalance`
  - `GetSmartContractState`
  - `GetSmartContractSubState`
  - `GetSmartContractInit`
  - `GetSmartContractCode`
  - `GetSmartContracts`