### PR TITLE
Add more API tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 Unreleased changes, in reverse chronological order. New entries are added at the top of this list.
 
-- [#1511](https://github.com/Zilliqa/zq2/pull/1511): Add more API tests.
 - [#1449](https://github.com/Zilliqa/zq2/pull/1449): Restructure how blocks are stored to prevent database inconsistencies.
 - [#1472](https://github.com/Zilliqa/zq2/pull/1472): Add `GetTransactionsForTxBlockEx` API.
 - [#1476](https://github.com/Zilliqa/zq2/pull/1476): Fix topic in EVM-encoded Scilla events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Unreleased changes, in reverse chronological order. New entries are added at the top of this list.
 
+- [#1511](https://github.com/Zilliqa/zq2/pull/1511): Add more API tests.
 - [#1449](https://github.com/Zilliqa/zq2/pull/1449): Restructure how blocks are stored to prevent database inconsistencies.
 - [#1472](https://github.com/Zilliqa/zq2/pull/1472): Add `GetTransactionsForTxBlockEx` API.
 - [#1476](https://github.com/Zilliqa/zq2/pull/1476): Fix topic in EVM-encoded Scilla events.

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -926,7 +926,7 @@ async fn get_txns_for_tx_block_ex_1(mut network: Network) {
         "Expected Transactions length to be less than or equal to 2500"
     );
     assert!(
-        txns.transactions.len() >= 1,
+        !txns.transactions.is_empty(),
         "Expected Transactions length to be greater than or equal to 1"
     );
 }
@@ -966,7 +966,7 @@ async fn get_txns_for_tx_block_0(mut network: Network) {
         serde_json::from_value(response).expect("Failed to deserialize response");
 
     assert!(
-        txns[0].len() >= 1,
+        !txns[0].is_empty(),
         "Expected Transactions length to be greater than or equal to 1"
     );
 }


### PR DESCRIPTION
The main intention here was to create an example test for testing transactions (`test_simulate_transactions`), since I thought something fishy was going on with the transaction tests. While I was at it I added a few more tests using the same methodology. I also identified that the strange behaviour I'd noted was due to 0 vs 1 based page numbers in `get_txns_for_tx_block_ex`, and I've now fixed the test to respect that.

- `get_txns_for_tx_block_0`
- `get_txns_for_tx_block_ex_1`
- `test_simulate_transactions`
- `get_tx_rate_1`
- `get_tx_block_rate_1`
- Some removals of duplicated asserts