### PR TITLE
feat: DEVOPS-1574 ops agent metrics config to exclude non-used metrics

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -265,6 +265,27 @@ logging:
       zilliqa:
         receivers: [ zilliqa ]
         processors: [ parse_log, parse_log_with_field, move_fields ]
+metrics:
+  receivers:
+    hostmetrics:
+      type: hostmetrics
+      collection_interval: 60s
+  processors:
+    metrics_filter:
+      type: exclude_metrics
+      metrics_pattern:
+      - agent.googleapis.com/gpu/*
+      - agent.googleapis.com/interface/*
+      - agent.googleapis.com/network/*
+      - agent.googleapis.com/swap/*
+      - agent.googleapis.com/pagefile/*
+      - agent.googleapis.com/processes/*
+  service:
+    log_level: info
+    pipelines:
+      default_pipeline:
+        receivers: [hostmetrics]
+        processors: [metrics_filter]
 """
 
 LOGROTATE_CONFIG="""


### PR DESCRIPTION
To reduce the number of unused metrics ($300 USD in devnet and $500 USD in testnet), first we need to exclude non-used metrics.

https://cloud.google.com/stackdriver/docs/solutions/agents/ops-agent/configuration#metrics-config

To further optimize the collection costs, we can eventually exclude more metrics inside the disks, memory and cpu scopes and reduce the scraping frequency (currently 60s).

As a plan B for the future probably a OTEL or Prometheus exporter could give us the same values with a more efficient pricing model.