### PR TITLE
Don't query database for block availability

### DIFF
--- a/zilliqa/src/block_store.rs
+++ b/zilliqa/src/block_store.rs
@@ -420,9 +420,9 @@ pub struct BlockStore {
     failed_request_sleep_duration: Duration,
     /// Our block strategies.
     strategies: Vec<BlockStrategy>,
-    /// Last time we updated our availability - we do this at most once a second or so to avoid spam
-    available_blocks: Vec<BlockStrategy>,
-    available_blocks_updated: Option<SystemTime>,
+    /// The block views we have available. This is read once from the DB at start-up and incrementally updated whenever
+    /// we receive a new block. We do this because obtaining the data from the DB is expensive.
+    available_blocks: RangeMap,
 
     /// Buffered block proposals.
     buffered: BlockCache,
@@ -587,6 +587,13 @@ impl BlockAvailability {
 
 impl BlockStore {
     pub fn new(config: &NodeConfig, db: Arc<Db>, message_sender: MessageSender) -> Result<Self> {
+        let available_blocks =
+            db.get_view_ranges()?
+                .iter()
+                .fold(RangeMap::new(), |mut range_map, range| {
+                    range_map.with_range(range);
+                    range_map
+                });
         Ok(BlockStore {
             db,
             block_cache: Arc::new(RwLock::new(LruCache::new(NonZeroUsize::new(5).unwrap()))),
@@ -596,8 +603,7 @@ impl BlockStore {
             max_blocks_in_flight: config.max_blocks_in_flight,
             failed_request_sleep_duration: config.failed_request_sleep_duration,
             strategies: vec![BlockStrategy::Latest(constants::RETAINS_LAST_N_BLOCKS)],
-            available_blocks: vec![],
-            available_blocks_updated: None,
+            available_blocks,
             buffered: BlockCache::new(config.max_blocks_in_flight),
             unserviceable_requests: None,
             message_sender,
@@ -619,8 +625,7 @@ impl BlockStore {
             max_blocks_in_flight: 0,
             failed_request_sleep_duration: Duration::ZERO,
             strategies: self.strategies.clone(),
-            available_blocks: Vec::new(),
-            available_blocks_updated: None,
+            available_blocks: RangeMap::new(),
             buffered: BlockCache::new(0),
             unserviceable_requests: None,
             message_sender: self.message_sender.clone(),
@@ -646,24 +651,14 @@ impl BlockStore {
     /// We need to do this by view range, which means that we need to account for views where there was no block.
     /// So, the underlying db function finds the view lower and upper bounds of our contiguous block ranges and we
     /// advertise those.
-    /// This function overlays that with a timeout so we don't ask (and thus load the db) too often.
-    pub fn availability(&mut self) -> Result<Option<Vec<BlockStrategy>>> {
+    pub fn availability(&self) -> Result<Option<Vec<BlockStrategy>>> {
         let mut to_return = self.strategies.clone();
-        let now = SystemTime::now();
-        if self.available_blocks_updated.map_or(true, |x| {
-            now.duration_since(x).unwrap_or(Duration::ZERO)
-                > constants::RECOMPUTE_BLOCK_AVAILABILITY_AFTER
-        }) {
-            debug!("Updating available views");
-            self.available_blocks = self
-                .db
-                .get_view_ranges()?
+        to_return.extend(
+            self.available_blocks
+                .ranges
                 .iter()
-                .map(|x| BlockStrategy::CachedViewRange(x.clone(), None))
-                .collect();
-            self.available_blocks_updated = Some(now);
-        }
-        to_return.extend(self.available_blocks.iter().cloned());
+                .map(|range| BlockStrategy::CachedViewRange(range.clone(), None)),
+        );
         Ok(Some(to_return))
     }
 
@@ -1065,6 +1060,7 @@ impl BlockStore {
     ) -> Result<Vec<(PeerId, Proposal)>> {
         trace!(?from, number = block.number(), hash = ?block.hash(), "block_store::process_block() : starting");
         self.db.insert_block(&block)?;
+        self.available_blocks.with_elem(block.view());
 
         if let Some(from) = from {
             let peer = self.peer_info(from);

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -188,8 +188,6 @@ impl Consensus {
             config.eth_chain_id
         );
 
-        let block_store = BlockStore::new(&config, db.clone(), message_sender.clone())?;
-
         // Start chain from checkpoint. Load data file and initialise data in tables
         let mut checkpoint_data = None;
         if let Some(checkpoint) = &config.load_checkpoint {
@@ -200,6 +198,10 @@ impl Consensus {
                 config.eth_chain_id,
             )?;
         }
+
+        // It is important to create the `BlockStore` after the checkpoint has been loaded into the DB. The
+        // `BlockStore` pre-loads and caches information about the currently stored blocks.
+        let block_store = BlockStore::new(&config, db.clone(), message_sender.clone())?;
 
         let latest_block = db
             .get_finalized_view()?

--- a/zilliqa/src/constants.rs
+++ b/zilliqa/src/constants.rs
@@ -29,9 +29,6 @@ pub const ZIL_CONTRACT_CREATE_GAS: usize = 50;
 // Gas needed for making transfer using ZIL transaction
 pub const ZIL_NORMAL_TXN_GAS: usize = 50;
 
-// Recompute available blocks after this many seconds
-pub const RECOMPUTE_BLOCK_AVAILABILITY_AFTER: Duration = Duration::from_secs(2);
-
 // Maximum rate at which to send availability requests
 pub const REQUEST_PEER_VIEW_AVAILABILITY_NOT_BEFORE: Duration = Duration::from_millis(1000);
 


### PR DESCRIPTION
The database query to calculate block availability is very slow (8 seconds on the devnet). Therefore, we now only perform this query once at start-up. We keep the result in a `RangeMap` which we keep up-to-date whenever a new block is added.