### PR TITLE
fix: default state_rpc_limit to isize maximum 

### DIFF
--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -139,7 +139,8 @@ pub fn block_request_batch_size_default() -> u64 {
 }
 
 pub fn state_rpc_limit_default() -> usize {
-    usize::MAX
+    // isize maximum because toml serialisation supports i64 integers
+    isize::MAX as usize
 }
 
 pub fn failed_request_sleep_duration_default() -> Duration {


### PR DESCRIPTION
This is the quick fix so that the default value can be set without a crash. 

This doesnt fix the wider issue of u64 being an unsuitable type for all configuration values.