### PR TITLE
Group related dependabot updates together

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,3 +19,13 @@ updates:
         - dependency-name: "semver"
         - dependency-name: "crates-io"
     open-pull-requests-limit: 100
+    groups:
+      opentelemetry:
+        applies-to: version-updates
+        patterns:
+          - "opentelemetry*"
+      alloy-revm:
+        applies-to: version-updates
+        patterns:
+          - "alloy*"
+          - "revm*"


### PR DESCRIPTION
Often these dependencies need to updated in lock-step to compile (since they have public dependencies on each other).