### PR TITLE
Implement GetSoftConfirmedTransaction

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -111,30 +111,28 @@ pub struct TxBlockHeader {
     pub committee_hash: Option<B256>,
 }
 
-#[derive(Clone, Serialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct GetTxResponse {
     #[serde(rename = "ID", serialize_with = "hex_no_prefix")]
-    id: B256,
+    pub id: B256,
     #[serde(with = "num_as_str")]
-    version: u32,
+    pub version: u32,
     #[serde(with = "num_as_str")]
-    nonce: u64,
+    pub nonce: u64,
     #[serde(serialize_with = "hex_no_prefix")]
-    to_addr: Address,
-    sender_pub_key: String,
+    pub to_addr: Address,
+    pub sender_pub_key: String,
     #[serde(with = "num_as_str")]
-    amount: ZilAmount,
-    signature: String,
-    receipt: GetTxResponseReceipt,
+    pub amount: ZilAmount,
+    pub signature: String,
+    pub receipt: GetTxResponseReceipt,
     #[serde(with = "num_as_str")]
-    gas_price: ZilAmount,
+    pub gas_price: ZilAmount,
     #[serde(with = "num_as_str")]
-    gas_limit: ScillaGas,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    code: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    data: Option<String>,
+    pub gas_limit: ScillaGas,
+    pub code: Option<String>,
+    pub data: Option<String>,
 }
 
 #[derive(Clone, Serialize, Debug)]
@@ -147,25 +145,25 @@ pub struct CreateTransactionResponse {
     pub tran_id: B256,
 }
 
