### PR TITLE
Add getter and setter functions to `Deposit` contract

### DIFF
--- a/zilliqa/src/contracts/deposit.sol
+++ b/zilliqa/src/contracts/deposit.sol
@@ -163,6 +163,12 @@ contract Deposit {
 
     uint64 public blocksPerEpoch;
 
+    modifier onlyControlAddress(bytes calldata blsPubKey) {
+        require(blsPubKey.length == 48);
+        require(_stakersMap[blsPubKey].controlAddress == msg.sender, "sender is not the control address");
+        _;
+    }
+
     constructor(
         uint256 _minimumStake,
         uint256 _maximumStakers,
@@ -273,6 +279,10 @@ contract Deposit {
         return committee().stakerKeys;
     }
 
+    function getTotalStake() public view returns (uint256) {
+        return committee().totalStake;
+    }
+
     function getStakersData()
         public
         view
@@ -309,6 +319,30 @@ contract Deposit {
             revert("not staked");
         }
         return _stakersMap[blsPubKey].rewardAddress;
+    }
+
+    function getControlAddress(
+        bytes calldata blsPubKey
+    ) public view returns (address) {
+        require(blsPubKey.length == 48);
+        if (_stakersMap[blsPubKey].controlAddress == address(0)) {
+            revert("not staked");
+        }
+        return _stakersMap[blsPubKey].controlAddress;
+    }
+
+    function setRewardAddress(
+        bytes calldata blsPubKey,
+        address rewardAddress
+    ) public onlyControlAddress(blsPubKey) {
+        _stakersMap[blsPubKey].rewardAddress = rewardAddress;
+    }
+
+    function setControlAddress(
+        bytes calldata blsPubKey,
+        address controlAddress
+    ) public onlyControlAddress(blsPubKey) {
+        _stakersMap[blsPubKey].controlAddress = controlAddress;
     }
 
     function getPeerId(

--- a/zilliqa/src/contracts/deposit.sol
+++ b/zilliqa/src/contracts/deposit.sol
@@ -165,7 +165,10 @@ contract Deposit {
 
     modifier onlyControlAddress(bytes calldata blsPubKey) {
         require(blsPubKey.length == 48);
-        require(_stakersMap[blsPubKey].controlAddress == msg.sender, "sender is not the control address");
+        require(
+            _stakersMap[blsPubKey].controlAddress == msg.sender,
+            "sender is not the control address"
+        );
         _;
     }
 

--- a/zilliqa/tests/it/staking.rs
+++ b/zilliqa/tests/it/staking.rs
@@ -443,7 +443,7 @@ async fn validators_can_unstake(mut network: Network) {
 // TODO: Tests for:
 // * partial unstaking staying above the minimum
 // * partial unstaking under the minimum (should fail)
-// * increase stake
-// * updating staker details (reward address)
+// * increase stake (deposit topup)
+// * updating staker details (reward address, control address)
 // * disallow access to callers other than the controlAddress
 // * withdraw stake after 2 weeks (exercise the circular buffer logic or test it separately if difficult to do here)


### PR DESCRIPTION
Implement `getTotalStake()` as per #1745, `getControlAddress()` as per #1746, as well as `setControlAddress()` and `setRewardAddress()` as defined in #1301 