### PR TITLE
Changed version returned by get_tx_block from 2 to 1, to match ZQ1

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -37,7 +37,7 @@ impl TxBlock {
         scalar[31] = 1;
         TxBlock {
             header: TxBlockHeader {
-                version: 2,                                    // ZQ2
+                version: 1,                                    // To match ZQ1
                 gas_limit: ScillaGas::from(block.gas_limit()), // In Scilla
                 gas_used: ScillaGas::from(block.gas_used()),   // In Scilla
                 rewards: 0,


### PR DESCRIPTION
Following on from discussion here: https://github.com/Zilliqa/zq2/pull/1752#discussion_r1834692023

This sets the version field to 1, as was reported to be returned by ZQ1 here: https://github.com/Zilliqa/zq2/issues/1676

