### PR TITLE
Fix to address missing transitions

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -721,7 +721,13 @@ fn try_with_zil_transaction(
                 }))
             })
             .collect::<Result<_>>()?,
-        transitions: vec![],
+        transitions: transaction
+            .receipt
+            .transitions
+            .clone()
+            .into_iter()
+            .map(|x| x.into())
+            .collect(),
         accepted: None,
         errors: BTreeMap::new(),
         exceptions: vec![],
@@ -790,7 +796,13 @@ fn try_with_evm_transaction(
                 }))
             })
             .collect::<Result<_>>()?,
-        transitions: vec![],
+        transitions: transaction
+            .receipt
+            .transitions
+            .clone()
+            .into_iter()
+            .map(|x| x.into())
+            .collect(),
         accepted: None,
         errors: BTreeMap::new(),
         exceptions: vec![],

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -796,13 +796,7 @@ fn try_with_evm_transaction(
                 }))
             })
             .collect::<Result<_>>()?,
-        transitions: transaction
-            .receipt
-            .transitions
-            .clone()
-            .into_iter()
-            .map(|x| x.into())
-            .collect(),
+        transitions: vec![],
         accepted: None,
         errors: BTreeMap::new(),
         exceptions: vec![],

--- a/z2/src/zq1/persistence.rs
+++ b/z2/src/zq1/persistence.rs
@@ -429,7 +429,7 @@ impl From<Transition> for ScillaTransition {
             from: x.address,
             to: x.message.recipient,
             depth: x.depth,
-            amount: zilliqa::transaction::ZilAmount::from_amount(x.message.amount as u128),
+            amount: zilliqa::transaction::ZilAmount::from_raw(x.message.amount as u128),
             tag: x.message.tag,
             params: serde_json::to_string(&x.message.params).unwrap(),
         }

--- a/z2/src/zq1/persistence.rs
+++ b/z2/src/zq1/persistence.rs
@@ -5,7 +5,7 @@ use alloy::{
 use anyhow::{anyhow, Result};
 use ethabi::Token;
 use k256::ecdsa::VerifyingKey;
-use serde::{Deserialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
 use sha2::Sha256;
 use sha3::{
@@ -16,6 +16,7 @@ use sha3::{
     },
     Digest, Keccak256,
 };
+use zilliqa::exec::ScillaTransition;
 
 use super::proto::{
     proto_account_base, proto_mb_info, proto_transaction_core_info, proto_transaction_receipt,
@@ -332,7 +333,7 @@ pub struct TransactionReceipt {
     #[serde(default)]
     pub event_logs: Vec<Log>,
     //#[serde(default)]
-    //pub transitions: Vec<Transition>,
+    pub transitions: Vec<Transition>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -413,11 +414,24 @@ pub struct Message {
 }
 
 #[allow(dead_code)]
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct ScillaParam {
     #[serde(rename = "vname")]
     name: String,
     #[serde(rename = "type")]
     ty: String,
     value: String,
+}
+
+impl From<Transition> for ScillaTransition {
+    fn from(x: Transition) -> Self {
+        ScillaTransition {
+            from: x.address,
+            to: x.message.recipient,
+            depth: x.depth,
+            amount: zilliqa::transaction::ZilAmount::from_amount(x.message.amount as u128),
+            tag: x.message.tag,
+            params: serde_json::to_string(&x.message.params).unwrap(),
+        }
+    }
 }


### PR DESCRIPTION
This adds code to support conversion of transitions.
However, it relies on adding back in the transitions field of TransactionReceipt, which may have been commented out for a reason, so I'd appreciate your input, @bzawisto 