### PR TITLE
Set view if current value is NULL

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -505,7 +505,7 @@ impl Db {
     /// Write view and timestamp to table if view is larger than current. Return true if write was successful
     pub fn set_view_with_db_tx(&self, sqlite_tx: &Connection, view: u64) -> Result<bool> {
         let res = sqlite_tx
-            .execute("INSERT INTO tip_info (view) VALUES (?1) ON CONFLICT(_single_row) DO UPDATE SET view = ?1 WHERE tip_info.view < ?1",
+            .execute("INSERT INTO tip_info (view) VALUES (?1) ON CONFLICT(_single_row) DO UPDATE SET view = ?1 WHERE tip_info.view IS NULL OR tip_info.view < ?1",
                     [view])?;
         Ok(res != 0)
     }


### PR DESCRIPTION
`WHERE tip_info.view < ?1` will always be `FALSE` if `tip_info.view` is `NULL`. This means when starting a fresh network from a checkpoint, we fail to set the view and it is later defaulted to 0.