### PR TITLE
Store block in cache when view is smaller than current

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -576,7 +576,7 @@ impl Consensus {
         during_sync: bool,
     ) -> Result<Option<NetworkMessage>> {
         self.cleanup_votes();
-        let (block, transactions) = proposal.clone().into_parts();
+        let (block, transactions) = proposal.into_parts();
         let head_block = self.head_block();
 
         trace!(
@@ -617,7 +617,19 @@ impl Consensus {
             Err((e, temporary)) => {
                 // If this block could become valid in the future, buffer it.
                 if temporary {
-                    self.block_store.buffer_proposal(from, proposal)?;
+                    self.block_store.buffer_proposal(
+                        from,
+                        Proposal::from_parts_with_hashes(
+                            block,
+                            transactions
+                                .into_iter()
+                                .map(|tx| {
+                                    let hash = tx.calculate_hash();
+                                    (tx, hash)
+                                })
+                                .collect(),
+                        ),
+                    )?;
                 } else {
                     warn!(?e, "invalid block proposal received!");
                 }
@@ -645,7 +657,19 @@ impl Consensus {
                     block.view(),
                     self.view.get_view()
                 );
-                self.block_store.buffer_proposal(from, proposal)?;
+                self.block_store.buffer_proposal(
+                    from,
+                    Proposal::from_parts_with_hashes(
+                        block,
+                        transactions
+                            .into_iter()
+                            .map(|tx| {
+                                let hash = tx.calculate_hash();
+                                (tx, hash)
+                            })
+                            .collect(),
+                    ),
+                )?;
                 return Ok(None);
             }
 

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -576,7 +576,7 @@ impl Consensus {
         during_sync: bool,
     ) -> Result<Option<NetworkMessage>> {
         self.cleanup_votes();
-        let (block, transactions) = proposal.into_parts();
+        let (block, transactions) = proposal.clone().into_parts();
         let head_block = self.head_block();
 
         trace!(
@@ -617,19 +617,7 @@ impl Consensus {
             Err((e, temporary)) => {
                 // If this block could become valid in the future, buffer it.
                 if temporary {
-                    self.block_store.buffer_proposal(
-                        from,
-                        Proposal::from_parts_with_hashes(
-                            block,
-                            transactions
-                                .into_iter()
-                                .map(|tx| {
-                                    let hash = tx.calculate_hash();
-                                    (tx, hash)
-                                })
-                                .collect(),
-                        ),
-                    )?;
+                    self.block_store.buffer_proposal(from, proposal)?;
                 } else {
                     warn!(?e, "invalid block proposal received!");
                 }
@@ -657,19 +645,7 @@ impl Consensus {
                     block.view(),
                     self.view.get_view()
                 );
-                self.block_store.buffer_proposal(
-                    from,
-                    Proposal::from_parts_with_hashes(
-                        block,
-                        transactions
-                            .into_iter()
-                            .map(|tx| {
-                                let hash = tx.calculate_hash();
-                                (tx, hash)
-                            })
-                            .collect(),
-                    ),
-                )?;
+                self.block_store.buffer_proposal(from, proposal)?;
                 return Ok(None);
             }
 


### PR DESCRIPTION
Currently we reject blocks whose `view <= self.view`. This means that nodes will reject then re-request the missing block later on. 

Instead, here we add outdated blocks to the `block_store`'s cache to be used later or trimmed out.

Note that we still reject blocks whose `view <= self.finalised_view()`.