### PR TITLE
Adds placeholders for in-progress APIs, plus comments

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -624,3 +624,15 @@ pub struct RecentTransactionsResponse {
     pub txn_hashes: Vec<String>,
     pub number: u64,
 }
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct MinerInfo {
+    pub dscommittee: Vec<String>,
+    pub shards: Vec<ShardInfo>,
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct ShardInfo {
+    pub nodes: Vec<String>,
+    pub size: u64,
+}

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -1717,3 +1717,48 @@ async fn combined_total_coin_supply_test(mut network: Network) {
         "Total coin supply from string and int APIs should be the same"
     );
 }
+
+#[allow(dead_code)]
+async fn getminerinfo(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getnodetype(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getprevdifficulty(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getprevdsdifficulty(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getshardingstructure(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getsmartcontractsubstate(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getsoftconfirmedtransaction(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn getstateproof(mut _network: Network) {
+    todo!();
+}
+
+#[allow(dead_code)]
+async fn gettransactionstatus(mut _network: Network) {
+    todo!();
+}


### PR DESCRIPTION
This is a bit of a housekeeping PR - it shouldn't change functionality substantially.

I've added placeholder API functions and tests for 9 API endpoints. This is intended to make merging easier by avoiding the situation where I have a PR for one API endpoint in flight, but get merge conflicts if I try to start work on another because they're both adding to the end of the file. This approach of adding placeholders avoids the alternative of creating loads of separate files.

In addition, I've done the same thing for tests, added the return type for getminerinfo, and added comments to API endpoint functions indicating what API endpoint they service.

@JamesHinshelwood Hopefully this avoids your concerns about making things more complicated with lots of files, while still making merges easier.