-#[derive(Clone, Serialize, Debug)]
-struct Transition {
-    addr: Address,
-    depth: u64,
-    msg: TransitionMessage,
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct Transition {
+    pub addr: Address,
+    pub depth: u64,
+    pub msg: TransitionMessage,
 }
 
-#[derive(Clone, Serialize, Debug)]
-struct TransitionMessage {
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct TransitionMessage {
     #[serde(rename = "_amount", with = "num_as_str")]
-    amount: ZilAmount,
+    pub amount: ZilAmount,
     #[serde(rename = "_recipient")]
-    recipient: Address,
+    pub recipient: Address,
     #[serde(rename = "_tag")]
-    tag: String,
-    params: serde_json::Value,
+    pub tag: String,
+    pub params: serde_json::Value,
 }
 
-#[derive(Clone, Serialize, Debug)]
+#[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct EventLog {
     pub address: Address,
     #[serde(rename = "_eventname")]
@@ -173,20 +171,18 @@ pub struct EventLog {
     pub params: Vec<ParamValue>,
 }
 
-#[derive(Clone, Serialize, Debug)]
-struct GetTxResponseReceipt {
-    accepted: bool,
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct GetTxResponseReceipt {
+    pub accepted: bool,
     #[serde(with = "num_as_str")]
-    cumulative_gas: ScillaGas,
+    pub cumulative_gas: ScillaGas,
     #[serde(with = "num_as_str")]
-    epoch_num: u64,
-    transitions: Vec<Transition>,
-    event_logs: Vec<EventLog>,
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
-    errors: BTreeMap<u64, Vec<u64>>,
-    #[serde(skip_serializing_if = "Vec::is_empty")]
-    exceptions: Vec<ScillaException>,
-    success: bool,
+    pub epoch_num: u64,
+    pub transitions: Vec<Transition>,
+    pub event_logs: Vec<EventLog>,
+    pub errors: BTreeMap<u64, Vec<u64>>,
+    pub exceptions: Vec<ScillaException>,
+    pub success: bool,
 }
 
 impl GetTxResponse {

--- a/zilliqa/src/api/zil.rs
+++ b/zilliqa/src/api/zil.rs
@@ -1371,10 +1371,10 @@ fn get_smart_contract_sub_state(params: Params, node: &Arc<Mutex<Node>>) -> Resu
 
 // GetSoftConfirmedTransaction
 fn get_soft_confirmed_transaction(
-    _params: Params,
-    _node: &Arc<Mutex<Node>>,
+    params: Params,
+    node: &Arc<Mutex<Node>>,
 ) -> Result<GetTxResponse> {
-    todo!("API getsoftconfirmedtransaction is not implemented yet");
+    get_transaction(params, node)
 }
 
 // GetStateProof

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -603,9 +603,8 @@ async fn get_transaction(mut network: Network) {
     let (secret_key, _address) = zilliqa_account(&mut network).await;
 
     // Define the recipient address
-    let to_addr: H160 = "0x00000000000000000000000000000000deadbeef"
-        .parse()
-        .unwrap();
+    let address_string_w_prefix = "0x00000000000000000000000000000000deadbeef";
+    let to_addr: H160 = address_string_w_prefix.parse().unwrap();
 
     // Send a transaction
     let (_contract_address, returned_transaction) = send_transaction(
@@ -655,6 +654,19 @@ async fn get_transaction(mut network: Network) {
         response["senderPubKey"].as_str().unwrap(),
         format!("0x{}", hex::encode(secret_key.public_key().to_sec1_bytes()))
     );
+
+    let parsed_response = zilliqa::api::types::zil::GetTxResponse::deserialize(&response)
+        .expect("Failed to deserialize response");
+
+    // Verify the transaction details
+    assert_eq!(parsed_response.nonce, 1);
+    // Logic should be case independent
+    assert_eq!(
+        parsed_response.to_addr.to_string().to_lowercase(),
+        address_string_w_prefix
+    );
+    assert_eq!(parsed_response.amount.to_string(), "200000000000000");
+    assert_eq!(parsed_response.gas_limit.0, 50000);
 }
 
 // We need to restrict the concurrency level of this test, because each node in the network will spawn a TCP listener
@@ -2249,9 +2261,78 @@ async fn get_smart_contract_sub_state(mut network: Network) {
     assert!(substate2.get("welcome_msg").is_none());
 }
 
-#[allow(dead_code)]
-async fn get_soft_confirmed_transaction(mut _network: Network) {
-    todo!();
+#[zilliqa_macros::test]
+async fn get_soft_confirmed_transaction(mut network: Network) {
+    let wallet = network.random_wallet().await;
+
+    // Create a Zilliqa account and get its secret key and address
+    let (secret_key, _address) = zilliqa_account(&mut network).await;
+
+    // Define the recipient address
+    let address_string_w_prefix = "0x00000000000000000000000000000000deadbeef";
+    let to_addr: H160 = address_string_w_prefix.parse().unwrap();
+
+    // Send a transaction
+    let (_contract_address, returned_transaction) = send_transaction(
+        &mut network,
+        &secret_key,
+        1,
+        ToAddr::Address(to_addr),
+        200u128 * 10u128.pow(12),
+        50_000,
+        None,
+        None,
+    )
+    .await;
+
+    // Get the transaction ID from the returned transaction
+    let transaction_id = returned_transaction["ID"]
+        .as_str()
+        .expect("Failed to get ID from response");
+
+    // Wait for the transaction to be mined
+    network.run_until_block(&wallet, 1.into(), 50).await;
+
+    // Use the GetTransaction API to retrieve the transaction details
+    let response: Value = wallet
+        .provider()
+        .request("GetTransaction", [transaction_id])
+        .await
+        .expect("Failed to call GetTransaction API");
+
+    // Check for keys
+    assert!(response["receipt"]["success"].is_boolean());
+    assert!(response["receipt"]["event_logs"].is_array());
+    assert!(response["receipt"]["transitions"].is_array());
+
+    // Check the string formats
+    assert!(!response["ID"].as_str().unwrap().starts_with("0x"));
+    assert!(!response["toAddr"].as_str().unwrap().starts_with("0x"));
+    assert!(response["senderPubKey"].as_str().unwrap().starts_with("0x"));
+    assert!(response["signature"].as_str().unwrap().starts_with("0x"));
+
+    // Verify the transaction details
+    assert_eq!(response["ID"].as_str().unwrap(), transaction_id);
+    assert_eq!(response["toAddr"].as_str().unwrap(), hex::encode(to_addr),);
+    assert_eq!(response["amount"].as_str().unwrap(), "200000000000000");
+    assert_eq!(response["gasLimit"].as_str().unwrap(), "50000");
+    assert_eq!(
+        response["senderPubKey"].as_str().unwrap(),
+        format!("0x{}", hex::encode(secret_key.public_key().to_sec1_bytes()))
+    );
+
+    let parsed_response = zilliqa::api::types::zil::GetTxResponse::deserialize(&response)
+        .expect("Failed to deserialize response");
+
+    // Verify the transaction details
+    assert_eq!(parsed_response.nonce, 1);
+    // Logic should be case independent
+    assert_eq!(
+        parsed_response.to_addr.to_string().to_lowercase(),
+        address_string_w_prefix
+    );
+    assert_eq!(parsed_response.amount.to_string(), "200000000000000");
+    assert_eq!(parsed_response.gas_limit.0, 50000);
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
- "Soft" isn't mentioned elsewhere in the ZQ2 codebase so this just wraps GetTransaction
- Adds a new test, and lengthenes the test for GetTransaction, but keeps them separate in case we need to modify one or both in future
- Looks like there might be a bug with stringification of addresses somewhere leading to mixed case results, but it feels outside the scope of this commit so I normalise via to_lowercase in the test
- Closes #1546