### PR TITLE
Reorder `NodeRole`s to make `Validator` adjacent to `Bootstrap`

### DIFF
--- a/z2/src/deployer.rs
+++ b/z2/src/deployer.rs
@@ -98,12 +98,12 @@ pub fn docker_image(component: &str, version: &str) -> Result<String> {
 pub enum NodeRole {
     /// Virtual machine bootstrap
     Bootstrap,
+    /// Virtual machine validator
+    Validator,
     /// Virtual machine api
     Api,
     /// Virtual machine apps
     Apps,
-    /// Virtual machine validator
-    Validator,
     /// Virtual machine checkpoint
     Checkpoint,
     /// Virtual machine sentry


### PR DESCRIPTION
`Bootstrap` and `Validator` are the roles responsible for proposing and voting on blocks. By performing these upgrades close to each other, we ensure minimum offset between the times they start up. In cases where the network has crashed, this minimises the time for the nodes to sync up their views again and restart the production of blocks.