### PR TITLE
Correctly calculate code_hash for EVM contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Unreleased changes.
 
+- [#1372](https://github.com/Zilliqa/zq2/pull/1372): Fix `code_hash` calculation and state delta application for empty EVM contracts.
+
 ## [0.1.1] - 2024-08-14
 
 - [#1290](https://github.com/Zilliqa/zq2/pull/1281): Fix over-eager clean up of votes which could cause votes for pending blocks to get lost.

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -292,13 +292,12 @@ impl DatabaseRef for &State {
         }
 
         let account = self.get_account(address)?;
+        let code = Bytecode::new_raw(account.code.evm_code().unwrap_or_default().into());
         let account_info = AccountInfo {
             balance: U256::from(account.balance),
             nonce: account.nonce,
-            code_hash: KECCAK_EMPTY,
-            code: Some(Bytecode::new_raw(
-                account.code.evm_code().unwrap_or_default().into(),
-            )),
+            code_hash: code.hash_slow(),
+            code: Some(code),
         };
 
         Ok(Some(account_info))
@@ -630,18 +629,25 @@ impl State {
                 )?;
             }
 
+            // `account.info.code` might be `None`, even though we always return `Some` for the account code in our
+            // [DatabaseRef] implementation. However, this is only the case for empty code, so we handle this case
+            // separately.
+            let code = if account.info.code_hash == KECCAK_EMPTY {
+                vec![]
+            } else {
+                account
+                    .info
+                    .code
+                    .as_ref()
+                    .expect("code_by_hash is not used")
+                    .original_bytes()
+                    .to_vec()
+            };
+
             let account = Account {
                 nonce: account.info.nonce,
                 balance: account.info.balance.try_into()?,
-                code: Code::Evm(
-                    account
-                        .info
-                        .code
-                        .as_ref()
-                        .expect("code_by_hash is not used")
-                        .original_bytes()
-                        .to_vec(),
-                ),
+                code: Code::Evm(code),
                 storage_root: storage.root_hash()?,
             };
             trace!(?address, ?account, "update account");


### PR DESCRIPTION
`revm` relies on querying the `code_hash` even if the `code` isn't `None`, meaning we need to set it correctly.

Also, we are now more lenient when applying deltas in `apply_delta_evm` by accepting `code = None` if `code_hash = KECCAK_EMPTY`.