### PR TITLE
feat: DEVOPS-1521 implement z2 deployer deposit command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1539,6 +1539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d19864d6b68464c59f7162c9914a0b569ddc2926b4a2d71afe62a9738eff53"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2224,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.74",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -3515,6 +3548,12 @@ checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
 dependencies = [
  "libm",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -9321,8 +9360,10 @@ dependencies = [
  "bitvec",
  "blsful",
  "clap",
+ "clap-verbosity-flag",
  "colored",
  "crypto-bigint",
+ "env_logger",
  "eth_trie",
  "ethabi",
  "ethereum",
@@ -9337,6 +9378,7 @@ dependencies = [
  "k256",
  "lazy_static",
  "libp2p",
+ "log",
  "octocrab",
  "primitive-types",
  "prost 0.13.1",

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -28,8 +28,10 @@ base64 = "0.22.0"
 bitvec = "1.0.1"
 blsful = "2.5.7"
 clap = {version = "4.5.15", features = ["derive"]}
+clap-verbosity-flag = "2.2.1"
 colored = "2.1.0"
 crypto-bigint = "=0.5.5"
+env_logger = "0.11.5"
 eth_trie = {version = "0.1.0", path = "../eth-trie.rs"}
 ethabi = "18.0.0"
 ethereum = "0.15.0"
@@ -44,6 +46,7 @@ jsonrpsee = {version = "0.22.4", features = ["client"]}
 k256 = "0.13.3"
 lazy_static = "1.5.0"
 libp2p = {version = "0.54.0", features = ["identify"]}
+log = "0.4.22"
 octocrab = "0.39.0"
 primitive-types = "0.12.2"
 prost = "0.13.1"

--- a/z2/docs/README.md
+++ b/z2/docs/README.md
@@ -34,6 +34,6 @@ To use it:
 ## What to run
 
 - to join as `zq2` validator: [`z2 join`](./join.md)
-- upgrade a `zq2` network: [`z2 deployer`](./deployer.md)
+- install / upgrade a `zq2` network: [`z2 deployer`](./deployer.md)
 - convert `zq1` to `zq2` persistence: [`z2 converter` ](./converter.md)
 - promote a node as validator by $ZILs deposit: [`z2 deposit` ](./deposit.md)

--- a/z2/docs/deployer.md
+++ b/z2/docs/deployer.md
@@ -4,18 +4,26 @@
 
 ```bash
 z2 deployer --help
-Deploy Zilliqa 2
+```
 
-Usage: z2 deployer <COMMAND>
+```bash
+Group of subcommands to deploy and configure a Zilliqa 2 network
+
+Usage: z2 deployer [OPTIONS] <COMMAND>
 
 Commands:
-  new      Generate the deployer config file
-  upgrade  Perfom the network upgrade
-  help     Print this message or the help of the given subcommand(s)
+  new                   Generate the deployer config file
+  install               Install the network defined in the deployer config file
+  upgrade               Update the network defined in the deployer config file
+  get-deposit-commands  Generate in output the commands to deposit stake amount to all the validators
+  deposit               Deposit the stake amounts to all the validators
+  help                  Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
-  ```
+  -v, --verbose...  Increase logging verbosity
+  -q, --quiet...    Decrease logging verbosity
+  -h, --help        Print help
+```
 
 ## To use it:
 
@@ -37,6 +45,9 @@ Options:
       --network-name <NETWORK_NAME>
           ZQ2 network name
 
+      --eth-chain-id <ETH_CHAIN_ID>
+          ZQ2 EVM chain ID
+
       --project-id <PROJECT_ID>
           GCP project-id where the network is running
 
@@ -45,11 +56,17 @@ Options:
 
           Possible values:
           - bootstrap:  Virtual machine bootstrap
+          - validator:  Virtual machine validator
           - api:        Virtual machine api
           - apps:       Virtual machine apps
-          - validator:  Virtual machine validator
           - checkpoint: Virtual machine checkpoint
           - sentry:     Virtual machine sentry
+
+  -v, --verbose...
+          Increase logging verbosity
+
+  -q, --quiet...
+          Decrease logging verbosity
 
   -h, --help
           Print help (see a summary with '-h')
@@ -59,7 +76,7 @@ Options:
 
 #### Scenario 1
 
-Generate the deployer configuration file for upgrade the validator nodes of the `zq2-prototestnet` running on a GCP project named `gcp-tests`.
+Generate the deployer configuration file to upgrade the validator nodes of the `zq2-prototestnet` with chain ID `33333` and running on a GCP project named `gcp-tests`.
 
 ```
 Network name: `zq2-prototestnet`
@@ -68,13 +85,14 @@ Roles: validators
 ```
 
 ```bash
-z2 deployer new --network-name zq2-prototestnet --project-id gcp-tests --roles validator
+z2 deployer new --network-name zq2-prototestnet --eth-chain-id 33333 --project-id gcp-tests --roles validator
 ```
 
 Output: `zq2-prototestnet.yaml`
 
 ```yaml
 name: zq2-prototestnet
+eth_chain_id: 33333
 project_id: gcp-tests
 roles:
 - validator
@@ -84,22 +102,24 @@ versions:
 
 #### Scenario 2
 
-Generate the deployer configuration file for upgrade the app node of the `zq2-prototestnet` running on a GCP project named `gcp-tests`.
+Generate the deployer configuration file for upgrade the app node of the `zq2-prototestnet` with chain ID `33333` and running on a GCP project named `gcp-tests`.
 
-```
-Network name: `zq2-prototestnet`
-Project Id: `gcp-tests`
+```yaml
+Network name: zq2-prototestnet
+Eth Chain ID: 33333
+Project ID: gcp-tests
 Roles: apps
 ```
 
 ```bash
-z2 deployer new --network-name zq2-prototestnet --project-id gcp-tests --roles apps
+z2 deployer new --network-name zq2-prototestnet --eth-chain-id 33333 --project-id gcp-tests --roles apps
 ```
 
 Output: `zq2-prototestnet.yaml`
 
 ```yaml
 name: zq2-prototestnet
+eth_chain_id: 33333
 project_id: gcp-tests
 roles:
 - apps
@@ -110,22 +130,24 @@ versions:
 
 #### Scenario 3
 
-Generate the deployer configuration file for upgrade both validators and app nodes of the `zq2-prototestnet` running on a GCP project named `gcp-tests`.
+Generate the deployer configuration file for upgrade both validators and app nodes of the `zq2-prototestnet` with chain ID `33333` and running on a GCP project named `gcp-tests`.
 
-```
-Network name: `zq2-prototestnet`
-Project Id: `gcp-tests`
-Roles: apps
+```yaml
+Network name: zq2-prototestnet
+Eth Chain ID: 33333
+Project ID: gcp-tests
+Roles: apps,validator
 ```
 
 ```bash
-z2 deployer new --network-name zq2-prototestnet --project-id gcp-tests --roles validator,apps
+z2 deployer new --network-name zq2-prototestnet --eth-chain-id 33333 --project-id gcp-tests --roles apps,validator
 ```
 
 Output: `zq2-prototestnet.yaml`
 
 ```yaml
 name: zq2-prototestnet
+eth_chain_id: 33333
 project_id: gcp-tests
 roles:
 - validator
@@ -149,52 +171,122 @@ z2 deployer upgrade --help
 ```
 
 ```bash
-Perfom the network upgrade
-Usage: z2 deployer upgrade [CONFIG_FILE]
+Update the network defined in the deployer config file
+
+Usage: z2 deployer upgrade [OPTIONS] [CONFIG_FILE]
 
 Arguments:
-  [CONFIG_FILE]  
+  [CONFIG_FILE]  The network deployer config file
 
 Options:
-  -h, --help  Print help
+  -v, --verbose...  Increase logging verbosity
+  -q, --quiet...    Decrease logging verbosity
+  -h, --help        Print help
 ```
 
 ### Usage example
 
 #### Scenario
 
-Network name: `zq2-prototestnet`
-Configuration file: `zq2-prototestnet.yaml`
+Upgrade to a new version the `zq2-prototestnet` nodes
+
+```yaml
+Network name: zq2-prototestnet
+Configuration file: zq2-prototestnet.yaml
+```
 
 ```bash
 z2 deployer upgrade zq2-prototestnet.yaml
 ```
 
-## Retrieve the `z2 deposit` commands for the validator nodes
+## Install the network
+
+```bash
+z2 deployer install --help
+```
+
+```bash
+Install the network defined in the deployer config file
+
+Usage: z2 deployer install [OPTIONS] [CONFIG_FILE]
+
+Arguments:
+  [CONFIG_FILE]  The network deployer config file
+
+Options:
+  -v, --verbose...  Increase logging verbosity
+  -q, --quiet...    Decrease logging verbosity
+  -h, --help        Print help
+```
+
+> Same as `upgrade` subcommand, but skipping the check if the nodes are receiving new blocks
+
+## Retrieve the commands to deposit stake amount to all the validators
 
 ```bash
 z2 deployer get-deposit-commands --help
 ```
 
 ```bash
-Provide the deposit commands for the validator nodes
+Generate in output the commands to deposit stake amount to all the validators
 
-Usage: z2 deployer get-deposit-commands [CONFIG_FILE]
+Usage: z2 deployer get-deposit-commands [OPTIONS] [CONFIG_FILE]
 
 Arguments:
-  [CONFIG_FILE]
+  [CONFIG_FILE]  The network deployer config file
 
 Options:
-  -h, --help  Print help
+  -v, --verbose...  Increase logging verbosity
+  -q, --quiet...    Decrease logging verbosity
+  -h, --help        Print help
 ```
 
 ### Usage example
 
 #### Scenario
 
-Network name: `zq2-prototestnet`
-Configuration file: `zq2-prototestnet.yaml`
+Retrieve the commands to deposit the stake amounts to the `zq2-prototestnet` validators
+
+```yaml
+Network name: zq2-prototestnet
+Configuration file: zq2-prototestnet.yaml
+```
 
 ```bash
 z2 deployer get-deposit-commands zq2-prototestnet.yaml
+```
+
+## Deposit the stake amounts to all the validators
+
+```bash
+z2 deployer deposit --help
+```
+
+```bash
+Deposit the stake amounts to all the validators
+
+Usage: z2 deployer deposit [OPTIONS] [CONFIG_FILE]
+
+Arguments:
+  [CONFIG_FILE]  The network deployer config file
+
+Options:
+  -v, --verbose...  Increase logging verbosity
+  -q, --quiet...    Decrease logging verbosity
+  -h, --help        Print help
+```
+
+### Usage example
+
+#### Scenario
+
+Deposit the stake amounts to the `zq2-prototestnet` validators
+
+```yaml
+Network name: zq2-prototestnet
+Configuration file: zq2-prototestnet.yaml
+```
+
+```bash
+z2 deployer deposit zq2-prototestnet.yaml
 ```

--- a/z2/resources/chain-specs/zq2-perftest.toml
+++ b/z2/resources/chain-specs/zq2-perftest.toml
@@ -1,0 +1,17 @@
+p2p_port = 3333
+bootstrap_address = [ "12D3KooWLQErYMNECpTd22VtTQeGXRf18yeeEM32rVAWZ9qXdLUB", "/ip4/34.143.150.198/tcp/3333" ]
+
+[[nodes]]
+eth_chain_id = 33469
+allowed_timestamp_skew = { secs = 60, nanos = 0 }
+data_dir = "/data"
+consensus.genesis_accounts = [ ["0xd4b13a10f43be60f8df150c0996f6de377cd770c", "21_000_000_000_000_000_000_000_000_000"] ]
+consensus.genesis_deposits = [ ["b6f185408f3f50c4021d4a000295653c8d42c641ab4bde5e04fcb739888e6a976eb3b62b5b4b404c5c3dfe2aa53e7ac8", "12D3KooWLQErYMNECpTd22VtTQeGXRf18yeeEM32rVAWZ9qXdLUB", "100_000_000_000_000_000_000_000_000", "0xd4b13a10f43be60f8df150c0996f6de377cd770c"] ]
+
+# Reward parameters
+consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"
+consensus.blocks_per_hour = 3600
+consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
+# Gas parameters
+consensus.eth_block_gas_limit = 84000000
+consensus.gas_price = "4_761_904_800_000"

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -3,14 +3,19 @@ use std::{collections::HashSet, env, fmt};
 use alloy::primitives::B256;
 use anyhow::{anyhow, Result};
 use clap::{builder::ArgAction, Args, Parser, Subcommand};
-use z2lib::{components::Component, deployer, plumbing, validators};
+use clap_verbosity_flag::{InfoLevel, Verbosity};
+use z2lib::{chain, components::Component, deployer, plumbing, validators};
 use zilliqa::crypto::SecretKey;
 
 #[derive(Parser, Debug)]
 #[clap(about)]
 struct Cli {
+    /// The subcommand to run
     #[clap(subcommand)]
     command: Commands,
+    /// Define the console output verbosity. Default is info. Use -v to enable `debug` and -vv to enable `trace`
+    #[command(flatten)]
+    verbose: Verbosity<InfoLevel>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -64,6 +69,8 @@ enum DeployerCommands {
     Upgrade(DeployerUpgradeArgs),
     /// Provide the deposit commands for the validator nodes
     GetDepositCommands(DeployerUpgradeArgs),
+    /// Deposit the stake amounts to the network validator nodes
+    Deposit(DeployerUpgradeArgs),
 }
 
 #[derive(Args, Debug)]
@@ -265,14 +272,14 @@ struct OnlyStruct {
 struct JoinStruct {
     /// Specify the ZQ2 chain you want join
     #[clap(long = "chain")]
-    chain_name: validators::Chain,
+    chain_name: chain::Chain,
 }
 
 #[derive(Args, Debug)]
 struct DepositStruct {
     /// Specify the ZQ2 deposit chain
     #[clap(long = "chain")]
-    chain_name: validators::Chain,
+    chain_name: chain::Chain,
     /// Specify the Validator Public Key
     #[clap(long)]
     public_key: String,
@@ -331,6 +338,10 @@ async fn main() -> Result<()> {
         }
     };
     let cli = Cli::parse();
+
+    env_logger::Builder::new()
+        .filter_level(cli.verbose.log_level_filter())
+        .init();
 
     match &cli.command {
         Commands::Only(ref arg) => {
@@ -478,13 +489,26 @@ async fn main() -> Result<()> {
                         "Provide a configuration file. [--config-file] mandatory argument"
                     )
                 })?;
-                plumbing::run_deployer_deposit_commands(&config_file)
+                plumbing::run_deployer_get_deposit_commands(&config_file)
                     .await
                     .map_err(|err| {
                         anyhow::anyhow!(
                             "Failed to run deployer get-deposit-commands command: {}",
                             err
                         )
+                    })?;
+                Ok(())
+            }
+            DeployerCommands::Deposit(ref arg) => {
+                let config_file = arg.config_file.clone().ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Provide a configuration file. [--config-file] mandatory argument"
+                    )
+                })?;
+                plumbing::run_deployer_deposit(&config_file)
+                    .await
+                    .map_err(|err| {
+                        anyhow::anyhow!("Failed to run deployer deposit command: {}", err)
                     })?;
                 Ok(())
             }

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -27,7 +27,7 @@ enum Commands {
     /// Test
     Perf(PerfStruct),
     #[clap(subcommand)]
-    /// Deploy Zilliqa 2
+    /// Group of subcommands to deploy and configure a Zilliqa 2 network
     Deployer(DeployerCommands),
     #[clap(subcommand)]
     /// Convert Zilliqa 1 to Zilliqa 2 persistnce
@@ -63,13 +63,13 @@ pub struct DependsUpdateOptions {
 enum DeployerCommands {
     /// Generate the deployer config file
     New(DeployerNewArgs),
-    /// Perfom the network install
+    /// Install the network defined in the deployer config file
     Install(DeployerUpgradeArgs),
-    /// Perfom the network upgrade
+    /// Update the network defined in the deployer config file
     Upgrade(DeployerUpgradeArgs),
-    /// Provide the deposit commands for the validator nodes
+    /// Generate in output the commands to deposit stake amount to all the validators
     GetDepositCommands(DeployerUpgradeArgs),
-    /// Deposit the stake amounts to the network validator nodes
+    /// Deposit the stake amounts to all the validators
     Deposit(DeployerUpgradeArgs),
 }
 
@@ -91,6 +91,7 @@ pub struct DeployerNewArgs {
 
 #[derive(Args, Debug)]
 pub struct DeployerUpgradeArgs {
+    /// The network deployer config file
     config_file: Option<String>,
 }
 

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -1,0 +1,80 @@
+use std::{fmt, str::FromStr};
+
+use anyhow::{anyhow, Error, Result};
+use clap::ValueEnum;
+
+#[derive(Clone, Debug, ValueEnum)]
+// TODO: decomment when became available
+pub enum Chain {
+    #[value(name = "zq2-infratest")]
+    Zq2InfraTest,
+    #[value(name = "zq2-perftest")]
+    Zq2PerfTest,
+    #[value(name = "zq2-devnet")]
+    Zq2Devnet,
+    #[value(name = "zq2-prototestnet")]
+    Zq2ProtoTestnet,
+    // #[value(name = "zq2-protomainnet")]
+    // Zq2ProtoMainnet,
+    // #[value(name = "zq2-testnet")]
+    // Zq2Testnet,
+    // #[value(name = "zq2-mainnet")]
+    // Zq2Mainnet,
+}
+
+impl Chain {
+    pub fn get_endpoint(&self) -> Option<&'static str> {
+        match self {
+            Self::Zq2InfraTest => Some("https://api.zq2-infratest.zilstg.dev"),
+            Self::Zq2PerfTest => Some("https://api.zq2-perftest.zilstg.dev"),
+            Self::Zq2Devnet => Some("https://api.zq2-devnet.zilliqa.com"),
+            Self::Zq2ProtoTestnet => Some("https://api.zq2-prototestnet.zilliqa.com"),
+            // Self::Zq2ProtoMainnet => None,
+            // Self::Zq2Testnet => None,
+            // Self::Zq2Mainnet => None,
+        }
+    }
+
+    pub fn get_toml_contents(chain_name: &str) -> Result<&'static str> {
+        match chain_name {
+            "zq2-infratest" => Err(anyhow!("Configuration file for {} not found", chain_name)),
+            "zq2-perftest" => Ok(include_str!("../resources/chain-specs/zq2-perftest.toml")),
+            "zq2-devnet" => Ok(include_str!("../resources/chain-specs/zq2-devnet.toml")),
+            "zq2-prototestnet" => Ok(include_str!(
+                "../resources/chain-specs/zq2-prototestnet.toml"
+            )),
+            _ => Err(anyhow!("Configuration file for {} not found", chain_name)),
+        }
+    }
+}
+
+impl FromStr for Chain {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "zq2-infratest" => Ok(Self::Zq2InfraTest),
+            "zq2-perftest" => Ok(Self::Zq2PerfTest),
+            "zq2-devnet" => Ok(Self::Zq2Devnet),
+            "zq2-prototestnet" => Ok(Self::Zq2ProtoTestnet),
+            // "zq2-protomainnet" => Ok(Self::Zq2ProtoMainnet),
+            // "zq2-testnet" => Ok(Self::Zq2Testnet),
+            // "zq2-mainnet" => Ok(Self::Zq2Mainnet),
+            _ => Err(anyhow!("Chain not supported")),
+        }
+    }
+}
+
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Zq2InfraTest => write!(f, "zq2-infratest"),
+            Self::Zq2PerfTest => write!(f, "zq2-perftest"),
+            Self::Zq2Devnet => write!(f, "zq2-devnet"),
+            Self::Zq2ProtoTestnet => write!(f, "zq2-prototestnet"),
+            // Self::Zq2ProtoMainnet => "zq2-protomainnet",
+            // Self::Zq2Testnet => "zq2-testnet",
+            // Self::Zq2Mainnet => "zq2-mainnet",
+        }
+    }
+}

--- a/z2/src/lib.rs
+++ b/z2/src/lib.rs
@@ -1,4 +1,5 @@
 mod address;
+pub mod chain;
 pub mod collector;
 pub mod components;
 pub mod converter;

--- a/z2/src/node.rs
+++ b/z2/src/node.rs
@@ -8,6 +8,7 @@ use tokio::{fs::File, io::AsyncWriteExt};
 
 use crate::{
     address::EthereumAddress,
+    chain::Chain,
     deployer::{docker_image, Machine, NodeRole},
 };
 
@@ -46,6 +47,11 @@ impl ChainNode {
         }
     }
 
+    pub fn chain(&self) -> Result<Chain> {
+        let chain_name = &self.chain_name;
+        chain_name.parse()
+    }
+
     pub fn name(&self) -> String {
         self.machine.name.clone()
     }
@@ -70,11 +76,7 @@ impl ChainNode {
         self.run_provisioning_script().await?;
 
         // Check the node is making progress
-        if self.role == NodeRole::Bootstrap
-            || self.role == NodeRole::Validator
-            || self.role == NodeRole::Api
-            || self.role == NodeRole::Checkpoint
-        {
+        if self.role != NodeRole::Apps {
             let first_block_number = self.machine.get_local_block_number().await?;
             loop {
                 let next_block_number = self.machine.get_local_block_number().await?;

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -114,9 +114,15 @@ pub async fn run_deployer_upgrade(config_file: &str) -> Result<()> {
     Ok(())
 }
 
-pub async fn run_deployer_deposit_commands(config_file: &str) -> Result<()> {
+pub async fn run_deployer_get_deposit_commands(config_file: &str) -> Result<()> {
     println!("🦆 Getting node deposit commands for {config_file} .. ");
     deployer::get_deposit_commands(config_file).await?;
+    Ok(())
+}
+
+pub async fn run_deployer_deposit(config_file: &str) -> Result<()> {
+    println!("🦆 Running deposit for {config_file} .. ");
+    deployer::run_deposit(config_file).await?;
     Ok(())
 }
 

--- a/zq2-devnet.yaml
+++ b/zq2-devnet.yaml
@@ -8,6 +8,6 @@ roles:
 - apps
 - checkpoint
 versions:
-  zq2: e5b4d088
+  zq2: 9f66a16e
   otterscan: develop
   spout: main

--- a/zq2-infratest.yaml
+++ b/zq2-infratest.yaml
@@ -1,11 +1,12 @@
-name: zq2-prototestnet
-eth_chain_id: 33103
-project_id: prj-d-zq2-testnet-g13pnaa8
+name: zq2-infratest
+eth_chain_id: 33469
+project_id: prj-d-zq2-devnet-c83bkpsd
 roles:
 - bootstrap
 - validator
 - api
 - apps
+- checkpoint
 versions:
   zq2: 9f66a16e
   otterscan: develop


### PR DESCRIPTION
- add perftest and infratest networks
- improve network install/update errors verbosity
- implement `z2 deployer deposit` command to deposit the stake amount on all the network validators
- run network install/update in parallel on all nodes except for bootstrap and apps nodes
- parallelise `z2 deployer get-deposit-commands` execution
- enhance z2 CLI command descriptions
- enhance z2 CLI documentation