### PR TITLE
(fix) Fix otterscan invocation so that it will run the first time

### DIFF
--- a/z2/runtime/start_otterscan.sh
+++ b/z2/runtime/start_otterscan.sh
@@ -1,5 +1,8 @@
 #! /bin/bash
 
 npm install
+if [ -x "scripts/gen-version.sh" ]; then
+    ./scripts/gen-version.sh autogen/version.ts
+fi
 npm run assets-start
 exec npx vite --port $PORT


### PR DESCRIPTION
Just runs the version stamp script if it sees one, to make sure the version file exists when otterscan tries to look for it later on.