### PR TITLE
Replace the TCP swarm with QUIC.

### DIFF
--- a/infra/config_networking_test.toml
+++ b/infra/config_networking_test.toml
@@ -1,7 +1,7 @@
 otlp_collector_endpoint = "http://otel-collector:4317"
 bootstrap_address = [
     "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
-    "/ip4/198.51.100.103/tcp/5643",
+    "/ip4/198.51.100.103/udp/5643/quic-v1",
 ]
 p2p_port = 5643
 

--- a/z2/docs/converter.md
+++ b/z2/docs/converter.md
@@ -29,7 +29,7 @@
 
   cat > config.toml <<-EOF
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWNYaasyfY1wFrSHga3WBdZkb7bGhQiUz9926bQvk4HQj2", "/ip4/10.40.5.16/tcp/3333" ]
+bootstrap_address = [ "12D3KooWNYaasyfY1wFrSHga3WBdZkb7bGhQiUz9926bQvk4HQj2", "/ip4/10.40.5.16/udp/3333/quic-v1" ]
 
 [[nodes]]
 eth_chain_id = 33101 # change the chain it for your conversion

--- a/z2/resources/chain-specs/zq2-devnet.toml
+++ b/z2/resources/chain-specs/zq2-devnet.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWJNUNgs1UM9mw1Pfskxk4o3VWz37cpneSHZsUecGGZgkb", "/ip4/35.198.245.220/tcp/3333" ]
+bootstrap_address = [ "12D3KooWJNUNgs1UM9mw1Pfskxk4o3VWz37cpneSHZsUecGGZgkb", "/ip4/172.18.0.9/udp/3333/quic-v1" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/chain-specs/zq2-devnet.toml
+++ b/z2/resources/chain-specs/zq2-devnet.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWJNUNgs1UM9mw1Pfskxk4o3VWz37cpneSHZsUecGGZgkb", "/ip4/172.18.0.9/udp/3333/quic-v1" ]
+bootstrap_address = [ "12D3KooWJNUNgs1UM9mw1Pfskxk4o3VWz37cpneSHZsUecGGZgkb", "/ip4/35.198.245.220/udp/3333/quic-v1" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/chain-specs/zq2-perftest.toml
+++ b/z2/resources/chain-specs/zq2-perftest.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWLQErYMNECpTd22VtTQeGXRf18yeeEM32rVAWZ9qXdLUB", "/ip4/34.143.150.198/tcp/3333" ]
+bootstrap_address = [ "12D3KooWLQErYMNECpTd22VtTQeGXRf18yeeEM32rVAWZ9qXdLUB", "/ip4/34.143.150.198/udp/3333/quic-v1" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/chain-specs/zq2-prototestnet.toml
+++ b/z2/resources/chain-specs/zq2-prototestnet.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWEpeCSbza6zYXJ8PY8v6iEZYzYD4mhk4QbmHGbjx186dS", "/ip4/34.87.62.126/tcp/3333" ]
+bootstrap_address = [ "12D3KooWEpeCSbza6zYXJ8PY8v6iEZYzYD4mhk4QbmHGbjx186dS", "/ip4/34.87.62.126/udp/3333/quic-v1" ]
 
 [[nodes]]
 eth_chain_id = 33103

--- a/z2/resources/chain-specs/zq2-uccbtest.toml
+++ b/z2/resources/chain-specs/zq2-uccbtest.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWReRperXgN12FUH6yRTXrcV3u98E753356AR1sAEJefup", "/ip4/34.87.127.118/tcp/3333" ]
+bootstrap_address = [ "12D3KooWReRperXgN12FUH6yRTXrcV3u98E753356AR1sAEJefup", "/ip4/34.87.127.118/udp/3333/quic-v1" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -1,7 +1,7 @@
 p2p_port = 3333
 
 {%- if role != "bootstrap" %}
-bootstrap_address = [ "{{ bootstrap_peer_id }}", "/ip4/{{ bootstrap_public_ip }}/tcp/3333" ]
+bootstrap_address = [ "{{ bootstrap_peer_id }}", "/ip4/{{ bootstrap_public_ip }}/udp/3333/quic-v1" ]
 {%- endif %}
 
 [[nodes]]

--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -107,7 +107,7 @@ ZQ2_IMAGE="{{ docker_image }}"
 
 start() {
     docker rm zilliqa-""" + VERSIONS.get('zilliqa') + """ &> /dev/null || echo 0
-    docker run -td -p 3333:3333 -p 4201:4201 --net=host --name zilliqa-""" + VERSIONS.get('zilliqa') + """ \
+    docker run -td -p 3333:3333/udp -p 4201:4201 --net=host --name zilliqa-""" + VERSIONS.get('zilliqa') + """ \
     --log-driver json-file --log-opt max-size=1g --log-opt max-file=30 \
     -e RUST_LOG="zilliqa=trace" -e RUST_BACKTRACE=1 \
     -v /config.toml:/config.toml -v /zilliqa.log:/zilliqa.log -v /data:/data \

--- a/z2/resources/start_node.tera.sh
+++ b/z2/resources/start_node.tera.sh
@@ -78,7 +78,7 @@ start() {
         MOUNT_OPTION=""
     fi
     DOCKER_COMMAND="docker run -td \
-    -p 3333:3333 \
+    -p 3333:3333/udp \
     -p 4201:4201 \
     --net=host \
     --name zilliqa-${ZQ_VERSION} \

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -45,7 +45,7 @@ hyper = "1.4.1"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.24.3", features = ["jsonrpsee-http-client", "server"] }
 k256 = {version = "0.13.4", features = ["serde", "pem"] }
-libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux", "autonat"] }
+libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux", "autonat", "quic"] }
 lru = "0.12"
 once_cell = "1.20.1"
 opentelemetry = { version = "0.26.0", features = ["metrics"] }

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -45,7 +45,7 @@ hyper = "1.4.1"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.24.3", features = ["jsonrpsee-http-client", "server"] }
 k256 = {version = "0.13.4", features = ["serde", "pem"] }
-libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tcp", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux", "autonat", "quic"] }
+libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tokio", "noise", "mdns", "request-response", "kad", "identify", "serde", "yamux", "autonat", "quic"] }
 lru = "0.12"
 once_cell = "1.20.1"
 opentelemetry = { version = "0.26.0", features = ["metrics"] }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -235,7 +235,6 @@ impl P2pNode {
             self.swarm.dial(
                 DialOpts::peer_id(*peer)
                     .addresses(vec![address.clone()])
-                    .override_role() // triggers hole-punching
                     .build(),
             )?;
             self.swarm

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -11,18 +11,15 @@ use anyhow::{anyhow, Result};
 use cfg_if::cfg_if;
 use libp2p::{
     autonat,
-    core::upgrade,
-    dns,
     futures::StreamExt,
     gossipsub::{self, IdentTopic, MessageAuthenticity, TopicHash},
     identify,
     kad::{self, store::MemoryStore},
     mdns,
     multiaddr::{Multiaddr, Protocol},
-    noise,
     request_response::{self, OutboundFailure, ProtocolSupport},
-    swarm::{self, dial_opts::DialOpts, NetworkBehaviour, SwarmEvent},
-    tcp, yamux, PeerId, StreamProtocol, Swarm, Transport,
+    swarm::{dial_opts::DialOpts, NetworkBehaviour, SwarmEvent},
+    PeerId, StreamProtocol, Swarm,
 };
 use tokio::{
     select,
@@ -101,51 +98,45 @@ impl P2pNode {
         let peer_id = PeerId::from(key_pair.public());
         info!(%peer_id);
 
-        let transport = tcp::tokio::Transport::new(tcp::Config::default())
-            .upgrade(upgrade::Version::V1)
-            .authenticate(noise::Config::new(&key_pair)?)
-            .multiplex(yamux::Config::default())
-            .boxed();
-        let transport = dns::tokio::Transport::system(transport)?.boxed();
-
-        let behaviour = Behaviour {
-            request_response: request_response::cbor::Behaviour::new(
-                iter::once((StreamProtocol::new("/zq2-message/1"), ProtocolSupport::Full)),
-                Default::default(),
-            ),
-            gossipsub: gossipsub::Behaviour::new(
-                MessageAuthenticity::Signed(key_pair.clone()),
-                gossipsub::ConfigBuilder::default()
-                    .max_transmit_size(524288)
-                    .build()
+        let swarm = libp2p::SwarmBuilder::with_existing_identity(key_pair)
+            .with_tokio()
+            .with_quic()
+            .with_dns()?
+            .with_behaviour(|key_pair| {
+                Ok(Behaviour {
+                    request_response: request_response::cbor::Behaviour::new(
+                        iter::once((StreamProtocol::new("/zq2-message/1"), ProtocolSupport::Full)),
+                        Default::default(),
+                    ),
+                    gossipsub: gossipsub::Behaviour::new(
+                        MessageAuthenticity::Signed(key_pair.clone()),
+                        gossipsub::ConfigBuilder::default()
+                            .max_transmit_size(524288)
+                            .build()
+                            .map_err(|e| anyhow!(e))?,
+                    )
                     .map_err(|e| anyhow!(e))?,
-            )
-            .map_err(|e| anyhow!(e))?,
-            mdns: mdns::Behaviour::new(Default::default(), peer_id)?,
-            autonat: autonat::Behaviour::new(
-                peer_id,
-                autonat::Config {
-                    // Config changes to speed up autonat initialization. Set back to default if too aggressive.
-                    retry_interval: Duration::from_secs(10),
-                    refresh_interval: Duration::from_secs(30),
-                    boot_delay: Duration::from_secs(5),
-                    throttle_server_period: Duration::ZERO,
-                    ..Default::default()
-                },
-            ),
-            identify: identify::Behaviour::new(identify::Config::new(
-                "/ipfs/id/1.0.0".to_owned(),
-                key_pair.public(),
-            )),
-            kademlia: kad::Behaviour::new(peer_id, MemoryStore::new(peer_id)),
-        };
-
-        let swarm = Swarm::new(
-            transport,
-            behaviour,
-            peer_id,
-            swarm::Config::with_tokio_executor(),
-        );
+                    mdns: mdns::Behaviour::new(Default::default(), peer_id)?,
+                    autonat: autonat::Behaviour::new(
+                        peer_id,
+                        autonat::Config {
+                            // Config changes to speed up autonat initialization.
+                            // Set back to default if too aggressive.
+                            retry_interval: Duration::from_secs(10),
+                            refresh_interval: Duration::from_secs(30),
+                            boot_delay: Duration::from_secs(5),
+                            throttle_server_period: Duration::ZERO,
+                            ..Default::default()
+                        },
+                    ),
+                    identify: identify::Behaviour::new(identify::Config::new(
+                        "/ipfs/id/1.0.0".to_owned(),
+                        key_pair.public(),
+                    )),
+                    kademlia: kad::Behaviour::new(peer_id, MemoryStore::new(peer_id)),
+                })
+            })?
+            .build();
 
         Ok(Self {
             shard_nodes: HashMap::new(),
@@ -224,7 +215,8 @@ impl P2pNode {
 
     pub async fn start(&mut self) -> Result<()> {
         let mut addr: Multiaddr = "/ip4/0.0.0.0".parse().unwrap();
-        addr.push(Protocol::Tcp(self.config.p2p_port));
+        addr.push(Protocol::Udp(self.config.p2p_port));
+        addr.push(Protocol::QuicV1);
 
         self.swarm.listen_on(addr)?;
 

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -235,6 +235,7 @@ impl P2pNode {
             self.swarm.dial(
                 DialOpts::peer_id(*peer)
                     .addresses(vec![address.clone()])
+                    .override_role() // triggers hole-punching
                     .build(),
             )?;
             self.swarm


### PR DESCRIPTION
This PR changes the underlying swarm transport from TCP to QUIC. This is also recommended by [libp2p](https://connectivity.libp2p.io/) as QUIC is faster. This has been deployed in `zq2-devnet` successfully. This is a breaking change and the entire network needs to be upgraded to QUIC.