### PR TITLE
Removing a stale code path and comment.

### DIFF
--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -208,7 +208,8 @@ impl Node {
 
     pub fn handle_broadcast(&mut self, from: PeerId, message: ExternalMessage) -> Result<()> {
         debug!(%from, to = %self.peer_id, %message, "handling broadcast");
-        // We only expect `Proposal`s and `NewTransaction`s to be broadcast.
+        // We only expect `NewTransaction`s to be broadcast.
+        // `Proposals` are re-routed to `handle_request()`.
         match message {
             ExternalMessage::NewTransaction(t) => {
                 // Don't process again txn sent by this node (it's already in the mempool)

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -210,9 +210,6 @@ impl Node {
         debug!(%from, to = %self.peer_id, %message, "handling broadcast");
         // We only expect `Proposal`s and `NewTransaction`s to be broadcast.
         match message {
-            ExternalMessage::Proposal(m) => {
-                self.handle_proposal(from, m)?;
-            }
             ExternalMessage::NewTransaction(t) => {
                 // Don't process again txn sent by this node (it's already in the mempool)
                 if self.peer_id != from {
@@ -314,9 +311,9 @@ impl Node {
             ExternalMessage::ProcessProposal(m) => {
                 self.handle_process_proposal(from, m)?;
             }
-            // Handle requests which just contain a block proposal. This shouldn't actually happen in production, but
-            // annoyingly we have some test cases which trigger this (by rewriting broadcasts to direct messages) and
-            // the easiest fix is just to handle requests with proposals gracefully.
+            // Handle requests which contain a block proposal. Initially sent as a broadcast, it is re-routed into
+            // a Request by the underlying layer, with a faux request-id. This is to mitigate issues when there are
+            // too many transactions in the broadcast queue.
             ExternalMessage::Proposal(m) => {
                 self.handle_proposal(from, m)?;
 

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -411,7 +411,14 @@ impl P2pNode {
                                 },
                                 // still publish to self, even if no other peers.
                                 Err(gossipsub::PublishError::InsufficientPeers) => {
-                                    self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message)))?;
+                                    match message {
+                                        ExternalMessage::Proposal(_) => {
+                                            self.send_to(&topic.hash(), |c| c.requests.send((from, "(faux-id)".to_string(), message, ResponseChannel::Local)))?;
+                                        }
+                                        _ => {
+                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message)))?;
+                                        }
+                                    }
                                 }
                                 Err(e) => {
                                     trace!(%e, "failed to publish message");

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -99,7 +99,7 @@ async fn block_production(mut network: Network) {
                     .map_or(0, |b| b.number())
                     >= 5
             },
-            50,
+            100,
         )
         .await
         .unwrap();

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -1427,7 +1427,7 @@ async fn test_eth_syncing(mut network: Network) {
     network
         .run_until_async(
             || async { wallet.get_block_number().await.unwrap().as_u64() > 4 },
-            50,
+            100,
         )
         .await
         .unwrap();

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1006,10 +1006,10 @@ impl Network {
                                 if inner.config.eth_chain_id == sender_chain_id {
                                     match external_message {
                                         // Re-route Proposals from Broadcast to Requests, which is the behaviour in Production.
-                                        ExternalMessage::Proposal(p) => inner
+                                        ExternalMessage::Proposal(_) => inner
                                             .handle_request(
                                                 source,
-                                                &p.hash().to_string(),
+                                                "(faux-id)",
                                                 external_message.clone(),
                                                 ResponseChannel::Local,
                                             )

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1004,9 +1004,20 @@ impl Network {
                                 let mut inner = node.inner.lock().unwrap();
                                 // Send to nodes only in the same shard (having same chain_id)
                                 if inner.config.eth_chain_id == sender_chain_id {
-                                    inner
-                                        .handle_broadcast(source, external_message.clone())
-                                        .unwrap();
+                                    match external_message {
+                                        // Re-route Proposals from Broadcast to Requests, which is the behaviour in Production.
+                                        ExternalMessage::Proposal(p) => inner
+                                            .handle_request(
+                                                source,
+                                                &p.hash().to_string(),
+                                                external_message.clone(),
+                                                ResponseChannel::Local,
+                                            )
+                                            .unwrap(),
+                                        _ => inner
+                                            .handle_broadcast(source, external_message.clone())
+                                            .unwrap(),
+                                    }
                                 }
                             });
                         }
@@ -1015,22 +1026,24 @@ impl Network {
             }
             AnyMessage::Response { channel, message } => {
                 info!(%message, ?channel, "response");
-                let destination = self.pending_responses.remove(channel).unwrap();
-                let (index, node) = self
-                    .nodes
-                    .iter()
-                    .enumerate()
-                    .find(|(_, n)| n.peer_id == destination)
-                    .unwrap();
-                if !self.disconnected.contains(&index) {
-                    let span = tracing::span!(tracing::Level::INFO, "handle_message", index);
-                    span.in_scope(|| {
-                        let mut inner = node.inner.lock().unwrap();
-                        // Send to nodes only in the same shard (having same chain_id)
-                        if inner.config.eth_chain_id == sender_chain_id {
-                            inner.handle_response(source, message.clone()).unwrap();
-                        }
-                    });
+                // skip on faux response
+                if let Some(destination) = self.pending_responses.remove(channel) {
+                    let (index, node) = self
+                        .nodes
+                        .iter()
+                        .enumerate()
+                        .find(|(_, n)| n.peer_id == destination)
+                        .unwrap();
+                    if !self.disconnected.contains(&index) {
+                        let span = tracing::span!(tracing::Level::INFO, "handle_message", index);
+                        span.in_scope(|| {
+                            let mut inner = node.inner.lock().unwrap();
+                            // Send to nodes only in the same shard (having same chain_id)
+                            if inner.config.eth_chain_id == sender_chain_id {
+                                inner.handle_response(source, message.clone()).unwrap();
+                            }
+                        });
+                    }
                 }
             }
         }


### PR DESCRIPTION
There was a stale code-path and comment that I forgot to remove earlier. ~~This quick PR removes it.~~ Turned out to be more work than I thought. But it's good to fix the tests, to reflect the actual code-path.