### PR TITLE
Implement GetMinerInfo

### DIFF
--- a/docs/api/zilliqa/getminerinfo.doc.md
+++ b/docs/api/zilliqa/getminerinfo.doc.md
@@ -12,16 +12,8 @@ NotYetDocumented
 
 # Description
 
-Returns the mining nodes (i.e., the members of the DS committee and shards) at
-the specified DS block.
-
-**Notes:**
-
-1. Nodes owned by Zilliqa Research are omitted.
-1. `dscommittee` has no `size` field since the DS committee size is fixed for a
-   given chain.
-1. For the Zilliqa mainnet, this API is only available from DS block 5500
-   onwards.
+DS nodes no longer exist in ZQ2, so this API now returns placeholder data.
+In Zilliqa 2.0, sharding structure should be accessed via the XShard on-chain query mechanism.
 
 # Curl
 

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -1229,7 +1229,13 @@ fn get_total_coin_supply_as_int(_params: Params, node: &Arc<Mutex<Node>>) -> Res
 
 // GetMinerInfo
 fn get_miner_info(_params: Params, _node: &Arc<Mutex<Node>>) -> Result<MinerInfo> {
-    todo!("API getminerinfo is not implemented yet");
+    // This endpoint was previously queries by DS block number, which no longer exists, and
+    // neither do DS committees, so it now returns placeholder data for all queries to stay ZQ1 compatible.
+
+    Ok(MinerInfo {
+        dscommittee: vec![],
+        shards: vec![],
+    })
 }
 
 // GetNodeType

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -2043,9 +2043,17 @@ async fn combined_total_coin_supply_test(mut network: Network) {
     );
 }
 
-#[allow(dead_code)]
-async fn get_miner_info(mut _network: Network) {
-    todo!();
+#[zilliqa_macros::test]
+async fn get_miner_info(mut network: Network) {
+    let wallet = network.genesis_wallet().await;
+
+    let response: Value = wallet
+        .provider()
+        .request("GetMinerInfo", ["5500"])
+        .await
+        .expect("Failed to call GetMinerInfo API");
+
+    zilliqa::api::types::zil::MinerInfo::deserialize(&response).unwrap();
 }
 
 #[zilliqa_macros::test]


### PR DESCRIPTION
The argument type (a DS block number) and some of the return type (dscommittee) aren't things that exist in ZQ2. For that reason I've hardcoded this to return nothing and updated the docs to say this is now a placeholder.

The other option was to try and return the closest equivalent data, but on balance that felt like it might be confusing.

I'm very open to changing to that option if anyone would prefer that, though.

Closes #1537 