### PR TITLE
Deduplicate unserviceable requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Unreleased changes.
 
+- [#1373](https://github.com/Zilliqa/zq2/pull/1373): Fix duplicated requests for blocks when a node connects to the network.
+
 ## [0.1.1] - 2024-08-14
 
 - [#1290](https://github.com/Zilliqa/zq2/pull/1281): Fix over-eager clean up of votes which could cause votes for pending blocks to get lost.

--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -1,4 +1,11 @@
-use std::{cell::RefCell, cmp, collections::HashMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{
+    cell::RefCell,
+    cmp,
+    collections::{BTreeSet, HashMap},
+    num::NonZeroUsize,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{anyhow, Result};
 use libp2p::PeerId;
@@ -53,7 +60,7 @@ pub struct BlockStore {
     /// newly created blocks that arrive while we are syncing.
     buffered: LruCache<Hash, Proposal>,
     /// Requests we would like to send, but haven't been able to (e.g. because we have no peers).
-    unserviceable_requests: Vec<(u64, u64)>,
+    unserviceable_requests: BTreeSet<(u64, u64)>,
     message_sender: MessageSender,
 }
 
@@ -94,7 +101,7 @@ impl BlockStore {
             buffered: LruCache::new(
                 NonZeroUsize::new(config.max_blocks_in_flight as usize + 100).unwrap(),
             ),
-            unserviceable_requests: vec![],
+            unserviceable_requests: BTreeSet::new(),
             message_sender,
         })
     }
@@ -153,11 +160,8 @@ impl BlockStore {
             self.requested_view = current_view;
         }
 
-        // Attempt to send pending requests if we can. Note that unserviceable requests are retried in LIFO order. This
-        // effectively means that requests for higher views are sent first. Also, we break early if a peer can't
-        // service the final request, despite the possibility that it could service a request for lower views. If this
-        // appears to be a problem in practice, we could use a `VecDeque` and retry requests in FIFO order.
-        while let Some((from, to)) = self.unserviceable_requests.pop() {
+        // Attempt to send pending requests if we can.
+        while let Some((from, to)) = self.unserviceable_requests.pop_first() {
             if !self.request_blocks(from, to)? {
                 // Stop trying to send requests if no peers are available.
                 break;
@@ -196,7 +200,7 @@ impl BlockStore {
     fn request_blocks(&mut self, from: u64, to: u64) -> Result<bool> {
         let Some(peer) = self.best_peer(from) else {
             warn!(from, "no peers to download missing blocks from");
-            self.unserviceable_requests.push((from, to));
+            self.unserviceable_requests.insert((from, to));
             return Ok(false);
         };
         trace!(%peer, from, to, "requesting blocks");


### PR DESCRIPTION
`BlockStore` now stores unserviceable requests in a set. Otherwise when we don't have any peers for an extended period of time, the list fills up with duplicate requests for the same range of blocks.

This also means we now service the requests in a more sensible order (lowest view to highest view).