### PR TITLE
Fix overflow in `create_transaction_errors` test

### DIFF
--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -351,7 +351,7 @@ async fn run_create_transaction_api_for_error(
     let mut signature = schnorr::sign(&txn_data, secret_key).to_bytes();
     if bad_signature {
         if let Some(x) = signature.first_mut() {
-            *x += 1;
+            *x = x.wrapping_add(1);
         }
     }
     let mut request = json!({


### PR DESCRIPTION
This bug causes 1/256th of test runs to fail with overflow checks enabled.