### PR TITLE
Mark blocks as canonical when we execute them

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2786,6 +2786,8 @@ impl Consensus {
             })?;
         }
 
+        self.db.mark_block_as_canonical(block.hash())?;
+
         // Tell the block store to request more blocks if it can.
         self.block_store.request_missing_blocks()?;
         Ok(())

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -613,6 +613,14 @@ impl Db {
         Ok(())
     }
 
+    pub fn mark_block_as_canonical(&self, hash: Hash) -> Result<()> {
+        self.block_store.lock().unwrap().execute(
+            "UPDATE blocks SET is_canonical = TRUE WHERE block_hash = ?1",
+            [hash],
+        )?;
+        Ok(())
+    }
+
     pub fn mark_block_as_non_canonical(&self, hash: Hash) -> Result<()> {
         self.block_store.lock().unwrap().execute(
             "UPDATE blocks SET is_canonical = FALSE WHERE block_hash = ?1",


### PR DESCRIPTION
Otherwise `deal_with_fork` gets into an infinite loop when re-executing blocks that were previously non-canonical, since `self.head_block()` is never updated.

I missed this when implementing #1449.