### PR TITLE
Batch SQL inserts for transactions

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -936,23 +936,17 @@ impl Consensus {
         current_block: BlockHeader,
         inspector: I,
     ) -> Result<Option<TransactionApplyResult>> {
-        let db = self.db.clone();
         let state = &mut self.state;
-        Self::apply_transaction_at(state, db, txn, current_block, inspector)
+        Self::apply_transaction_at(state, txn, current_block, inspector)
     }
 
     pub fn apply_transaction_at<I: Inspector<PendingState> + ScillaInspector>(
         state: &mut State,
-        db: Arc<Db>,
         txn: VerifiedTransaction,
         current_block: BlockHeader,
         inspector: I,
     ) -> Result<Option<TransactionApplyResult>> {
         let hash = txn.hash;
-
-        if !db.contains_transaction(&txn.hash)? {
-            db.insert_transaction(&txn.hash, &txn.tx)?;
-        }
 
         let result = state.apply_transaction(txn.clone(), current_block, inspector);
         let result = match result {
@@ -1391,11 +1385,11 @@ impl Consensus {
             let mut inspector = TouchedAddressInspector::default();
             let result = Self::apply_transaction_at(
                 &mut state,
-                self.db.clone(),
                 tx.clone(),
                 proposal.header,
                 &mut inspector,
             )?;
+            self.db.insert_transaction(&tx.hash, &tx.tx)?;
 
             // Skip transactions whose execution resulted in an error and drop them.
             let Some(result) = result else {
@@ -1581,11 +1575,11 @@ impl Consensus {
             // Apply specific txn
             let result = Self::apply_transaction_at(
                 state,
-                self.db.clone(),
                 txn.clone(),
                 executed_block_header,
                 inspector::noop(),
             )?;
+            self.db.insert_transaction(&txn.hash, &txn.tx)?;
 
             // Skip transactions whose execution resulted in an error
             let Some(result) = result else {
@@ -3012,16 +3006,17 @@ impl Consensus {
             .map(|tx| format!("{:?}", tx.hash))
             .join(",");
 
-        for (tx_index, txn) in verified_txns.into_iter().enumerate() {
+        let mut touched_addresses = vec![];
+        for (tx_index, txn) in verified_txns.iter().enumerate() {
             self.new_transaction(txn.clone())?;
             let tx_hash = txn.hash;
             let mut inspector = TouchedAddressInspector::default();
             let result = self
                 .apply_transaction(txn.clone(), block.header, &mut inspector)?
                 .ok_or_else(|| anyhow!("proposed transaction failed to execute"))?;
-            self.transaction_pool.mark_executed(&txn);
+            self.transaction_pool.mark_executed(txn);
             for address in inspector.touched {
-                self.db.add_touched_address(address, tx_hash)?;
+                touched_addresses.push((address, tx_hash));
             }
 
             let gas_used = result.gas_used();
@@ -3044,6 +3039,17 @@ impl Consensus {
             debug!(?receipt, "applied transaction {:?}", receipt);
             block_receipts.push((receipt, tx_index));
         }
+        self.db.with_sqlite_tx(|sqlite_tx| {
+            for txn in &verified_txns {
+                self.db
+                    .insert_transaction_with_db_tx(sqlite_tx, &txn.hash, &txn.tx)?;
+            }
+            for (addr, txn_hash) in touched_addresses {
+                self.db
+                    .add_touched_address_with_db_tx(sqlite_tx, addr, txn_hash)?;
+            }
+            Ok(())
+        })?;
 
         if cumulative_gas_used != block.gas_used() {
             warn!("Cumulative gas used by executing all transactions: {cumulative_gas_used} is different that the one provided in the block: {}", block.gas_used());


### PR DESCRIPTION
I've seen that SQL insert latency is a large bottleneck for the execution of blocks with many transactions. By batching these transactions and performing them all with a single SQL query at the end of executing a block, we should reduce this latency.