### PR TITLE
(feat) Run evm_scilla_js_tests with z2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,6 +102,8 @@ dependencies = [
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-serde",
+ "alloy-signer",
+ "alloy-signer-local",
 ]
 
 [[package]]
@@ -412,6 +414,22 @@ dependencies = [
  "auto_impl",
  "elliptic-curve",
  "k256",
+ "thiserror",
+]
+
+[[package]]
+name = "alloy-signer-local"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "494e0a256f3e99f2426f994bcd1be312c02cb8f88260088dacb33a8b8936475f"
+dependencies = [
+ "alloy-consensus",
+ "alloy-network",
+ "alloy-primitives",
+ "alloy-signer",
+ "async-trait",
+ "k256",
+ "rand",
  "thiserror",
 ]
 

--- a/evm_scilla_js_tests/README.z2.md
+++ b/evm_scilla_js_tests/README.z2.md
@@ -1,0 +1,22 @@
+# Running evm js tests with z2
+
+You can run these tests with your `z2 run` network.
+
+`z2 run /my/dir` will write:
+
+ * Include 32 accounts with secret keys `0x...10000` upwards in the genesis account set and write the private keys into `/my/dir/test.signers`
+ * Generate a file `/my/dir/test_env.sh` which you can `source` from your shell to set up for testing.
+
+`test_env.sh` sets environment variables which are tested in `hardhat.config.ts` to configure the test environment.
+
+With your network running, you can then do:
+
+```sh
+$ source /my/dir/test_env.sh
+$ npx hardhat test
+```
+
+See `README.md` for other hardhat options.
+
+By default, the RPC endpoint used is the `mitmproxy`'d endpoint, so `mitmproxy` will show you test traffic for debugging.
+

--- a/evm_scilla_js_tests/hardhat.config.ts
+++ b/evm_scilla_js_tests/hardhat.config.ts
@@ -31,7 +31,7 @@ declare module "hardhat/types/config" {
 
 const loadFromSignersFile = (network_name: string): string[] => {
   try {
-    return JSON.parse(fs.readFileSync(`.signers/${network_name}.json`, "utf8"));
+    return JSON.parse(fs.readFileSync(process.env.SIGNERS_FILE ?? `.signers/${network_name}.json`, "utf8"));
   } catch (error) {
     return [];
   }
@@ -39,7 +39,7 @@ const loadFromSignersFile = (network_name: string): string[] => {
 
 const config: HardhatUserConfig = {
   solidity: "0.8.9",
-  defaultNetwork: "isolated_server",
+  defaultNetwork: process.env.DEFAULT_NETWORK ?? "isolated_server",
 
   networks: {
     from_env: {

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -21,7 +21,7 @@ test = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-alloy = { version = "0.4.2", default-features = false, features = ["consensus", "rlp", "serde"] }
+alloy = { version = "0.4.2", default-features = false, features = ["consensus", "rlp", "serde", "signer-local"] }
 anyhow = "1.0.89"
 async-trait = "0.1.83"
 base64 = "0.22.0"

--- a/z2/resources/test_env.tera.sh
+++ b/z2/resources/test_env.tera.sh
@@ -1,0 +1,5 @@
+export SIGNERS_FILE={{signers_file}}
+export CHAIN_URL={{chain_url}}
+export CHAIN_ID={{chain_id}}
+export DEFAULT_NETWORK="from_env"
+


### PR DESCRIPTION
Some boilerplate to allow evm_scilla_js_tests to run in z2 networks; my next move is to try to get them to pass (including the Scilla library tests) - after that if you want it should be easy enough to add them to CICD.

Do say if you want an issue filed for reference here .. 