### PR TITLE
Read from init_data or contract state in scilla_read precompile

### DIFF
--- a/evm_scilla_js_tests/test/scilla/Timestamp.ts
+++ b/evm_scilla_js_tests/test/scilla/Timestamp.ts
@@ -12,7 +12,7 @@ describe("Scilla timestamp #parallel", () => {
     const blockCount = await ethers.provider.getBlockNumber();
     const blockTimestamp = (await ethers.provider.getBlock(blockCount)).timestamp;
     const tx = await contract.EventTimestamp(blockCount);
-    const timestamp = Number(JSON.parse(tx.receipt.event_logs[0].params[0].value).arguments[0]);
+    const timestamp = Number(tx.receipt.event_logs[0].params[0].value.arguments[0]);
     expect(Math.floor(timestamp / 1000_000)).to.be.eq(blockTimestamp);
   });
 });

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -42,7 +42,7 @@ use zilliqa::{
     message::{Block, BlockHeader, QuorumCertificate, Vote, MAX_COMMITTEE_SIZE},
     node::{MessageSender, RequestId},
     schnorr,
-    scilla::storage_key,
+    scilla::{storage_key, ParamValue},
     state::{contract_addr, Account, Code, State},
     time::SystemTime,
     transaction::{
@@ -202,7 +202,7 @@ fn get_contract_code(zq1_db: &zq1::Db, address: Address) -> Result<Code> {
     Ok(Code::Scilla {
         code: String::from_utf8(code)
             .map_err(|err| anyhow!("Unable to convert scilla code into string: {err}"))?,
-        init_data,
+        init_data: serde_json::from_str(&init_data)?,
         types: BTreeMap::default(),
         transitions: vec![],
     })

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -34,7 +34,7 @@ use crate::{
     message::Block,
     node::Node,
     schnorr,
-    scilla::split_storage_key,
+    scilla::{split_storage_key, ParamValue},
     state::Code,
     time::SystemTime,
     transaction::{ScillaGas, SignedTransaction, TxZilliqa, ZilAmount, EVM_GAS_PER_SCILLA_GAS},
@@ -427,7 +427,7 @@ fn get_smart_contract_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<Va
     Ok(json!({ "code": code, "type": type_ }))
 }
 
-fn get_smart_contract_init(params: Params, node: &Arc<Mutex<Node>>) -> Result<Value> {
+fn get_smart_contract_init(params: Params, node: &Arc<Mutex<Node>>) -> Result<Vec<ParamValue>> {
     let address: ZilAddress = params.one()?;
     let address: Address = address.into();
 
@@ -440,8 +440,9 @@ fn get_smart_contract_init(params: Params, node: &Arc<Mutex<Node>>) -> Result<Va
     let Some((_, init_data)) = account.code.scilla_code_and_init_data() else {
         return Err(anyhow!("Address not contract address"));
     };
+    let init_data = init_data.into_iter().map(ParamValue::from).collect();
 
-    Ok(serde_json::from_str(&init_data)?)
+    Ok(init_data)
 }
 
 fn get_transactions_for_tx_block(

--- a/zilliqa/src/precompiles/scilla.rs
+++ b/zilliqa/src/precompiles/scilla.rs
@@ -236,11 +236,10 @@ impl ContextStatefulPrecompile<PendingState> for ScillaRead {
             init_data.iter().find(|p| p.name == field),
             types.get(&field),
         ) {
-            (None, Some((ty, _))) => (ty, None),
+            // Note that if a field exists in both the `init_data` and mutable fields, we ignore the `init_data` and
+            // read from the field. This behaviour matches the semantics of Scilla and specification in ZIP-21.
+            (_, Some((ty, _))) => (ty, None),
             (Some(v), None) => (&v.ty, Some(v.value.clone())),
-            (Some(_), Some(_)) => {
-                return err(format!("variable {field} in both init data and state"));
-            }
             (None, None) => {
                 return err(format!("variable {field} does not exist in contract"));
             }

--- a/zilliqa/src/precompiles/scilla.rs
+++ b/zilliqa/src/precompiles/scilla.rs
@@ -216,14 +216,34 @@ impl ContextStatefulPrecompile<PendingState> for ScillaRead {
         let address = Address::detokenize(decoder.decode().unwrap());
         let field = String::detokenize(decoder.decode().unwrap());
 
-        let Ok(account) = context.db.load_account(address) else {
-            return fatal("state access failed");
+        let account = match context.db.load_account(address) {
+            Ok(account) => account,
+            Err(e) => {
+                tracing::error!(?e, "state access failed");
+                return fatal("state access failed");
+            }
         };
-        let Code::Scilla { ref types, .. } = account.account.code else {
+        let Code::Scilla {
+            ref types,
+            ref init_data,
+            ..
+        } = account.account.code
+        else {
             return err(format!("{address} is not a scilla contract"));
         };
-        let Some((ty, _)) = types.get(&field) else {
-            return err(format!("variable {field} does not exist in contract"));
+
+        let (ty, init_data_value) = match (
+            init_data.iter().find(|p| p.name == field),
+            types.get(&field),
+        ) {
+            (None, Some((ty, _))) => (ty, None),
+            (Some(v), None) => (&v.ty, Some(v.value.clone())),
+            (Some(_), Some(_)) => {
+                return err(format!("variable {field} in both init data and state"));
+            }
+            (None, None) => {
+                return err(format!("variable {field} does not exist in contract"));
+            }
         };
 
         let mut errors = vec![];
@@ -240,45 +260,64 @@ impl ContextStatefulPrecompile<PendingState> for ScillaRead {
             return err("failed to read indices");
         };
 
-        macro_rules! decoder {
+        macro_rules! encoder {
             ($ty:ty) => {{
-                let Ok(value) = context.db.load_storage(address, &field, &indices) else {
-                    return fatal("failed to read value");
-                };
-                let Some(value) = value else {
-                    return err("no such value");
-                };
-                let Ok(value) = serde_json::from_slice::<String>(&value) else {
-                    return fatal("failed to parse raw value");
-                };
-                let Ok(value) = value.parse::<$ty>() else {
-                    return fatal("failed to parse value");
-                };
-                value.abi_encode()
+                if let Some(value) = init_data_value {
+                    let Ok(value) = serde_json::from_value::<String>(value) else {
+                        return fatal("failed to parse raw value");
+                    };
+                    let Ok(value) = value.parse::<$ty>() else {
+                        return fatal("failed to parse value");
+                    };
+                    value.abi_encode()
+                } else {
+                    let Ok(value) = context.db.load_storage(address, &field, &indices) else {
+                        return fatal("failed to read value");
+                    };
+                    if let Some(value) = value {
+                        let Ok(value) = serde_json::from_slice::<String>(&value) else {
+                            return fatal("failed to parse raw value");
+                        };
+                        let Ok(value) = value.parse::<$ty>() else {
+                            return fatal("failed to parse value");
+                        };
+                        value.abi_encode()
+                    } else {
+                        vec![]
+                    }
+                }
             }};
         }
 
         let value = match ty {
-            ScillaType::ByStr20 => decoder!(Address),
-            ScillaType::Int32 => decoder!(i32),
-            ScillaType::Int64 => decoder!(i64),
-            ScillaType::Int128 => decoder!(i128),
-            ScillaType::Int256 => decoder!(I256),
-            ScillaType::Uint32 => decoder!(u32),
-            ScillaType::Uint64 => decoder!(u64),
-            ScillaType::Uint128 => decoder!(u128),
-            ScillaType::Uint256 => decoder!(U256),
+            ScillaType::ByStr20 => encoder!(Address),
+            ScillaType::Int32 => encoder!(i32),
+            ScillaType::Int64 => encoder!(i64),
+            ScillaType::Int128 => encoder!(i128),
+            ScillaType::Int256 => encoder!(I256),
+            ScillaType::Uint32 => encoder!(u32),
+            ScillaType::Uint64 => encoder!(u64),
+            ScillaType::Uint128 => encoder!(u128),
+            ScillaType::Uint256 => encoder!(U256),
             ScillaType::String => {
-                let Ok(value) = context.db.load_storage(address, &field, &indices) else {
-                    return fatal("failed to read value");
-                };
-                let Some(value) = value else {
-                    return err("no such value");
-                };
-                let Ok(value) = serde_json::from_slice::<String>(value) else {
-                    return fatal("failed to parse raw value");
-                };
-                value.abi_encode()
+                if let Some(value) = init_data_value {
+                    let Ok(value) = serde_json::from_value::<String>(value) else {
+                        return fatal("failed to parse raw value");
+                    };
+                    value.abi_encode()
+                } else {
+                    let Ok(value) = context.db.load_storage(address, &field, &indices) else {
+                        return fatal("failed to read value");
+                    };
+                    if let Some(value) = value {
+                        let Ok(value) = serde_json::from_slice::<String>(value) else {
+                            return fatal("failed to parse raw value");
+                        };
+                        value.abi_encode()
+                    } else {
+                        vec![]
+                    }
+                }
             }
             ScillaType::Map(_, _) => unreachable!("map will not be returned from `get_indices`"),
         };
@@ -362,8 +401,12 @@ fn scilla_call_precompile(
         return err("call mode should be either 0 or 1");
     };
 
-    let Ok(account) = evmctx.db.pre_state.get_account(address) else {
-        return fatal("state access failed");
+    let account = match evmctx.db.pre_state.get_account(address) {
+        Ok(account) => account,
+        Err(e) => {
+            tracing::error!(?e, "state access failed");
+            return fatal("state access failed");
+        }
     };
     let Code::Scilla { transitions, .. } = account.code else {
         return err(format!("{address} is not a scilla contract"));
@@ -423,7 +466,7 @@ fn scilla_call_precompile(
     ) else {
         return fatal("scilla call failed");
     };
-    if !result.success {
+    if !&result.success {
         if result
             .errors
             .values()

--- a/zilliqa/src/serde_util.rs
+++ b/zilliqa/src/serde_util.rs
@@ -37,3 +37,80 @@ pub mod bool_as_str {
         Ok(b)
     }
 }
+
+pub mod json_value_as_str {
+    use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+    use serde_json::Value;
+
+    pub fn serialize<S>(value: &Value, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        value.to_string().serialize(serializer)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        serde_json::from_str(&String::deserialize(deserializer)?).map_err(de::Error::custom)
+    }
+}
+
+/// Custom (de)serializer for `Vec<ParamValue>` which doesn't rely on `deserialize_any` by serializing the inner
+/// `serde_json::Value` as a string. This means bincode is able to handle it.
+pub mod vec_param_value {
+    use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serialize, Serializer};
+
+    use crate::scilla::ParamValue;
+
+    pub fn serialize<S>(values: &Vec<ParamValue>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        #[derive(Serialize)]
+        struct ParamValueEncoded<'s> {
+            #[serde(rename = "vname")]
+            pub name: &'s str,
+            pub value: String,
+            #[serde(rename = "type")]
+            pub ty: &'s str,
+        }
+
+        let mut serializer = serializer.serialize_seq(Some(values.len()))?;
+        for value in values {
+            let encoded = ParamValueEncoded {
+                name: &value.name,
+                value: serde_json::to_string(&value.value).unwrap(),
+                ty: &value.ty,
+            };
+            serializer.serialize_element(&encoded)?;
+        }
+        serializer.end()
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<ParamValue>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct ParamValueEncoded {
+            #[serde(rename = "vname")]
+            pub name: String,
+            pub value: String,
+            #[serde(rename = "type")]
+            pub ty: String,
+        }
+
+        let values = <Vec<ParamValueEncoded>>::deserialize(deserializer)?
+            .into_iter()
+            .map(|value| ParamValue {
+                name: value.name,
+                value: serde_json::from_str(&value.value).unwrap(),
+                ty: value.ty,
+            })
+            .collect();
+
+        Ok(values)
+    }
+}

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -23,7 +23,8 @@ use crate::{
     inspector,
     message::{BlockHeader, MAX_COMMITTEE_SIZE},
     node::ChainId,
-    scilla::{Scilla, Transition},
+    scilla::{ParamValue, Scilla, Transition},
+    serde_util::vec_param_value,
     transaction::EvmGas,
 };
 
@@ -325,7 +326,8 @@ pub enum Code {
     Evm(#[serde(with = "serde_bytes")] Vec<u8>),
     Scilla {
         code: String,
-        init_data: String,
+        #[serde(with = "vec_param_value")]
+        init_data: Vec<ParamValue>,
         types: BTreeMap<String, (String, u8)>,
         transitions: Vec<Transition>,
     },
@@ -356,7 +358,7 @@ impl Code {
         }
     }
 
-    pub fn scilla_code_and_init_data(self) -> Option<(String, String)> {
+    pub fn scilla_code_and_init_data(self) -> Option<(String, Vec<ParamValue>)> {
         match self {
             Code::Scilla {
                 code, init_data, ..

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -33,10 +33,11 @@ use crate::{
         EVM_MAX_INIT_CODE_SIZE, EVM_MAX_TX_INPUT_SIZE, EVM_MIN_GAS_UNITS, ZIL_CONTRACT_CREATE_GAS,
         ZIL_CONTRACT_INVOKE_GAS, ZIL_MAX_CODE_SIZE, ZIL_NORMAL_TXN_GAS,
     },
-    crypto,
-    crypto::Hash,
+    crypto::{self, Hash},
     exec::{ScillaError, ScillaException, ScillaTransition},
     schnorr,
+    scilla::ParamValue,
+    serde_util::vec_param_value,
     state::Account,
     zq1_proto::{Code, Data, Nonce, ProtoTransactionCoreInfo},
 };
@@ -875,29 +876,29 @@ pub struct ScillaLog {
     pub address: Address,
     #[serde(rename = "_eventname")]
     pub event_name: String,
-    pub params: Vec<ScillaParam>,
+    #[serde(with = "vec_param_value")]
+    pub params: Vec<ParamValue>,
 }
 
 impl ScillaLog {
     pub fn into_evm(self) -> EvmLog {
-        /// A version of [ScillaLog] which lets us serialise the `address` manually. We need to serialize it without
-        /// the checksum.
-        #[derive(Serialize)]
-        struct ScillaLogNoChecksum {
+        /// A version of [ScillaLog] which lets us serialise the `address` manually, so we can exclude the checksum, and doesn't encode the `params` values as strings.
+        #[derive(Clone, Serialize, Debug)]
+        pub struct ScillaLogRaw {
             address: String,
             #[serde(rename = "_eventname")]
             event_name: String,
-            params: Vec<ScillaParam>,
+            params: Vec<ParamValue>,
         }
 
         let address = self.address;
-        let log = ScillaLogNoChecksum {
+        let log = ScillaLogRaw {
             address: format!("{address:?}"),
             event_name: self.event_name,
             params: self.params,
         };
 
-        // Unwrap is safe because [ScillaLogNoChecksum::Serialize] is infallible.
+        // Unwrap is safe because [ScillaLogRaw::Serialize] is infallible.
         let data = serde_json::to_string(&log).unwrap().abi_encode();
         EvmLog {
             address,
@@ -956,25 +957,6 @@ impl Log {
                 .with(log.topics.iter().map(|topic| topic.to_vec()).concat())
                 .finalize(),
         }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ScillaParam {
-    #[serde(rename = "type")]
-    pub ty: String,
-    pub value: String,
-    #[serde(rename = "vname")]
-    pub name: String,
-}
-
-impl ScillaParam {
-    pub fn compute_hash(&self) -> Hash {
-        Hash::builder()
-            .with(self.ty.as_bytes())
-            .with(self.value.as_bytes())
-            .with(self.name.as_bytes())
-            .finalize()
     }
 }
 

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -524,7 +524,14 @@ async fn scilla_precompiles(mut network: Network) {
     assert_eq!(scilla_log["_eventname"], "Inserted");
     assert_eq!(scilla_log["params"][0]["type"], "ByStr20");
     assert_eq!(scilla_log["params"][0]["vname"], "a");
-    assert_eq!(scilla_log["params"][0]["value"], format!("{key:?}"));
+    assert_eq!(
+        scilla_log["params"][0]["value"]
+            .as_str()
+            .unwrap()
+            .parse::<H160>()
+            .unwrap(),
+        key
+    );
     assert_eq!(scilla_log["params"][1]["type"], "Uint128");
     assert_eq!(scilla_log["params"][1]["vname"], "b");
     assert_eq!(scilla_log["params"][1]["value"], "5");


### PR DESCRIPTION
The scilla_read precompile now reads from either the contract state or the contract's init data when a value is queried.

To achieve this, I have changed the type of a Scilla contract's `init_data` from `String` to `Vec<ParamValue>`. The same data is stored, but we now parse the data on entry so that we can retrieve values easily later.

Also this fixes #1380 
