### PR TITLE
Deduct genesis deposits and accounts from zero address

### DIFF
--- a/z2/docs/converter.md
+++ b/z2/docs/converter.md
@@ -48,8 +48,7 @@ session later. Use `screen`)
 ```
 screen -a
 export Z2_CONVERTER=true
-z2 converter convert <--convert-accounts|--convert-blocks> /my/dir/persistences/zq1 /my/dir/persistences/zq2 config.toml <secret key>
+z2 converter convert /my/dir/persistences/zq1 /my/dir/persistences/zq2 config.toml <secret key>
 ```
 
 The secret key is for a single validator which will be assumed to have 64 ZIL staked, so that the network has a validator on startup.
-This tool requires plenty of ram to convert both accounts and blocks in a single run. Therefore, it's possible to convert either accounts or blocks at once.

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -241,20 +241,7 @@ struct ConvertConfigStruct {
     zq2_config_file: String,
     #[arg(value_parser = SecretKey::from_hex)]
     secret_key: SecretKey,
-    #[clap(flatten)]
-    convert_type_group: ConvertTypeGroup,
 }
-#[derive(Args, Debug)]
-#[group(required = true, multiple = false)]
-pub struct ConvertTypeGroup {
-    #[clap(long)]
-    #[arg(default_value_t = false)]
-    convert_accounts: bool,
-    #[clap(long)]
-    #[arg(default_value_t = false)]
-    convert_blocks: bool,
-}
-
 #[derive(Args, Debug)]
 struct ConverterPrintTransactionConfigStruct {
     zq1_persistence_directory: String,
@@ -925,8 +912,6 @@ async fn main() -> Result<()> {
                     &arg.zq2_data_dir,
                     &arg.zq2_config_file,
                     arg.secret_key,
-                    arg.convert_type_group.convert_accounts,
-                    arg.convert_type_group.convert_blocks,
                 )
                 .await?;
                 Ok(())

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -34,7 +34,7 @@ use tokio::sync::mpsc;
 use tracing::{info, trace, warn};
 use zilliqa::{
     block_store::BlockStore,
-    cfg::{scilla_ext_libs_path_default, Config},
+    cfg::{scilla_ext_libs_path_default, Amount, Config, NodeConfig},
     consensus::Validator,
     constants::SCILLA_INVOKE_CHECKER,
     contracts,
@@ -308,13 +308,42 @@ fn stop_scilla_docker(child: &mut Child) -> Result<ExitStatus> {
         .or(Err(anyhow!("Unable to stop docker container!")))
 }
 
+fn deduct_funds_from_zero_account(state: &mut State, config: &NodeConfig) -> Result<()> {
+    let total_requested_amount = config
+        .consensus
+        .total_native_token_supply
+        .0
+        .checked_add(
+            config
+                .consensus
+                .genesis_accounts
+                .iter()
+                .fold(0, |acc, item: &(Address, Amount)| acc + item.1 .0),
+        )
+        .expect("Genesis accounts sum to more than max value of u128")
+        .checked_add(
+            config
+                .consensus
+                .genesis_deposits
+                .iter()
+                .fold(0, |acc, item| acc + item.stake.0),
+        )
+        .expect("Genesis accounts + genesis deposits sum to more than max value of u128");
+    state.mutate_account(Address::ZERO, |acc| {
+        acc.balance = acc.balance.checked_sub(total_requested_amount).expect("Sum of funds in genesis.deposit and genesis.accounts exceeds funds in ZeroAccount from zq1!");
+        Ok(())
+    })?;
+
+    // Flush any pending changes to db
+    let _ = state.root_hash()?;
+    Ok(())
+}
+
 pub async fn convert_persistence(
     zq1_db: zq1::Db,
     zq2_db: Db,
     zq2_config: Config,
     secret_key: SecretKey,
-    convert_accounts: bool,
-    convert_blocks: bool,
 ) -> Result<()> {
     let style = ProgressStyle::with_template(
         "{msg} {wide_bar} [{per_sec}] {human_pos}/~{human_len} ({elapsed}/~{duration})",
@@ -343,88 +372,83 @@ pub async fn convert_persistence(
         block_store,
     )?;
 
-    if convert_accounts {
-        let mut scilla_docker = run_scilla_docker()?;
-        // Calculate an estimate for the number of accounts by taking the first 100 accounts, calculating the distance
-        // between pairs of adjacent addresses, taking the average and extrapolating to the end of the key space.
-        let distance_sum: u64 = zq1_db
-            .accounts()
-            .map(|(addr, _)| addr)
-            .take(100)
-            .tuple_windows()
-            .map(|(a, b)| {
-                // Downsample the addresses to 8 bytes, treating them as `u64`s, for ease of computation.
-                let a = u64::from_be_bytes(a.as_slice()[..8].try_into().unwrap());
-                let b = u64::from_be_bytes(b.as_slice()[..8].try_into().unwrap());
+    let mut scilla_docker = run_scilla_docker()?;
+    // Calculate an estimate for the number of accounts by taking the first 100 accounts, calculating the distance
+    // between pairs of adjacent addresses, taking the average and extrapolating to the end of the key space.
+    let distance_sum: u64 = zq1_db
+        .accounts()
+        .map(|(addr, _)| addr)
+        .take(100)
+        .tuple_windows()
+        .map(|(a, b)| {
+            // Downsample the addresses to 8 bytes, treating them as `u64`s, for ease of computation.
+            let a = u64::from_be_bytes(a.as_slice()[..8].try_into().unwrap());
+            let b = u64::from_be_bytes(b.as_slice()[..8].try_into().unwrap());
 
-                b - a
-            })
-            .sum();
-        let average_distance = distance_sum as f64 / 99.;
-        let address_count = ((u64::MAX as f64) / average_distance) as u64;
+            b - a
+        })
+        .sum();
+    let average_distance = distance_sum as f64 / 99.;
+    let address_count = ((u64::MAX as f64) / average_distance) as u64;
 
-        let progress = ProgressBar::new(address_count)
-            .with_style(style.clone())
-            .with_message("collect accounts")
-            .with_finish(ProgressFinish::AndLeave);
+    let progress = ProgressBar::new(address_count)
+        .with_style(style.clone())
+        .with_message("collect accounts")
+        .with_finish(ProgressFinish::AndLeave);
 
-        let accounts: Vec<_> = zq1_db.accounts().progress_with(progress).collect();
+    let accounts: Vec<_> = zq1_db.accounts().progress_with(progress).collect();
 
-        let progress = ProgressBar::new(accounts.len() as u64)
-            .with_style(style.clone())
-            .with_message("convert accounts")
-            .with_finish(ProgressFinish::AndLeave);
+    let progress = ProgressBar::new(accounts.len() as u64)
+        .with_style(style.clone())
+        .with_message("convert accounts")
+        .with_finish(ProgressFinish::AndLeave);
 
-        for (address, zq1_account) in accounts.into_iter().progress_with(progress) {
-            if address.is_zero() {
-                continue;
-            }
-            let zq1_account = zq1::Account::from_proto(zq1_account)?;
-
-            let code = get_contract_code(&zq1_db, address)?;
-
-            let (code, storage_root) = match code {
-                Code::Evm(evm_code) if !evm_code.is_empty() => {
-                    let storage_root = convert_evm_state(&zq1_db, &zq2_db, address)?;
-                    (Code::Evm(evm_code), storage_root)
-                }
-                Code::Scilla {
-                    code, init_data, ..
-                } => {
-                    let (storage_root, types, transitions) =
-                        convert_scilla_state(&zq1_db, &zq2_db, &state, &code, &init_data, address)?;
-                    (
-                        Code::Scilla {
-                            code,
-                            init_data,
-                            types,
-                            transitions,
-                        },
-                        storage_root,
-                    )
-                }
-                _ => (code, EMPTY_ROOT_HASH),
-            };
-
-            let account = Account {
-                nonce: zq1_account.nonce,
-                balance: zq1_account.balance * 10u128.pow(6),
-                code,
-                storage_root,
-            };
-
-            state.save_account(address, account)?;
-            // Flush any pending changes to db
-            let _ = state.root_hash()?;
+    for (address, zq1_account) in accounts.into_iter().progress_with(progress) {
+        if address.is_zero() {
+            continue;
         }
+        let zq1_account = zq1::Account::from_proto(zq1_account)?;
 
-        stop_scilla_docker(&mut scilla_docker)?;
+        let code = get_contract_code(&zq1_db, address)?;
+
+        let (code, storage_root) = match code {
+            Code::Evm(evm_code) if !evm_code.is_empty() => {
+                let storage_root = convert_evm_state(&zq1_db, &zq2_db, address)?;
+                (Code::Evm(evm_code), storage_root)
+            }
+            Code::Scilla {
+                code, init_data, ..
+            } => {
+                let (storage_root, types, transitions) =
+                    convert_scilla_state(&zq1_db, &zq2_db, &state, &code, &init_data, address)?;
+                (
+                    Code::Scilla {
+                        code,
+                        init_data,
+                        types,
+                        transitions,
+                    },
+                    storage_root,
+                )
+            }
+            _ => (code, EMPTY_ROOT_HASH),
+        };
+
+        let account = Account {
+            nonce: zq1_account.nonce,
+            balance: zq1_account.balance * 10u128.pow(6),
+            code,
+            storage_root,
+        };
+
+        state.save_account(address, account)?;
+        // Flush any pending changes to db
+        let _ = state.root_hash()?;
     }
 
-    if !convert_blocks {
-        println!("Accounts converted. Skipping blocks.");
-        return Ok(());
-    }
+    stop_scilla_docker(&mut scilla_docker)?;
+
+    deduct_funds_from_zero_account(&mut state, node_config)?;
 
     let max_block = zq1_db
         .get_tx_blocks_aux("MaxTxBlockNumber")?

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -353,8 +353,6 @@ pub async fn run_persistence_converter(
     zq2_data_dir: &str,
     zq2_config: &str,
     secret_key: SecretKey,
-    convert_accounts: bool,
-    convert_blocks: bool,
 ) -> Result<()> {
     println!("🐼 Converting {zq1_pers_dir} into {zq2_data_dir}.. ");
     let zq1_dir = PathBuf::from_str(zq1_pers_dir)?;
@@ -369,15 +367,7 @@ pub async fn run_persistence_converter(
         node_config.state_cache_size,
     )?;
     let zq1_db = zq1::Db::new(zq1_dir)?;
-    converter::convert_persistence(
-        zq1_db,
-        zq2_db,
-        zq2_config,
-        secret_key,
-        convert_accounts,
-        convert_blocks,
-    )
-    .await?;
+    converter::convert_persistence(zq1_db, zq2_db, zq2_config, secret_key).await?;
     Ok(())
 }
 


### PR DESCRIPTION
As title says - we should deduct the funds provided in genesis accounts and deposits from zero address during conversion. 

Also, we no longer convert accounts and blocks separately since it doesn't make sense that much. 