### PR TITLE
 Do not blindly unwrap processing of network messages

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -106,7 +106,7 @@ struct CachedLeader {
 
 /// The consensus algorithm is pipelined fast-hotstuff, as given in this paper: https://arxiv.org/pdf/2010.11454.pdf
 ///
-/// The algorithm can be condensed down into the following explaination:
+/// The algorithm can be condensed down into the following explanation:
 /// - Blocks must contain either a QuorumCertificate (QC), or an aggregated QuorumCertificate (aggQC).
 /// - A QuorumCertificate is an aggregation of signatures of threshold validators against a block hash (the previous block)
 /// - An aggQC is an aggregation of threshold QC.
@@ -143,7 +143,7 @@ pub struct Consensus {
     pub block_store: BlockStore,
     latest_leader_cache: RefCell<Option<CachedLeader>>,
     votes: BTreeMap<Hash, BlockVotes>,
-    /// Votes for a block we don't have stored. They are retained in case we recieve the block later.
+    /// Votes for a block we don't have stored. They are retained in case we receive the block later.
     // TODO(#719): Consider how to limit the size of this.
     buffered_votes: BTreeMap<Hash, Vec<Vote>>,
     new_views: BTreeMap<u64, NewViewVote>,

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -182,20 +182,27 @@ impl NodeLauncher {
             select! {
                 message = self.broadcasts.next() => {
                     let (source, message) = message.expect("message stream should be infinite");
-                    self.node.lock().unwrap().handle_broadcast(source, message).unwrap();
+                    if let Err(e) = self.node.lock().unwrap().handle_broadcast(source, message) {
+                        error!("Failed to process broadcast message: {e}");
+                    }
                 }
                 message = self.requests.next() => {
                     let (source, message, response_channel) = message.expect("message stream should be infinite");
-                    self.node.lock().unwrap().handle_request(source, message, response_channel).unwrap();
+                    if let Err(e) = self.node.lock().unwrap().handle_request(source, message, response_channel) {
+                        error!("Failed to process request message: {e}");
+                    }
                 }
                 message = self.request_failures.next() => {
                     let (source, message) = message.expect("message stream should be infinite");
-                    // TODOtomos here we handle request failures. there is opporunity to panic. 
-                    self.node.lock().unwrap().handle_request_failure(source, message).unwrap();
+                    if let Err(e) = self.node.lock().unwrap().handle_request_failure(source, message) {
+                        error!("Failed to process request failure message: {e}");
+                    };
                 }
                 message = self.responses.next() => {
                     let (source, message) = message.expect("message stream should be infinite");
-                    self.node.lock().unwrap().handle_response(source, message).unwrap();
+                    if let Err(e) = self.node.lock().unwrap().handle_response(source, message) {
+                        error!("Failed to process response message: {e}");
+                    }
                 }
                 message = self.local_messages.next() => {
                     let (_source, _message) = message.expect("message stream should be infinite");

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -190,6 +190,7 @@ impl NodeLauncher {
                 }
                 message = self.request_failures.next() => {
                     let (source, message) = message.expect("message stream should be infinite");
+                    // TODOtomos here we handle request failures. there is opporunity to panic. 
                     self.node.lock().unwrap().handle_request_failure(source, message).unwrap();
                 }
                 message = self.responses.next() => {

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -395,8 +395,10 @@ impl P2pNode {
                 message = self.request_responses_receiver.next() => {
                     let (ch, _rs) = message.expect("message stream should be infinite");
                     if let Some(_ch) = ch.into_inner() {
+                        // let a = self.swarm.behaviour_mut().request_response.send_response(_ch, _rs);
                         cfg_if! {
                             if #[cfg(not(feature = "fake_response_channel"))] {
+                                // TODOtomos response here may be returned as Err if channel is closed. handle it
                                 let _ = self.swarm.behaviour_mut().request_response.send_response(_ch, _rs);
                             } else {
                                 panic!("fake_response_channel is enabled and you are trying to use a real libp2p network");
@@ -417,6 +419,7 @@ impl P2pNode {
                             if from == dest {
                                 self.send_to(&topic.hash(), |c| c.requests.send((from, message, ResponseChannel::Local)))?;
                             } else {
+                                // TODOtomos catch panic here. we attempt to connect with the receiver or add to pending_requests if unsuccessful 
                                 let libp2p_request_id = self.swarm.behaviour_mut().request_response.send_request(&dest, (shard_id, message));
                                 self.pending_requests.insert(libp2p_request_id, (shard_id, request_id));
                             }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -395,10 +395,8 @@ impl P2pNode {
                 message = self.request_responses_receiver.next() => {
                     let (ch, _rs) = message.expect("message stream should be infinite");
                     if let Some(_ch) = ch.into_inner() {
-                        // let a = self.swarm.behaviour_mut().request_response.send_response(_ch, _rs);
                         cfg_if! {
                             if #[cfg(not(feature = "fake_response_channel"))] {
-                                // TODOtomos response here may be returned as Err if channel is closed. handle it
                                 let _ = self.swarm.behaviour_mut().request_response.send_response(_ch, _rs);
                             } else {
                                 panic!("fake_response_channel is enabled and you are trying to use a real libp2p network");
@@ -419,7 +417,6 @@ impl P2pNode {
                             if from == dest {
                                 self.send_to(&topic.hash(), |c| c.requests.send((from, message, ResponseChannel::Local)))?;
                             } else {
-                                // TODOtomos catch panic here. we attempt to connect with the receiver or add to pending_requests if unsuccessful 
                                 let libp2p_request_id = self.swarm.behaviour_mut().request_response.send_request(&dest, (shard_id, message));
                                 self.pending_requests.insert(libp2p_request_id, (shard_id, request_id));
                             }


### PR DESCRIPTION
Instead of unwrap i've converted any potential errors to error logs. There are no expected errors here but we we should avoid a crash if there is.