### PR TITLE
Accept `input` or `data` for transaction request payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Unreleased changes, in reverse chronological order. New entries are added at the top of this list.
 
+- [#1534](https://github.com/Zilliqa/zq2/pull/1534): Accept `input` or `data` for transaction request payloads.
 - [#1530](https://github.com/Zilliqa/zq2/pull/1530): State at checkpoint should contain current block data as well as parent block data
 - [#1449](https://github.com/Zilliqa/zq2/pull/1449): Restructure how blocks are stored to prevent database inconsistencies.
 - [#1472](https://github.com/Zilliqa/zq2/pull/1472): Add `GetTransactionsForTxBlockEx` API.

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -180,18 +180,13 @@ fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
         &block,
         call_params.from,
         call_params.to,
-        call_params.data.clone(),
+        call_params
+            .data
+            .try_into_unique_input()?
+            .unwrap_or_default()
+            .to_vec(),
         call_params.value.to(),
     )?;
-
-    trace!(
-        "Performed eth call. Args: {:?} ie: {:?} {:?} {:?}  ret: {:?}",
-        serde_json::to_string(&call_params),
-        call_params.from,
-        call_params.to,
-        call_params.data,
-        ret.to_hex()
-    );
 
     Ok(ret.to_hex())
 }
@@ -212,7 +207,11 @@ fn estimate_gas(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
         block_number,
         call_params.from,
         call_params.to,
-        call_params.data.clone(),
+        call_params
+            .data
+            .try_into_unique_input()?
+            .unwrap_or_default()
+            .to_vec(),
         call_params.gas.map(|g| EvmGas(g.to())),
         call_params.gas_price.map(|g| g.to()),
         call_params.value.to(),

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -3,11 +3,9 @@ use std::collections::HashMap;
 use alloy::{
     consensus::TxEip1559,
     primitives::{Address, B256, U128, U256, U64},
+    rpc::types::TransactionInput,
 };
-use serde::{
-    de::{self, Unexpected},
-    Deserialize, Deserializer, Serialize,
-};
+use serde::{Deserialize, Serialize};
 use sha3::{Digest, Keccak256};
 
 use super::{bool_as_int, hex, option_hex, vec_hex};
@@ -422,18 +420,8 @@ pub struct CallParams {
     pub gas_price: Option<U128>,
     #[serde(default)]
     pub value: U128,
-    #[serde(default, deserialize_with = "deserialize_data")]
-    pub data: Vec<u8>,
-}
-
-fn deserialize_data<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
-    let s = String::deserialize(deserializer)?;
-
-    let s = s.strip_prefix("0x").ok_or_else(|| {
-        de::Error::invalid_value(Unexpected::Str(&s), &"a string prefixed with \"0x\"")
-    })?;
-
-    hex::decode(s).map_err(de::Error::custom)
+    #[serde(default, flatten)]
+    pub data: TransactionInput,
 }
 
 #[derive(Clone, Serialize)]


### PR DESCRIPTION
`eth_call` and `eth_estimateGas` now accept `input` as well as `data`. If both fields are passed, we expect them to have the same value and return an error if not.