### PR TITLE
Fix converter crashing because of blank init data

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -198,11 +198,18 @@ fn get_contract_code(zq1_db: &zq1::Db, address: Address) -> Result<Code> {
             .map_err(|err| anyhow!("Unable to convert scilla initdata into string: {err}"))?,
         None => String::new(),
     };
+    let init_data_vec = if init_data.trim().is_empty() {
+        Vec::new()
+    } else {
+        serde_json::from_str::<Vec<ParamValue>>(&init_data).map_err(|err| {
+            anyhow!("Unable to convert scilla init data into Vec<ParamValue>: {init_data} - {err}")
+        })?
+    };
 
     Ok(Code::Scilla {
         code: String::from_utf8(code)
             .map_err(|err| anyhow!("Unable to convert scilla code into string: {err}"))?,
-        init_data: serde_json::from_str(&init_data)?,
+        init_data: init_data_vec,
         types: BTreeMap::default(),
         transitions: vec![],
     })


### PR DESCRIPTION
Converter with crashing with following error when we run on mainnet persistence.
```
Error: EOF while parsing a value at line 1 column 0

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
             at /home/chetan_zilliqa_com/.cargo/registry/src/index.crates.io-6f17d22bba15001f/anyhow-1.0.89/src/backtrace.rs:27:14
   1: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/result.rs:1989:27
   2: z2lib::converter::get_contract_code
             at ./z2/src/converter.rs:205:20
   3: z2lib::converter::convert_persistence::{{closure}}
             at ./z2/src/converter.rs:285:24
   4: z2lib::plumbing::run_persistence_converter::{{closure}}
             at ./z2/src/plumbing.rs:306:6
   5: z2::main::{{closure}}
             at ./z2/src/bin/z2.rs:773:18
   6: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/eeb90cda196```

This happened because of empty init data and the code crashed while parsing.