### PR TITLE
Put qcs in an aggregate in order to enable validation

### DIFF
--- a/z2/src/perf.rs
+++ b/z2/src/perf.rs
@@ -293,8 +293,8 @@ pub struct ConformConfig {
 
 impl Perf {
     pub fn from_file(config_file: &str) -> Result<Self> {
-        let file_contents =
-            fs::read_to_string(config_file).context("Cannot read configuration {config_file}")?;
+        let file_contents = fs::read_to_string(config_file)
+            .context(format!("Cannot read configuration {config_file}"))?;
         let config_obj: Config = serde_yaml::from_str(&file_contents)?;
         let provider = Provider::<Http>::try_from(config_obj.rpc_url.as_str())?;
         let source_of_funds = config_obj

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -46,6 +46,9 @@ const DATADIR_PREFIX: &str = "z2_node_";
 const NETWORK_CONFIG_FILE_NAME: &str = "network.yaml";
 const ZQ2_CONFIG_FILE_NAME: &str = "config.toml";
 const CHAIN_ID: u64 = 700;
+const ONE_MILLION: u128 = 1_000_000u128;
+const ONE_ETH: u128 = ONE_MILLION * ONE_MILLION * ONE_MILLION;
+const ONE_BILLION: u128 = 1_000u128 * ONE_MILLION;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct NodeData {
@@ -418,27 +421,27 @@ impl Setup {
         let mut genesis_accounts: Vec<(Address, Amount)> = vec![
             (
                 address!("7E5F4552091A69125d5DfCb7b8C2659029395Bdf"),
-                5000000000000000000000u128.into(),
+                zilliqa::cfg::Amount(2u128 * ONE_BILLION * ONE_ETH),
             ),
             // privkey db11cfa086b92497c8ed5a4cc6edb3a5bfe3a640c43ffb9fc6aa0873c56f2ee3
             (
                 address!("cb57ec3f064a16cadb36c7c712f4c9fa62b77415"),
-                5000000000000000000000u128.into(),
+                zilliqa::cfg::Amount(2u128 * ONE_BILLION * ONE_ETH),
             ),
             // e53d1c3edaffc7a7bab5418eb836cf75819a82872b4a1a0f1c7fcf5c3e020b89
             (
                 address!("2ce2dbd623b3c277fae4074f0b2605e624510e20"),
-                5000000000000000000000u128.into(),
+                zilliqa::cfg::Amount(2u128 * ONE_BILLION * ONE_ETH),
             ),
             // d96e9eb5b782a80ea153c937fa83e5948485fbfc8b7e7c069d7b914dbc350aba
             (
                 address!("f0cb24ac66ba7375bf9b9c4fa91e208d9eaabd2e"),
-                5000000000000000000000u128.into(),
+                zilliqa::cfg::Amount(2u128 * ONE_BILLION * ONE_ETH),
             ),
             // 589417286a3213dceb37f8f89bd164c3505a4cec9200c61f7c6db13a30a71b45
             (
                 address!("cf671756a8238cbeb19bcb4d77fc9091e2fce1a3"),
-                5000000000000000000000u128.into(),
+                zilliqa::cfg::Amount(2u128 * ONE_BILLION * ONE_ETH),
             ),
         ];
 


### PR DESCRIPTION
(fix) consensus.rs: Put qcs in an aggregate in committee index order so that they will always validate.
(fix) perf.rs: format!() the error message correctly.
(feat) setup.ts: Give genesis accounts a decent quantity of tokens so they can be used for load tests

Relates to #1570 