### PR TITLE
Do not immediately propose block upon receiving tx

### DIFF
--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -207,11 +207,11 @@ pub struct ConsensusConfig {
     /// Accounts that will be pre-funded at genesis.
     #[serde(default)]
     pub genesis_accounts: Vec<(Address, Amount)>,
-    /// Minimum time to wait for consensus to propose new block if there are no transactions.
+    /// Minimum time to wait for consensus to propose new block if there are no transactions. This therefore acts also as the minimum block time.
     #[serde(default = "empty_block_timeout_default")]
     pub empty_block_timeout: Duration,
     /// Minimum remaining time before end of round in which Proposer has the opportunity to broadcast empty block proposal.
-    /// If there is less time than this value left in a round then the view will likely move on before a proposal can be finalised.
+    /// If there is less time than this value left in a round then the view will likely move on before a proposal has time to be finalised.
     #[serde(default = "minimum_time_left_for_empty_block_default")]
     pub minimum_time_left_for_empty_block: Duration,
     /// Address of the Scilla server. Defaults to "http://localhost:3000".

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -210,7 +210,8 @@ pub struct ConsensusConfig {
     /// Minimum time to wait for consensus to propose new block if there are no transactions.
     #[serde(default = "empty_block_timeout_default")]
     pub empty_block_timeout: Duration,
-    /// Minimum remaining time allowing to wait for empty block proposal
+    /// Minimum remaining time before end of round in which Proposer has the opportunity to broadcast empty block proposal. 
+    /// If there is less time than this value left in a round then the view will likely move on before a proposal can be finalised.
     #[serde(default = "minimum_time_left_for_empty_block_default")]
     pub minimum_time_left_for_empty_block: Duration,
     /// Address of the Scilla server. Defaults to "http://localhost:3000".

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -210,7 +210,7 @@ pub struct ConsensusConfig {
     /// Minimum time to wait for consensus to propose new block if there are no transactions.
     #[serde(default = "empty_block_timeout_default")]
     pub empty_block_timeout: Duration,
-    /// Minimum remaining time before end of round in which Proposer has the opportunity to broadcast empty block proposal. 
+    /// Minimum remaining time before end of round in which Proposer has the opportunity to broadcast empty block proposal.
     /// If there is less time than this value left in a round then the view will likely move on before a proposal can be finalised.
     #[serde(default = "minimum_time_left_for_empty_block_default")]
     pub minimum_time_left_for_empty_block: Duration,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -99,6 +99,13 @@ struct CachedLeader {
     next_leader: Validator,
 }
 
+type EarlyProposal = (
+    Block,
+    Vec<VerifiedTransaction>,
+    EthTrie<MemoryDB>,
+    EthTrie<MemoryDB>,
+);
+
 /// The consensus algorithm is pipelined fast-hotstuff, as given in this paper: https://arxiv.org/pdf/2010.11454.pdf
 ///
 /// The algorithm can be condensed down into the following explanation:
@@ -152,12 +159,7 @@ pub struct Consensus {
     /// Actions that act on newly created blocks
     transaction_pool: TransactionPool,
     /// Pending proposal
-    early_proposal: Option<(
-        Block,
-        Vec<VerifiedTransaction>,
-        EthTrie<MemoryDB>,
-        EthTrie<MemoryDB>,
-    )>,
+    early_proposal: Option<EarlyProposal>,
     /// Flag indicating that block creation should be postponed due to empty mempool
     create_next_block_on_timeout: bool,
     pub new_blocks: broadcast::Sender<BlockHeader>,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1163,7 +1163,6 @@ impl Consensus {
     /// It does all the needed work but with a dummy QC.
     fn assemble_early_block_at(&mut self, state: &mut State) -> Result<()> {
         if self.early_proposal.is_some() {
-            error!("attempted to assemble early proposal but it already exists");
             return Ok(());
         }
         info!("assemble early proposal for view {}", self.view.get_view());

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -203,9 +203,7 @@ impl Node {
             ExternalMessage::NewTransaction(t) => {
                 let inserted = self.consensus.new_transaction(t.verify()?)?;
                 if inserted {
-                    if let Some((_, message)) = self.consensus.try_to_propose_new_block()? {
-                        self.message_sender.broadcast_external_message(message)?;
-                    }
+                    self.consensus.assemble_early_block()?;
                 }
             }
             _ => {

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -201,10 +201,7 @@ impl Node {
                 self.handle_proposal(from, m)?;
             }
             ExternalMessage::NewTransaction(t) => {
-                let inserted = self.consensus.new_transaction(t.verify()?)?;
-                if inserted {
-                    self.consensus.assemble_early_block()?;
-                }
+                self.consensus.handle_new_transaction(t)?;
             }
             _ => {
                 warn!("unexpected message type");
@@ -379,7 +376,7 @@ impl Node {
 
         info!(?hash, "seen new txn {:?}", txn);
 
-        if self.consensus.new_transaction(txn.clone().verify()?)? {
+        if self.consensus.handle_new_transaction(txn.clone())? {
             self.message_sender
                 .broadcast_external_message(ExternalMessage::NewTransaction(txn))?;
         }


### PR DESCRIPTION
Closes https://github.com/Zilliqa/zq2/issues/1218

The overall goal is to stop blocks being created and broadcast immediately upon receive of a transaction. 

- Create `early_proposal` block proposal as soon as any Votes arrive l
- As new transactions come in update `early_proposal` to include them
- Broadcast proposal only after `empty_block_timeout` seconds have passed since last view