### PR TITLE
feat: Re-request likely missing blocks after restart

### DIFF
--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -542,7 +542,6 @@ impl BlockStoreStatus {
             .iter()
             .map(|(k, v)| (format!("{:?}", k), PeerInfoStatus::new(v)))
             .collect::<Vec<_>>();
-
         Ok(Self {
             highest_known_view: block_store.highest_known_view,
             views_held: block_store.db.get_view_ranges()?,
@@ -611,6 +610,20 @@ impl BlockStore {
             started_syncing_at: 0,
             last_sync_flag: false,
         })
+    }
+
+    /// The data set here is held in memory. It can be useful to update manually
+    /// For example after a restart to remind block_store of its peers and height
+    pub fn set_peers_and_view(
+        &mut self,
+        highest_known_view: u64,
+        peer_ids: &Vec<PeerId>,
+    ) -> Result<()> {
+        for peer_id in peer_ids {
+            self.peer_info(*peer_id);
+        }
+        self.highest_known_view = highest_known_view;
+        Ok(())
     }
 
     /// Create a read-only clone of this [BlockStore]. The read-only property must be upheld by the caller - Calling

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -395,20 +395,22 @@ impl Consensus {
                 .get_block(high_qc.block_hash)?
                 .ok_or_else(|| anyhow!("missing block that high QC points to!"))?;
 
-            // Grab a few  peerIds in case others also went offline
-            let mut recent_peer_ids = vec![];
-            for view in (high_block.view().saturating_sub(5)..=high_block.view()).rev() {
-                if view < 1 {
-                    break;
-                }
-                if let Some(block) = consensus.block_store.get_block_by_view(view)? {
-                    if let Some(leader) = consensus.leader_at_block(&block, view) {
-                        if leader.peer_id != consensus.peer_id() {
-                            recent_peer_ids.push(leader.peer_id);
-                        }
-                    };
-                }
-            }
+            let executed_block = BlockHeader {
+                number: high_block.header.number + 1,
+                ..Default::default()
+            };
+            let state_at = consensus.state.at_root(high_block.state_root_hash().into());
+
+            // Grab last seen committee's peerIds in case others also went offline
+            let committee = state_at.get_stakers(executed_block)?;
+            let recent_peer_ids: Vec<_> = committee
+                .iter()
+                .filter(|&&peer_public_key| peer_public_key != consensus.public_key())
+                .filter_map(|&peer_public_key| {
+                    state_at.get_peer_id(peer_public_key).unwrap_or(None)
+                })
+                .collect();
+
             consensus
                 .block_store
                 .set_peers_and_view(high_block.view(), &recent_peer_ids)?;


### PR DESCRIPTION
In the scenario in which a node restarts and consensus does not continue without it, it is likely that it has a lower `high_qc` than the other nodes - if it Votes then goes offline before receiving the proposal.

`block_store` populates its peers list when it receives Proposals. So if consensus does not continue then the node never gets a chance to learn that it is behind and  thus never catches up its `high_qc`. 

When a node's `high_qc` is out of line with the other nodes then the exponential backoff will not catch it up for reasons explained in the linked ticket.