### PR TITLE
Early-Proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 Unreleased changes.
-
+- [#1321](https://github.com/Zilliqa/zq2/issues/1321): Early block assembly before a supermajority vote is received.
 - [#1350](https://github.com/Zilliqa/zq2/pull/1350): Support `CHAINID`, `BLOCKNUMBER`, and `TIMESTAMP` in Scilla contracts.
 - [#1358](https://github.com/Zilliqa/zq2/pull/1358): Support `_codehash` in Scilla contracts.
 - [#1390](https://github.com/Zilliqa/zq2/pull/1390): Implement `GetNumPeers` API endpoint to get the current number of peers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased]
 
 Unreleased changes.
-- [#1321](https://github.com/Zilliqa/zq2/issues/1321): Early block assembly before a supermajority vote is received.
+- [#1321](https://github.com/Zilliqa/zq2/issues/1321): Begin assembling a block proposal before a supermajority of votes is received.
 - [#1350](https://github.com/Zilliqa/zq2/pull/1350): Support `CHAINID`, `BLOCKNUMBER`, and `TIMESTAMP` in Scilla contracts.
 - [#1358](https://github.com/Zilliqa/zq2/pull/1358): Support `_codehash` in Scilla contracts.
 - [#1390](https://github.com/Zilliqa/zq2/pull/1390): Implement `GetNumPeers` API endpoint to get the current number of peers.

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -462,7 +462,7 @@ impl Consensus {
             .minimum_time_left_for_empty_block
             .as_millis() as u64;
 
-        info!(
+        trace!(
             "({}:{}:{})",
             time_since_last_view_change,
             exponential_backoff_timeout,
@@ -1422,7 +1422,7 @@ impl Consensus {
     pub fn assemble_early_block(&mut self) -> Result<()> {
         // If no early_proposal, then assemble it
         if self.early_proposal.is_none() {
-            info!("assembling early proposal {}", self.view.get_view());
+            trace!("assembling early proposal {}", self.view.get_view());
             let mut state = self.state.clone();
             let mut tx_pool = self.transaction_pool.clone();
             self.early_proposal =

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1177,7 +1177,6 @@ impl Consensus {
             let result = Self::apply_transaction_at(
                 state,
                 self.db.clone(),
-                &self.config,
                 tx.clone(),
                 executed_block_header,
                 inspector::noop(),

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -463,10 +463,9 @@ impl Consensus {
             .as_millis() as u64;
 
         trace!(
-            "({}:{}:{})",
             time_since_last_view_change,
             exponential_backoff_timeout,
-            minimum_time_left_for_empty_block
+            minimum_time_left_for_empty_block,
         );
 
         (

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1029,18 +1029,12 @@ impl Consensus {
         // Should have supermajority by now.
         // Retrieve the committee - for rewards
         let committee = state.get_stakers_at_block_raw(&parent_block)?;
-        let (signatures, cosigned, _, supermajority_reached) = votes
+        let (signatures, cosigned, _, _) = votes
             .get(&parent_block_hash)
             .context("tried to finalise a proposal without any votes")?;
 
         // Compute the majority QC
         let qc = self.qc_from_bits(parent_block_hash, signatures, *cosigned, parent_block_view);
-
-        // allow timeout codepath, without supermajority
-        // ensure!(
-        //     supermajority_reached,
-        //     "illegal to finalise early proposal without supermajority"
-        // );
 
         // Retrieve the previous leader - for rewards.
         let proposer = self
@@ -1239,6 +1233,7 @@ impl Consensus {
         Ok(Some((proposal, broadcasted_transactions)))
     }
 
+    #[allow(dead_code)]
     fn propose_new_block_at(
         &self,
         state: &mut State,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1168,6 +1168,8 @@ impl Consensus {
             if time_since_last_view_change + minimum_time_left_for_empty_block
                 >= exponential_backoff_timeout
             {
+                // don't have time, reinsert txn.
+                transaction_pool.insert_ready_transaction(tx);
                 break;
             }
 

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -310,6 +310,15 @@ impl QuorumCertificate {
         }
     }
 
+    pub fn new_with_identity(block_hash: Hash, view: u64) -> Self {
+        QuorumCertificate {
+            signature: NodeSignature::identity(),
+            cosigned: bitarr![u8, Msb0; 0; MAX_COMMITTEE_SIZE],
+            block_hash,
+            view,
+        }
+    }
+
     pub fn new(
         signatures: &[NodeSignature],
         cosigned: BitArray,


### PR DESCRIPTION
This change introduces early Proposal block assembly by separating the step into two (2) phases: a) block assembly; and b) rewards application.

The feature is triggered whenever a Vote is received by the Leader. This allows the Leader several opportunities to (a) assemble the Proposal, before super-majority is reached. The early Block will be assembled with any ready transactions from the pool. When super-majority is reached (b) the rewards are applied and the final block is produced with the majority QC.