### PR TITLE
Make checkpoint loading idempotent

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -337,6 +337,11 @@ impl Db {
             if let Some(db_block) = self.get_block_by_hash(&block.hash())? {
                 if db_block != block {
                     return Err(anyhow!("Inconsistent checkpoint file: block loaded from checkpoint and block stored in database with same hash have differing parent hashes"));
+                } else {
+                    // In this case, the database already has the block contained in this checkpoint. We assume the
+                    // database contains the full state for that block too and thus return early, without actually
+                    // loading the checkpoint file.
+                    return Ok(db_block);
                 }
             } else {
                 return Err(anyhow!("Inconsistent checkpoint file: block loaded from checkpoint file does not exist in non-empty database"));
@@ -991,12 +996,24 @@ mod tests {
         )
         .unwrap();
 
-        // now parse the checkpoint
-        db.load_trusted_checkpoint(
-            checkpoint_path.join(checkpoint_block.number().to_string()),
-            &checkpoint_block.hash(),
-            SHARD_ID,
-        )
-        .unwrap();
+        // now load the checkpoint
+        let block = db
+            .load_trusted_checkpoint(
+                checkpoint_path.join(checkpoint_block.number().to_string()),
+                &checkpoint_block.hash(),
+                SHARD_ID,
+            )
+            .unwrap();
+        assert_eq!(checkpoint_block, block);
+
+        // load the checkpoint again, to ensure idempotency
+        let block = db
+            .load_trusted_checkpoint(
+                checkpoint_path.join(checkpoint_block.number().to_string()),
+                &checkpoint_block.hash(),
+                SHARD_ID,
+            )
+            .unwrap();
+        assert_eq!(checkpoint_block, block);
     }
 }


### PR DESCRIPTION
PR #1366 attempted to do this, but it didn't quite work because `load_trusted_checkpoint` still tries to add the checkpoint block to the database, which fails due to breaking the `UNIQUE` constraint on the table. Instead, if the block already exists in the database we return early without loading any state from the checkpoint file.