### PR TITLE
Some GetTransaction bugfixes

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -202,68 +202,48 @@ impl GetTxResponse {
             SignedTransaction::Zilliqa { tx, sig, key } => (
                 ((tx.chain_id as u32) << 16) | 1,
                 tx.to_addr,
-                key.to_encoded_point(true)
-                    .as_bytes()
-                    .to_hex()
-                    .to_uppercase(),
-                <[u8; 64]>::from(sig.to_bytes()).to_hex().to_uppercase(),
+                key.to_encoded_point(true).as_bytes().to_hex(),
+                <[u8; 64]>::from(sig.to_bytes()).to_hex(),
                 (!tx.code.is_empty()).then_some(tx.code),
-                (!tx.data.is_empty())
-                    .then_some(tx.data)
-                    .map(|x| x.to_uppercase()),
+                (!tx.data.is_empty()).then_some(tx.data),
             ),
             SignedTransaction::Legacy { tx, sig } => (
                 ((tx.chain_id.unwrap_or_default() as u32) << 16) | 2,
                 tx.to.to().copied().unwrap_or_default(),
                 sig.recover_from_prehash(&tx.signature_hash())?
                     .to_sec1_bytes()
-                    .to_hex()
-                    .to_uppercase(),
-                sig.as_bytes().to_hex().to_uppercase(),
+                    .to_hex(),
+                sig.as_bytes().to_hex(),
                 tx.to.is_create().then(|| hex::encode(&tx.input)),
-                tx.to
-                    .is_call()
-                    .then(|| hex::encode(&tx.input))
-                    .map(|x| x.to_uppercase()),
+                tx.to.is_call().then(|| hex::encode(&tx.input)),
             ),
             SignedTransaction::Eip2930 { tx, sig } => (
                 ((tx.chain_id as u32) << 16) | 3,
                 tx.to.to().copied().unwrap_or_default(),
                 sig.recover_from_prehash(&tx.signature_hash())?
                     .to_sec1_bytes()
-                    .to_hex()
-                    .to_uppercase(),
-                sig.as_bytes().to_hex().to_uppercase(),
+                    .to_hex(),
+                sig.as_bytes().to_hex(),
                 tx.to.is_create().then(|| hex::encode(&tx.input)),
-                tx.to
-                    .is_call()
-                    .then(|| hex::encode(&tx.input))
-                    .map(|x| x.to_uppercase()),
+                tx.to.is_call().then(|| hex::encode(&tx.input)),
             ),
             SignedTransaction::Eip1559 { tx, sig } => (
                 ((tx.chain_id as u32) << 16) | 4,
                 tx.to.to().copied().unwrap_or_default(),
                 sig.recover_from_prehash(&tx.signature_hash())?
                     .to_sec1_bytes()
-                    .to_hex()
-                    .to_uppercase(),
-                sig.as_bytes().to_hex().to_uppercase(),
+                    .to_hex(),
+                sig.as_bytes().to_hex(),
                 tx.to.is_create().then(|| hex::encode(&tx.input)),
-                tx.to
-                    .is_call()
-                    .then(|| hex::encode(&tx.input))
-                    .map(|x| x.to_uppercase()),
+                tx.to.is_call().then(|| hex::encode(&tx.input)),
             ),
             SignedTransaction::Intershard { tx, .. } => (
                 ((tx.chain_id as u32) << 16) | 20,
                 tx.to_addr.unwrap_or_default(),
-                String::new().to_uppercase(),
-                String::new().to_uppercase(),
+                String::new(),
+                String::new(),
                 tx.to_addr.is_none().then(|| hex::encode(&tx.payload)),
-                tx.to_addr
-                    .is_some()
-                    .then(|| hex::encode(&tx.payload))
-                    .map(|x| x.to_uppercase()),
+                tx.to_addr.is_some().then(|| hex::encode(&tx.payload)),
             ),
         };
 

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -198,6 +198,7 @@ impl GetTxResponse {
         let amount = tx.tx.zil_amount();
         let gas_price = tx.tx.gas_price_per_scilla_gas();
         let gas_limit = tx.tx.gas_limit_scilla();
+        // Some of these are returned as all caps in ZQ1, but that should be fine
         let (version, to_addr, sender_pub_key, signature, code, data) = match tx.tx {
             SignedTransaction::Zilliqa { tx, sig, key } => (
                 ((tx.chain_id as u32) << 16) | 1,

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -174,13 +174,11 @@ pub struct EventLog {
 
 #[derive(Clone, Serialize, Debug)]
 struct GetTxResponseReceipt {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    accepted: Option<bool>,
+    accepted: bool,
     #[serde(with = "num_as_str")]
     cumulative_gas: ScillaGas,
     #[serde(with = "num_as_str")]
     epoch_num: u64,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
     transitions: Vec<Transition>,
     event_logs: Vec<EventLog>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty")]
@@ -200,7 +198,6 @@ impl GetTxResponse {
         let amount = tx.tx.zil_amount();
         let gas_price = tx.tx.gas_price_per_scilla_gas();
         let gas_limit = tx.tx.gas_limit_scilla();
-        // ZQ1 returns keys, signature and data in all caps here so we do the same
         let (version, to_addr, sender_pub_key, signature, code, data) = match tx.tx {
             SignedTransaction::Zilliqa { tx, sig, key } => (
                 ((tx.chain_id as u32) << 16) | 1,
@@ -291,7 +288,7 @@ impl GetTxResponse {
                     })
                     .collect(),
                 success: receipt.success,
-                accepted: receipt.accepted,
+                accepted: receipt.accepted.unwrap_or(false),
                 errors: receipt
                     .errors
                     .into_iter()

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -559,6 +559,63 @@ async fn create_transaction_errors(mut network: Network) {
     }
 }
 
+#[zilliqa_macros::test]
+async fn get_transaction(mut network: Network) {
+    let wallet = network.random_wallet().await;
+
+    // Create a Zilliqa account and get its secret key and address
+    let (secret_key, _address) = zilliqa_account(&mut network).await;
+
+    // Define the recipient address
+    let to_addr: H160 = "0x00000000000000000000000000000000deadbeef"
+        .parse()
+        .unwrap();
+
+    // Send a transaction
+    let (_contract_address, returned_transaction) = send_transaction(
+        &mut network,
+        &secret_key,
+        1,
+        ToAddr::Address(to_addr),
+        200u128 * 10u128.pow(12),
+        50_000,
+        None,
+        None,
+    )
+    .await;
+
+    // Get the transaction ID from the returned transaction
+    let transaction_id = returned_transaction["ID"]
+        .as_str()
+        .expect("Failed to get ID from response");
+
+    // Wait for the transaction to be mined
+    network.run_until_block(&wallet, 1.into(), 50).await;
+
+    // Use the GetTransaction API to retrieve the transaction details
+    let response: Value = wallet
+        .provider()
+        .request("GetTransaction", [transaction_id])
+        .await
+        .expect("Failed to call GetTransaction API");
+
+    // Check the string formats
+    assert!(!response["ID"].as_str().unwrap().starts_with("0x"));
+    assert!(!response["toAddr"].as_str().unwrap().starts_with("0x"));
+    assert!(response["senderPubKey"].as_str().unwrap().starts_with("0x"));
+    assert!(response["signature"].as_str().unwrap().starts_with("0x"));
+
+    // Verify the transaction details
+    assert_eq!(response["ID"].as_str().unwrap(), transaction_id);
+    assert_eq!(response["toAddr"].as_str().unwrap(), hex::encode(to_addr),);
+    assert_eq!(response["amount"].as_str().unwrap(), "200000000000000");
+    assert_eq!(response["gasLimit"].as_str().unwrap(), "50000");
+    assert_eq!(
+        response["senderPubKey"].as_str().unwrap(),
+        format!("0x{}", hex::encode(secret_key.public_key().to_sec1_bytes()))
+    );
+}
+
 // We need to restrict the concurrency level of this test, because each node in the network will spawn a TCP listener
 // once it invokes Scilla. When many tests are run in parallel, this results in "Too many open files" errors.
 #[zilliqa_macros::test(restrict_concurrency)]

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -599,6 +599,11 @@ async fn get_transaction(mut network: Network) {
         .await
         .expect("Failed to call GetTransaction API");
 
+    // Check for keys
+    assert!(response["receipt"]["success"].is_boolean());
+    assert!(response["receipt"]["event_logs"].is_array());
+    assert!(response["receipt"]["transitions"].is_array());
+
     // Check the string formats
     assert!(!response["ID"].as_str().unwrap().starts_with("0x"));
     assert!(!response["toAddr"].as_str().unwrap().starts_with("0x"));


### PR DESCRIPTION
- event logs field now always returned
- accepted field now always returned
- transitions field now always returned
- added test

Not addressed:
- nonces sometimes different (looks like its outside the API code)
- invalid signature errors (looks like its outside the API code)
- version different (presumed acceptable)
- capitalisation different (presumed acceptable)
- cumulative_gas sometimes zero (looks like its outside the API code)

Relates to #1666