### PR TITLE
Allow networks with no genesis accounts

### DIFF
--- a/z2/src/docgen.rs
+++ b/z2/src/docgen.rs
@@ -285,22 +285,11 @@ pub struct ApiCallStatus {
 
 pub fn get_implemented_jsonrpc_methods() -> Result<HashMap<ApiMethod, PageStatus>> {
     let mut methods = HashMap::new();
-    // Construct an empty node so we can check for the existence of RPC methods without constructing a full node.
-    let genesis_accounts: Vec<(Address, Amount)> = vec![
-        (
-            address!("7E5F4552091A69125d5DfCb7b8C2659029395Bdf"),
-            5000000000000000000000u128.into(),
-        ),
-        // privkey db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3
-        (
-            address!("cb57ec3f064a16cadb36c7c712f4c9fa62b77415"),
-            5000000000000000000000u128.into(),
-        ),
-    ];
 
+    // Construct an empty node so we can check for the existence of RPC methods without constructing a full node.
     let config = NodeConfig {
         consensus: ConsensusConfig {
-            genesis_accounts,
+            genesis_accounts: vec![],
             rewards_per_hour: 51_000_000_000_000_000_000_000u128.into(),
             blocks_per_hour: 3600,
             is_main: true,
@@ -308,7 +297,7 @@ pub fn get_implemented_jsonrpc_methods() -> Result<HashMap<ApiMethod, PageStatus
             minimum_stake: 10_000_000_000_000_000_000_000_000u128.into(),
             gas_price: 4_761_904_800_000u128.into(),
             eth_block_gas_limit: EvmGas(84000000),
-            genesis_deposits: Vec::new(),
+            genesis_deposits: vec![],
             consensus_timeout: consensus_timeout_default(),
             local_address: local_address_default(),
             scilla_lib_dir: scilla_lib_dir_default(),

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -95,9 +95,9 @@ impl State {
             Some(contract_addr::INTERSHARD_BRIDGE),
         )?;
 
-        if config.genesis_accounts.is_empty() {
-            panic!("No genesis accounts provided");
-        }
+        // if config.genesis_accounts.is_empty() {
+        //     panic!("No genesis accounts provided");
+        // }
 
         for (address, balance) in config.genesis_accounts {
             state.mutate_account(address, |a| a.balance = *balance)?;


### PR DESCRIPTION
- Remove check preventing networks with no genesis accounts

- Update `docgen.rs` to remove no longer needed genesis accounts
