### PR TITLE
Pass health checks if any block is produced

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -69,7 +69,7 @@ def health():
     current_time = int(time())
     print (f"block {block_number} latest {latest_block_number}")
 
-    if block_number > latest_block_number:
+    if block_number != latest_block_number:
         latest_block_number = block_number
         latest_block_number_obtained_at = current_time
 


### PR DESCRIPTION
Previously, the check only passed if the latest returned block was greater than the previous one. Occasionally, we reset the devnet to an earlier block. This causes all the health checks to fail. So instead we just assert that the 'latest' block has changed within the last 60 seconds, even if the block number has decreased.