### PR TITLE
Implement GetNodeType

### DIFF
--- a/docs/api/zilliqa/getnodetype.doc.md
+++ b/docs/api/zilliqa/getnodetype.doc.md
@@ -14,9 +14,8 @@ NotDocumented
 
 Returns node type. The possible return values are:
 
-- `"Not in network, synced till epoch [epoch number]"` if the server has not joined the network and is synced until a specific epoch.
-- `"Seed"` if the server is in lookup node mode and is an archival lookup node.
-- `"Lookup"` if the server is in lookup node mode
+- `"Leader"` if we are currently the lead node
+- `"Validator"` otherwise
 
 # Curl
 
@@ -32,7 +31,7 @@ curl -d '{
 # Response
 
 ```json
-{ "id": "1", "jsonrpc": "2.0", "result": "Seed" }
+{ "id": "1", "jsonrpc": "2.0", "result": "Validator" }
 ```
 
 # Arguments
@@ -43,4 +42,3 @@ curl -d '{
 | `jsonrpc` | string | Required | `"2.0"`           |
 | `method`  | string | Required | `"GetNodeType"`   |
 | `params`  | string | Required | Empty string `""` |
-

--- a/docs/api/zilliqa/getnodetype.doc.md
+++ b/docs/api/zilliqa/getnodetype.doc.md
@@ -12,10 +12,7 @@ NotDocumented
 
 # Description
 
-Returns node type. The possible return values are:
-
-- `"Leader"` if we are currently the lead node
-- `"Validator"` otherwise
+Returns node type. For backwards compatibility reasons, in ZQ2 this always returns "Seed".
 
 # Curl
 
@@ -31,7 +28,7 @@ curl -d '{
 # Response
 
 ```json
-{ "id": "1", "jsonrpc": "2.0", "result": "Validator" }
+{ "id": "1", "jsonrpc": "2.0", "result": "Seed" }
 ```
 
 # Arguments

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -1180,8 +1180,13 @@ fn get_miner_info(_params: Params, _node: &Arc<Mutex<Node>>) -> Result<MinerInfo
 }
 
 // GetNodeType
-fn get_node_type(_params: Params, _node: &Arc<Mutex<Node>>) -> Result<String> {
-    todo!("API getnodetype is not implemented yet");
+fn get_node_type(_params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
+    let node = node.lock().unwrap();
+    if node.consensus.are_we_leader_now() {
+        Ok("Leader".to_string())
+    } else {
+        Ok("Validator".to_string())
+    }
 }
 
 // GetPrevDifficulty

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -1180,13 +1180,8 @@ fn get_miner_info(_params: Params, _node: &Arc<Mutex<Node>>) -> Result<MinerInfo
 }
 
 // GetNodeType
-fn get_node_type(_params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    let node = node.lock().unwrap();
-    if node.consensus.are_we_leader_now() {
-        Ok("Leader".to_string())
-    } else {
-        Ok("Validator".to_string())
-    }
+fn get_node_type(_params: Params, _node: &Arc<Mutex<Node>>) -> Result<String> {
+    Ok("Seed".into())
 }
 
 // GetPrevDifficulty

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1700,6 +1700,14 @@ impl Consensus {
         }
     }
 
+    pub fn are_we_leader_now(&self) -> bool {
+        let head_block = self.head_block();
+        let leader = self
+            .leader_at_block(&head_block, head_block.view())
+            .unwrap();
+        leader.public_key == self.public_key()
+    }
+
     fn leader_for_view(&mut self, parent_hash: Hash, view: u64) -> Option<NodePublicKey> {
         if let Ok(Some(parent)) = self.get_block(&parent_hash) {
             let leader = self.leader_at_block(&parent, view).unwrap();

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1700,14 +1700,6 @@ impl Consensus {
         }
     }
 
-    pub fn are_we_leader_now(&self) -> bool {
-        let head_block = self.head_block();
-        let leader = self
-            .leader_at_block(&head_block, head_block.view())
-            .unwrap();
-        leader.public_key == self.public_key()
-    }
-
     fn leader_for_view(&mut self, parent_hash: Hash, view: u64) -> Option<NodePublicKey> {
         if let Ok(Some(parent)) = self.get_block(&parent_hash) {
             let leader = self.leader_at_block(&parent, view).unwrap();

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -2049,9 +2049,30 @@ async fn get_miner_info(mut _network: Network) {
     todo!();
 }
 
-#[allow(dead_code)]
-async fn get_node_type(mut _network: Network) {
-    todo!();
+#[zilliqa_macros::test]
+async fn get_node_type(mut network: Network) {
+    let wallet = network.genesis_wallet().await;
+
+    let response: Value = wallet
+        .provider()
+        .request("GetNodeType", [""])
+        .await
+        .expect("Failed to call GetNodeType API");
+
+    assert!(
+        response.is_string(),
+        "Expected response to be a string, got: {:?}",
+        response
+    );
+
+    let allowed_node_types = ["Leader", "Validator"];
+    let response_str = response.as_str().expect("Expected response to be a string");
+
+    assert!(
+        allowed_node_types.contains(&response_str),
+        "Unexpected node type: {}",
+        response_str
+    );
 }
 
 #[allow(dead_code)]

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -2065,7 +2065,7 @@ async fn get_node_type(mut network: Network) {
         response
     );
 
-    let allowed_node_types = ["Leader", "Validator"];
+    let allowed_node_types = ["Seed"];
     let response_str = response.as_str().expect("Expected response to be a string");
 
     assert!(


### PR DESCRIPTION
- Previous node types (Seed/Lookup/Not in network...) don't appear to be relevant in ZQ2, so this now returns Leader or Validator instead
- Docs updated to match
- Test added
- Closes #1538
- References #1590