### PR TITLE
Move state root hash check for blocks earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Unreleased changes, in reverse chronological order. New entries are added at the top of this list.
 
+- [#1469](https://github.com/Zilliqa/zq2/pull/1469): Calculate block state roots earlier to avoid database inconsistency.
+
 ## [0.3.1] - 2024-09-13
 
 - [#1445](https://github.com/Zilliqa/zq2/pull/1445): Apply state changes from transactions atomically.


### PR DESCRIPTION
This has two benefits:
1. We avoid putting blocks in our database which would fail the later check.
2. The changes to state are only flushed to disk when we calculate the state root hash. By calculating the state root hash of the block before storing that block, we ensure we aren't storing a block with unflushed state. This fixes a source of database inconsistency.