### PR TITLE
Add metric to report P2P message processing time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5859,6 +5859,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1b6902ff63b32ef6c489e8048c5e253e2e4a803ea3ea7e783914536eb15c52"
+
+[[package]]
 name = "opentelemetry_sdk"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9871,6 +9877,7 @@ dependencies = [
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "paste",
  "primitive-types",

--- a/infra/otel-collector-config.yaml
+++ b/infra/otel-collector-config.yaml
@@ -2,6 +2,7 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: otel-collector:4317
 
 exporters:
   prometheusremotewrite:

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -84,6 +84,7 @@ cfg-if = "1.0.0"
 serde_repr = "0.1.19"
 thiserror = "2.0.3"
 lru-mem = "0.3.0"
+opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
 
 [dev-dependencies]
 alloy = { version = "0.6.4", default-features = false, features = ["rand"] }

--- a/zilliqa/src/bin/zilliqa.rs
+++ b/zilliqa/src/bin/zilliqa.rs
@@ -110,9 +110,10 @@ async fn main() -> Result<()> {
             .with_export_config(export_config)
             .build()?;
         let reader = PeriodicReader::builder(exporter, runtime::Tokio).build();
-        opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+        let provider = opentelemetry_sdk::metrics::SdkMeterProvider::builder()
             .with_reader(reader)
             .build();
+        opentelemetry::global::set_meter_provider(provider);
     };
 
     let mut node = P2pNode::new(args.secret_key, config.clone())?;


### PR DESCRIPTION
We will now export the `messaging.process.duration` metric which records the time spent processing P2P messages.

This also fixes a few minor issues with the existing metrics.