### PR TITLE
Faster vote handling

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2797,14 +2797,14 @@ impl Consensus {
             return *stake;
         }
 
+        // keep cache small
+        if self.stake_cache.len() == 10 {
+            self.stake_cache.pop_first(); // remove oldest block stake
+        }
+
         // populate cache
         let stake = self.total_weight_raw(executed_block);
         self.stake_cache.insert(executed_block.number, stake);
-
-        // keep cache small
-        while self.stake_cache.len() > 10 {
-            self.stake_cache.pop_first(); // remove oldest block stake
-        }
 
         stake
     }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2787,18 +2787,8 @@ impl Consensus {
         })
     }
 
-    fn total_weight(&self, committee: &[NodePublicKey], executed_block: BlockHeader) -> u128 {
-        committee
-            .iter()
-            .map(|&pub_key| {
-                let stake = self
-                    .state
-                    .get_stake(pub_key, executed_block)
-                    .unwrap()
-                    .unwrap();
-                stake.get()
-            })
-            .sum()
+    fn total_weight(&self, _committee: &[NodePublicKey], executed_block: BlockHeader) -> u128 {
+        self.state.get_total_stake(executed_block).unwrap().unwrap().into()
     }
 
     /// Deal with the fork to this block. The block is assumed to be valid to switch to.

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1109,7 +1109,9 @@ impl Consensus {
         }
 
         // Either way assemble early proposal now if it doesnt already exist
-        self.early_proposal_assemble_at(None)?;
+        if self.transaction_pool.has_txn_ready() {
+            self.early_proposal_assemble_at(None)?;
+        }
 
         Ok(None)
     }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1159,9 +1159,7 @@ impl Consensus {
         }
 
         // Either way assemble early proposal now if it doesnt already exist
-        if self.transaction_pool.has_txn_ready() {
-            self.early_proposal_assemble_at(None)?;
-        }
+        self.early_proposal_assemble_at(None)?;
 
         Ok(None)
     }

--- a/zilliqa/src/contracts/mod.rs
+++ b/zilliqa/src/contracts/mod.rs
@@ -34,6 +34,8 @@ pub mod deposit {
         Lazy::new(|| CONTRACT.abi.function("minimumStake").unwrap().clone());
     pub static COMMITTEE: Lazy<Function> =
         Lazy::new(|| CONTRACT.abi.function("committee").unwrap().clone());
+    pub static GET_TOTAL_STAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getTotalStake").unwrap().clone());
 }
 
 pub mod shard {

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -734,7 +734,7 @@ impl State {
         )
     }
 
-    pub fn get_stakers(&self, current_block: BlockHeader) -> Result<Vec<NodePublicKey>> {
+    pub fn get_stakers_raw(&self, current_block: BlockHeader) -> Result<Vec<NodePublicKey>> {
         let data = contracts::deposit::GET_STAKERS.encode_input(&[])?;
 
         let stakers = self.call_contract(

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -774,6 +774,19 @@ impl State {
         Ok(())
     }
 
+    pub fn get_total_stake(&self, current_block: BlockHeader) -> Result<Option<NonZeroU128>> {
+        let data = contracts::deposit::GET_TOTAL_STAKE.encode_input(&[])?;
+        let total = self.call_contract(
+            Address::ZERO,
+            Some(contract_addr::DEPOSIT),
+            data,
+            0,
+            current_block,
+        )?;
+        let total = NonZeroU128::new(U256::from_be_slice(&total).to());
+        Ok(total)
+    }
+
     pub fn get_stake(
         &self,
         public_key: NodePublicKey,


### PR DESCRIPTION
Analysis of the vote handling process on local, finds that in the case of a 4-validator network, it takes about 25ms to handle a vote. Of this, ~13ms is spent in `total_weight()` and ~7ms is spent in `get_stakers()` calls to the EVM. This represents about 80% of the overall vote handling time. Increasing the number of validators also increases the vote handling time (as observed earlier).

This PR introduces some changes:
1. Rewrite of `total_weight()` from O(n) to O(1) time, which reduced the handling time from 13ms to ~3ms by calling the `getTotalStake()` deposit contract; then adding a caching mechanism reduced this further to a negligible cost after the first call.
2. Adding caching to `get_stakers()`, which reduces the call cost to negligible, after the first call.

This brings into the question of whether it might make sense to build a generalised caching mechanism for all EVM calls. But that might be overkill for now, and is something to think about if the need arises.

I think it's fine to merge these changes first, since they definitely provide some measure of improvement to the vote handling process. Hopefully, we can test and measure the real impact of these changes once the present devops issues have been resolved.