### PR TITLE
BREAKING CHANGE: Persist node's current view in the database

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -328,7 +328,7 @@ pub async fn convert_persistence(
         .get_tx_blocks_aux("MaxTxBlockNumber")?
         .unwrap_or_default();
 
-    let current_block = zq2_db.get_latest_finalized_view()?.unwrap_or(1);
+    let current_block = zq2_db.get_finalized_view()?.unwrap_or(1);
 
     let progress = ProgressBar::new(max_block)
         .with_style(style.clone())
@@ -451,7 +451,7 @@ pub async fn convert_persistence(
         zq2_db.with_sqlite_tx(|sqlite_tx| {
             zq2_db.insert_block_with_db_tx(sqlite_tx, &block)?;
             zq2_db.set_high_qc_with_db_tx(sqlite_tx, block.header.qc)?;
-            zq2_db.set_latest_finalized_view_with_db_tx(sqlite_tx, block.view())?;
+            zq2_db.set_finalized_view_with_db_tx(sqlite_tx, block.view())?;
             trace!("{} block inserted", block.number());
 
             for (hash, transaction) in &transactions {

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -325,7 +325,7 @@ impl Consensus {
 
                     // If current_view was written to disk then always start from there. Otherwise start from (highest out of high block and finalised block) + 1
                     let start_view = db
-                        .get_current_view()?
+                        .get_latest_view()?
                         .or_else(|| {
                             Some(std::cmp::max(high_block.view(), finalized_block.view()) + 1)
                         })
@@ -334,9 +334,9 @@ impl Consensus {
                     let mut view = View::new(start_view);
 
                     // If timestamp of when current view was written exists then use it to estimate the minimum number of blocks the network has moved on since shut down
-                    if let Some(current_view_timestamp) = db.get_current_view_timestamp()? {
+                    if let Some(latest_view_timestamp) = db.get_latest_view_timestamp()? {
                         view.update_view_after_being_inactive(
-                            current_view_timestamp.elapsed()?,
+                            latest_view_timestamp.elapsed()?,
                             config.consensus.consensus_timeout.as_millis() as u64,
                         );
                     }
@@ -2592,7 +2592,7 @@ impl Consensus {
     /// Set view in memory and update tip_info.current_view in storage
     pub fn set_view(&mut self, view: u64) -> Result<()> {
         if self.view.set_view(view) {
-            self.db.set_current_view(view)?;
+            self.db.set_latest_view(view)?;
         }
         Ok(())
     }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -240,7 +240,7 @@ impl View {
             .checked_ilog2()
             .unwrap_or(0);
         info!(
-            "Based on elapsed clock time of {} seconds since last view update jump ahead {} views",
+            "Based on elapsed clock time of {} seconds since lastest view update, jump ahead {} views",
             time_difference.as_secs(),
             view_difference
         );
@@ -323,7 +323,7 @@ impl Consensus {
                         .get_block_by_view(finalized_number)?
                         .ok_or_else(|| anyhow!("missing finalized block!"))?;
 
-                    // If current_view was written to disk then always start from there. Otherwise start from (highest out of high block and finalised block) + 1
+                    // If latest view was written to disk then always start from there. Otherwise start from (highest out of high block and finalised block) + 1
                     let start_view = db
                         .get_latest_view()?
                         .or_else(|| {
@@ -2589,7 +2589,7 @@ impl Consensus {
         self.view.get_view()
     }
 
-    /// Set view in memory and update tip_info.current_view in storage
+    /// Set view in memory and update tip_info.latest_view in storage
     pub fn set_view(&mut self, view: u64) -> Result<()> {
         if self.view.set_view(view) {
             self.db.set_latest_view(view)?;
@@ -3256,7 +3256,7 @@ mod tests {
     #[test]
     fn test_view_backout_timeout() {
         let mut view = View::new(10);
-        assert_eq!(view.exponential_backoff_timeout(view.get_view() - 0, 1), 1);
+        assert_eq!(view.exponential_backoff_timeout(view.get_view(), 1), 1);
         assert_eq!(view.exponential_backoff_timeout(view.get_view() - 1, 1), 1);
         assert_eq!(view.exponential_backoff_timeout(view.get_view() - 2, 1), 1);
         assert_eq!(view.exponential_backoff_timeout(view.get_view() - 3, 1), 2);

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -296,7 +296,13 @@ impl Consensus {
                         .get_block_by_view(finalized_number)?
                         .ok_or_else(|| anyhow!("missing finalized block!"))?;
 
-                    let start_view = std::cmp::max(high_block.view(), finalized_block.view()) + 1;
+                    let mut start_view =
+                        std::cmp::max(high_block.view(), finalized_block.view()) + 1;
+                    // If current_view was written then always start from there
+                    if let Some(current_view) = db.get_current_view()? {
+                        start_view = current_view;
+                    }
+
                     trace!(
                         "recovery: high_block view {0}, finalized_number {1} , start_view {2}",
                         high_block.view(),

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2570,7 +2570,7 @@ impl Consensus {
             time_difference.as_secs(),
             views
         );
-        return views as u64;
+        views as u64
     }
 
     pub fn state(&self) -> &State {

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -524,7 +524,8 @@ impl Db {
             .lock()
             .unwrap()
             .query_row("SELECT latest_view FROM tip_info", (), |row| row.get(0))
-            .optional()?)
+            .optional()
+            .unwrap_or(None))
     }
 
     pub fn get_latest_view_timestamp(&self) -> Result<Option<SystemTime>> {
@@ -535,7 +536,8 @@ impl Db {
             .query_row("SELECT latest_view_timestamp FROM tip_info", (), |row| {
                 row.get::<_, SystemTimeSqlable>(0)
             })
-            .optional()?
+            .optional()
+            .unwrap_or(None)
             .map(Into::<SystemTime>::into))
     }
 

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -253,8 +253,8 @@ impl Db {
                 PRIMARY KEY (address, tx_hash));
             CREATE TABLE IF NOT EXISTS tip_info (
                 latest_finalized_view INTEGER,
-                current_view INTEGER,
-                current_view_timestamp BLOB,
+                latest_view INTEGER,
+                latest_view_timestamp BLOB,
                 high_qc BLOB,
                 _single_row INTEGER DEFAULT 0 NOT NULL UNIQUE CHECK (_single_row = 0)); -- max 1 row
             CREATE TABLE IF NOT EXISTS state_trie (key BLOB NOT NULL PRIMARY KEY, value BLOB NOT NULL);
@@ -442,7 +442,7 @@ impl Db {
             self.insert_block_with_db_tx(tx, parent_ref)?;
             self.set_latest_finalized_view_with_db_tx(tx, parent_ref.view())?;
             self.set_high_qc_with_db_tx(tx, block.header.qc)?;
-            self.set_current_view_with_db_tx(tx, parent_ref.view() + 1)?;
+            self.set_latest_view_with_db_tx(tx, parent_ref.view() + 1)?;
             Ok(())
         })?;
 
@@ -503,9 +503,9 @@ impl Db {
             .optional()?)
     }
 
-    pub fn set_current_view_with_db_tx(&self, sqlite_tx: &Connection, view: u64) -> Result<()> {
+    pub fn set_latest_view_with_db_tx(&self, sqlite_tx: &Connection, view: u64) -> Result<()> {
         sqlite_tx
-            .execute("INSERT INTO tip_info (current_view, current_view_timestamp) VALUES (:view, :timestamp) ON CONFLICT DO UPDATE SET current_view = :view, current_view_timestamp = :timestamp",
+            .execute("INSERT INTO tip_info (latest_view, latest_view_timestamp) VALUES (:view, :timestamp) ON CONFLICT DO UPDATE SET latest_view = :view, latest_view_timestamp = :timestamp",
                     named_params! {
                         ":view": view,
                         ":timestamp": SystemTimeSqlable(SystemTime::now())
@@ -513,29 +513,29 @@ impl Db {
         Ok(())
     }
 
-    pub fn set_current_view(&self, view: u64) -> Result<()> {
-        self.set_current_view_with_db_tx(&self.db.lock().unwrap(), view)
+    pub fn set_latest_view(&self, view: u64) -> Result<()> {
+        self.set_latest_view_with_db_tx(&self.db.lock().unwrap(), view)
     }
 
-    pub fn get_current_view(&self) -> Result<Option<u64>> {
+    pub fn get_latest_view(&self) -> Result<Option<u64>> {
         Ok(self
             .db
             .lock()
             .unwrap()
-            .query_row("SELECT current_view FROM tip_info", (), |row| row.get(0))
+            .query_row("SELECT latest_view FROM tip_info", (), |row| row.get(0))
             .optional()?)
     }
 
-    pub fn get_current_view_timestamp(&self) -> Result<Option<SystemTime>> {
+    pub fn get_latest_view_timestamp(&self) -> Result<Option<SystemTime>> {
         Ok(self
             .db
             .lock()
             .unwrap()
-            .query_row("SELECT current_view_timestamp FROM tip_info", (), |row| {
+            .query_row("SELECT latest_view_timestamp FROM tip_info", (), |row| {
                 row.get::<_, SystemTimeSqlable>(0)
             })
             .optional()?
-            .map(|val| Into::<SystemTime>::into(val)))
+            .map(Into::<SystemTime>::into))
     }
 
     // Deliberately not named get_highest_block_number() because there used to be one

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -865,8 +865,8 @@ impl Node {
         self.consensus.finalized_view()
     }
 
-    pub fn get_current_view(&self) -> u64 {
-        self.consensus.view()
+    pub fn get_current_view(&self) -> Result<u64> {
+        self.consensus.get_view()
     }
 
     pub fn get_transaction_receipt(&self, tx_hash: Hash) -> Result<Option<TransactionReceipt>> {

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -865,6 +865,10 @@ impl Node {
         self.consensus.finalized_view()
     }
 
+    pub fn get_currnet_view(&self) -> u64 {
+        self.consensus.view()
+    }
+
     pub fn get_transaction_receipt(&self, tx_hash: Hash) -> Result<Option<TransactionReceipt>> {
         self.consensus.get_transaction_receipt(&tx_hash)
     }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -430,7 +430,7 @@ impl Node {
             BlockNumberOrTag::Latest => Ok(Some(self.consensus.head_block())),
             BlockNumberOrTag::Pending => self.consensus.get_pending_block(),
             BlockNumberOrTag::Finalized => {
-                let Some(view) = self.db.get_latest_finalized_view()? else {
+                let Some(view) = self.db.get_finalized_view()? else {
                     return self.resolve_block_number(BlockNumberOrTag::Earliest);
                 };
                 let Some(block) = self.db.get_block_by_view(view)? else {
@@ -861,8 +861,8 @@ impl Node {
         self.db.get_transaction_receipts_in_block(&block_hash)
     }
 
-    pub fn get_finalized_height(&self) -> u64 {
-        self.consensus.finalized_view()
+    pub fn get_finalized_height(&self) -> Result<u64> {
+        self.consensus.get_finalized_view()
     }
 
     pub fn get_current_view(&self) -> Result<u64> {

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -865,7 +865,7 @@ impl Node {
         self.consensus.finalized_view()
     }
 
-    pub fn get_currnet_view(&self) -> u64 {
+    pub fn get_current_view(&self) -> u64 {
         self.consensus.view()
     }
 

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -21,7 +21,7 @@ async fn network_can_die_restart(mut network: Network) {
         .run_until(
             |n| {
                 let index = n.random_index();
-                n.get_node(index).get_finalized_height() >= start_block
+                n.get_node(index).get_finalized_height().unwrap() >= start_block
             },
             100,
         )
@@ -36,7 +36,7 @@ async fn network_can_die_restart(mut network: Network) {
         .run_until(
             |n| {
                 let index = n.random_index();
-                n.get_node(index).get_finalized_height() >= finish_block
+                n.get_node(index).get_finalized_height().unwrap() >= finish_block
             },
             1000,
         )
@@ -46,7 +46,7 @@ async fn network_can_die_restart(mut network: Network) {
 
 fn get_block_number(n: &mut Network) -> u64 {
     let index = n.random_index();
-    n.get_node(index).get_finalized_height()
+    n.get_node(index).get_finalized_height().unwrap()
 }
 
 // test that even with some consensus messages being dropped, the network can still proceed
@@ -63,7 +63,7 @@ async fn block_production_even_when_lossy_network(mut network: Network) {
         .run_until(
             |n| {
                 let index = n.random_index();
-                n.get_node(index).get_finalized_height() >= start_block
+                n.get_node(index).get_finalized_height().unwrap() >= start_block
             },
             100,
         )
@@ -136,7 +136,7 @@ async fn handle_forking_correctly(mut network: Network) {
         .run_until(
             |n| {
                 let index = n.random_index();
-                n.get_node(index).get_finalized_height() >= start_block
+                n.get_node(index).get_finalized_height().unwrap() >= start_block
             },
             100,
         )

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -82,7 +82,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
     let last_block = inner.get_block(last_number).unwrap().unwrap();
     let tx = inner.get_transaction_by_hash(hash).unwrap().unwrap();
     let current_view = inner.get_current_view().unwrap();
-    let finalized_view = inner.get_finalized_height();
+    let finalized_view = inner.get_finalized_height().unwrap();
     // sanity check
     assert_eq!(tx.hash, hash);
     assert_eq!(block_with_tx.transactions.len(), 1);
@@ -173,7 +173,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
 
     // ensure were back on the same view
     assert_eq!(current_view, inner.get_current_view().unwrap());
-    assert_eq!(finalized_view, inner.get_finalized_height());
+    assert_eq!(finalized_view, inner.get_finalized_height().unwrap());
 }
 
 #[zilliqa_macros::test(do_checkpoints)]

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -81,7 +81,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
     let block_with_tx = inner.get_block(receipt.block_hash).unwrap().unwrap();
     let last_block = inner.get_block(last_number).unwrap().unwrap();
     let tx = inner.get_transaction_by_hash(hash).unwrap().unwrap();
-    let current_view = inner.get_currnet_view();
+    let current_view = inner.get_current_view();
     let finalized_view = inner.get_finalized_height();
     // sanity check
     assert_eq!(tx.hash, hash);
@@ -172,7 +172,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
     );
 
     // ensure were back on the same view
-    assert_eq!(current_view, inner.get_currnet_view());
+    assert_eq!(current_view, inner.get_current_view());
     assert_eq!(finalized_view, inner.get_finalized_height());
 }
 

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -81,7 +81,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
     let block_with_tx = inner.get_block(receipt.block_hash).unwrap().unwrap();
     let last_block = inner.get_block(last_number).unwrap().unwrap();
     let tx = inner.get_transaction_by_hash(hash).unwrap().unwrap();
-    let current_view = inner.get_current_view();
+    let current_view = inner.get_current_view().unwrap();
     let finalized_view = inner.get_finalized_height();
     // sanity check
     assert_eq!(tx.hash, hash);
@@ -172,7 +172,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
     );
 
     // ensure were back on the same view
-    assert_eq!(current_view, inner.get_current_view());
+    assert_eq!(current_view, inner.get_current_view().unwrap());
     assert_eq!(finalized_view, inner.get_finalized_height());
 }
 


### PR DESCRIPTION
Closes https://github.com/Zilliqa/zq2/issues/1609 and https://github.com/Zilliqa/zq2/issues/1709.

For the purpose of reducing re-sync time after consensus has not been reached for a while. 

For example, before these changes a node on `view: 30` with `finalised_view: 10` would start from `view: 10` if restarted. Now, they'll start back on `view :30`. If enough time has passed since they went down then they will jump ahead the minimum number of views.

These changes make breaking changes to the db