### PR TITLE
Add `GetTxBlockRate` API to return the current transaction block rate.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Unreleased changes.
 
 - [#1373](https://github.com/Zilliqa/zq2/pull/1373): Fix duplicated requests for blocks when a node connects to the network.
 
+- Add `GetTxBlockRate` API to return the current transaction block rate.
+
 ## [0.1.1] - 2024-08-14
 
 - [#1290](https://github.com/Zilliqa/zq2/pull/1281): Fix over-eager clean up of votes which could cause votes for pending blocks to get lost.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Unreleased changes.
 
 - [#1373](https://github.com/Zilliqa/zq2/pull/1373): Fix duplicated requests for blocks when a node connects to the network.
 
-- Add `GetTxBlockRate` API to return the current transaction block rate.
+- [#1379](https://github.com/Zilliqa/zq2/pull/1379): Add `GetTxBlockRate` API to return the current transaction block rate.
 
 ## [0.1.1] - 2024-08-14
 

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -538,3 +538,8 @@ pub struct DSBlockListing {
     #[serde(rename = "Hash")]
     pub hash: String,
 }
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TXBlockRateResult {
+    pub rate: f64,
+}

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -632,7 +632,7 @@ pub fn calculate_tx_block_rate(node: &Arc<Mutex<Node>>) -> Result<f64> {
     let node = node.lock().unwrap();
     let max_measurement_blocks = 5;
     let height = node.get_chain_tip();
-    if height <= 0 {
+    if height == 0 {
         return Ok(0.0);
     }
     let measurement_blocks = height.min(max_measurement_blocks);

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -20,7 +20,7 @@ use super::{
     types::zil::{
         self, BlockchainInfo, DSBlock, DSBlockHeaderVerbose, DSBlockListing, DSBlockListingResult,
         DSBlockRateResult, DSBlockVerbose, GetCurrentDSCommResult, SWInfo, ShardingStructure,
-        SmartContract,
+        SmartContract, TXBlockRateResult,
     },
 };
 use crate::{
@@ -31,6 +31,7 @@ use crate::{
     schnorr,
     scilla::split_storage_key,
     state::Code,
+    time::SystemTime,
     transaction::{ScillaGas, SignedTransaction, TxZilliqa, ZilAmount, EVM_GAS_PER_SCILLA_GAS},
 };
 
@@ -66,6 +67,7 @@ pub fn rpc_module(node: Arc<Mutex<Node>>) -> RpcModule<Arc<Mutex<Node>>> {
             ("GetCurrentDSEpoch", get_current_ds_epoch),
             ("DSBlockListing", ds_block_listing),
             ("GetDSBlockRate", get_ds_block_rate),
+            ("GetTxBlockRate", get_tx_block_rate),
         ],
     )
 }
@@ -626,9 +628,36 @@ pub fn ds_block_listing(params: Params, node: &Arc<Mutex<Node>>) -> Result<DSBlo
     })
 }
 
-pub fn get_ds_block_rate(_params: Params, _node: &Arc<Mutex<Node>>) -> Result<DSBlockRateResult> {
-    // Dummy implementation
+pub fn calculate_tx_block_rate(node: &Arc<Mutex<Node>>) -> Result<f64> {
+    let node = node.lock().unwrap();
+    let max_measurement_blocks = 5;
+    let height = node.get_chain_tip();
+    if height <= 0 {
+        return Ok(0.0);
+    }
+    let measurement_blocks = height.min(max_measurement_blocks);
+    let start_measure_block = node
+        .consensus
+        .get_block_by_number(height - measurement_blocks + 1)?
+        .ok_or(anyhow!("Unable to get block"))?;
+    let start_measure_time = start_measure_block.header.timestamp;
+    let end_measure_time = SystemTime::now();
+    let elapsed_time = end_measure_time.duration_since(start_measure_time)?;
+    let tx_block_rate = measurement_blocks as f64 / elapsed_time.as_secs_f64();
+    Ok(tx_block_rate)
+}
+
+pub fn get_ds_block_rate(_params: Params, node: &Arc<Mutex<Node>>) -> Result<DSBlockRateResult> {
+    let tx_block_rate = calculate_tx_block_rate(node)?;
+    let ds_block_rate = tx_block_rate / TX_BLOCKS_PER_DS_BLOCK as f64;
     Ok(DSBlockRateResult {
-        rate: 0.00014142137245459714,
+        rate: ds_block_rate,
+    })
+}
+
+fn get_tx_block_rate(_params: Params, node: &Arc<Mutex<Node>>) -> Result<TXBlockRateResult> {
+    let tx_block_rate = calculate_tx_block_rate(node)?;
+    Ok(TXBlockRateResult {
+        rate: tx_block_rate,
     })
 }

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -629,5 +629,22 @@ async fn get_ds_block_rate(mut network: Network) {
         .await
         .expect("Failed to call GetDSBlockRate API");
 
-    zilliqa::api::types::zil::DSBlockRateResult::deserialize(&response).unwrap();
+    let returned = zilliqa::api::types::zil::DSBlockRateResult::deserialize(&response).unwrap();
+
+    assert!(returned.rate >= 0.0, "Block rate should be non-negative");
+}
+
+#[zilliqa_macros::test]
+async fn get_tx_block_rate(mut network: Network) {
+    let wallet = network.genesis_wallet().await;
+
+    let response: Value = wallet
+        .provider()
+        .request("GetTxBlockRate", [""])
+        .await
+        .expect("Failed to call GetTxBlockRate API");
+
+    let returned = zilliqa::api::types::zil::TXBlockRateResult::deserialize(&response).unwrap();
+
+    assert!(returned.rate >= 0.0, "Block rate should be non-negative");
 }


### PR DESCRIPTION
Adds GetTxBlockRate, and alters GetDSBlockRate to be based off the TX rate.

I initially implemented this by querying the DB to count the number `n` of blocks in the last hour, and then returning n/3600, but I've now altered it to instead work out the time `t` since the 5th from last block, and then calculating 5/t. Both methods have pros and cons in terms of complexity, accuracy, speed etc, but this method of using a fixed number of blocks seemed better overall. The main pros were that it only requires accessing one block, doesn't require much in the way of special cases for young networks, and doesn't require additional DB code. 

I've also added a simple test to check we're getting roughly the right thing back