### PR TITLE
Use latest libp2p version and switch to TCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,6 +28,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array 0.14.7",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +46,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -799,6 +823,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-io"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1180,15 @@ dependencies = [
  "serde",
  "tap",
  "wyz",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1552,6 +1597,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1623,6 +1692,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1982,6 +2052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
+ "rand_core",
  "typenum",
 ]
 
@@ -3174,17 +3245,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
-name = "futures-ticker"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9763058047f713632a52e916cc7f6a4b3fc6e9fc1ff8c5b1dc49e5a89041682e"
-dependencies = [
- "futures",
- "futures-timer",
- "instant",
-]
-
-[[package]]
 name = "futures-timer"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3280,6 +3340,16 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -4069,16 +4139,18 @@ dependencies = [
 
 [[package]]
 name = "igd-next"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "064d90fec10d541084e7b39ead8875a5a80d9114a2b18791565253bae25f49e4"
+checksum = "76b0d7d4541def58a37bf8efc559683f21edce7c82f0d866c93ac21f7e098f93"
 dependencies = [
  "async-trait",
  "attohttpc",
  "bytes",
  "futures",
- "http 0.2.12",
- "hyper 0.14.31",
+ "http 1.1.0",
+ "http-body-util",
+ "hyper 1.5.1",
+ "hyper-util",
  "log",
  "rand",
  "tokio",
@@ -4725,9 +4797,8 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libp2p"
-version = "0.54.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbbe80f9c7e00526cd6b838075b9c171919404a4732cb2fa8ece0a093223bfc4"
+version = "0.54.2"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "bytes",
  "either",
@@ -4745,34 +4816,33 @@ dependencies = [
  "libp2p-kad",
  "libp2p-mdns",
  "libp2p-metrics",
+ "libp2p-noise",
  "libp2p-quic",
  "libp2p-request-response",
  "libp2p-swarm",
  "libp2p-tcp",
  "libp2p-upnp",
+ "libp2p-yamux",
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "libp2p-allow-block-list"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1027ccf8d70320ed77e984f273bc8ce952f623762cb9bf2d126df73caef8041"
+version = "0.4.2"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-autonat"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a083675f189803d0682a2726131628e808144911dad076858bfbe30b13065499"
+version = "0.13.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "async-trait",
  "asynchronous-codec",
@@ -4789,29 +4859,25 @@ dependencies = [
  "quick-protobuf-codec",
  "rand",
  "rand_core",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-connection-limits"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d003540ee8baef0d254f7b6bfd79bac3ddf774662ca0abf69186d517ef82ad8"
+version = "0.4.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "void",
 ]
 
 [[package]]
 name = "libp2p-core"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a61f26c83ed111104cd820fe9bc3aaabbac5f1652a1d213ed6e900b7918a1298"
+version = "0.42.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "either",
  "fnv",
@@ -4829,18 +4895,16 @@ dependencies = [
  "rw-stream-sink",
  "serde",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tracing",
- "unsigned-varint 0.8.0",
- "void",
+ "unsigned-varint",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-dns"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97f37f30d5c7275db282ecd86e54f29dd2176bd3ac656f06abf43bedb21eb8bd"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "async-trait",
  "futures",
@@ -4854,10 +4918,10 @@ dependencies = [
 
 [[package]]
 name = "libp2p-gossipsub"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e830fdf24ac8c444c12415903174d506e1e077fbe3875c404a78c5935a8543"
+version = "0.48.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
+ "async-channel",
  "asynchronous-codec",
  "base64 0.22.1",
  "byteorder",
@@ -4865,7 +4929,7 @@ dependencies = [
  "either",
  "fnv",
  "futures",
- "futures-ticker",
+ "futures-timer",
  "getrandom",
  "hex_fmt",
  "libp2p-core",
@@ -4880,15 +4944,13 @@ dependencies = [
  "sha2",
  "smallvec",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-identify"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711b004a273be4f30202778856368683bd9a83c4c7dcc8f848847606831a4e3"
+version = "0.46.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "asynchronous-codec",
  "either",
@@ -4902,9 +4964,8 @@ dependencies = [
  "quick-protobuf",
  "quick-protobuf-codec",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tracing",
- "void",
 ]
 
 [[package]]
@@ -4928,9 +4989,8 @@ dependencies = [
 
 [[package]]
 name = "libp2p-kad"
-version = "0.46.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced237d0bd84bbebb7c2cad4c073160dacb4fe40534963c32ed6d4c6bb7702a3"
+version = "0.47.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "arrayvec",
  "asynchronous-codec",
@@ -4949,18 +5009,16 @@ dependencies = [
  "serde",
  "sha2",
  "smallvec",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tracing",
  "uint",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-mdns"
 version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b8546b6644032565eb29046b42744aee1e9f261ed99671b2c93fb140dba417"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "data-encoding",
  "futures",
@@ -4974,14 +5032,12 @@ dependencies = [
  "socket2",
  "tokio",
  "tracing",
- "void",
 ]
 
 [[package]]
 name = "libp2p-metrics"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ebafa94a717c8442d8db8d3ae5d1c6a15e30f2d347e0cd31d057ca72e42566"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "futures",
  "libp2p-core",
@@ -4996,10 +5052,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "libp2p-noise"
+version = "0.45.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
+dependencies = [
+ "asynchronous-codec",
+ "bytes",
+ "curve25519-dalek",
+ "futures",
+ "libp2p-core",
+ "libp2p-identity",
+ "multiaddr",
+ "multihash",
+ "once_cell",
+ "quick-protobuf",
+ "rand",
+ "sha2",
+ "snow",
+ "static_assertions",
+ "thiserror 2.0.3",
+ "tracing",
+ "x25519-dalek",
+ "zeroize",
+]
+
+[[package]]
 name = "libp2p-quic"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46352ac5cd040c70e88e7ff8257a2ae2f891a4076abad2c439584a31c15fd24e"
+version = "0.11.2"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "bytes",
  "futures",
@@ -5014,16 +5094,15 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.18",
  "socket2",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "libp2p-request-response"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1356c9e376a94a75ae830c42cdaea3d4fe1290ba409a22c809033d1b7dcab0a6"
+version = "0.27.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "async-trait",
  "cbor4ii",
@@ -5037,15 +5116,13 @@ dependencies = [
  "serde",
  "smallvec",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm"
-version = "0.45.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dd6741793d2c1fb2088f67f82cf07261f25272ebe3c0b0c311e0c6b50e851a"
+version = "0.45.2"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "either",
  "fnv",
@@ -5061,15 +5138,13 @@ dependencies = [
  "smallvec",
  "tokio",
  "tracing",
- "void",
  "web-time",
 ]
 
 [[package]]
 name = "libp2p-swarm-derive"
 version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "206e0aa0ebe004d778d79fb0966aa0de996c19894e2c0605ba2f8524dd4443d8"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5080,8 +5155,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tcp"
 version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad964f312c59dcfcac840acd8c555de8403e295d39edf96f5240048b5fcaa314"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5097,8 +5171,7 @@ dependencies = [
 [[package]]
 name = "libp2p-tls"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b23dddc2b9c355f73c1e36eb0c3ae86f7dc964a3715f0731cfad352db4d847"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "futures",
  "futures-rustls",
@@ -5108,16 +5181,15 @@ dependencies = [
  "ring 0.17.8",
  "rustls 0.23.18",
  "rustls-webpki 0.101.7",
- "thiserror 1.0.69",
+ "thiserror 2.0.3",
  "x509-parser",
  "yasna",
 ]
 
 [[package]]
 name = "libp2p-upnp"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf2d1b772bd3abca049214a3304615e6a36fa6ffc742bdd1ba774486200b8f"
+version = "0.3.1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5126,7 +5198,20 @@ dependencies = [
  "libp2p-swarm",
  "tokio",
  "tracing",
- "void",
+]
+
+[[package]]
+name = "libp2p-yamux"
+version = "0.46.0"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
+dependencies = [
+ "either",
+ "futures",
+ "libp2p-core",
+ "thiserror 2.0.3",
+ "tracing",
+ "yamux 0.12.1",
+ "yamux 0.13.3",
 ]
 
 [[package]]
@@ -5368,7 +5453,7 @@ dependencies = [
  "percent-encoding",
  "serde",
  "static_assertions",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
  "url",
 ]
 
@@ -5391,7 +5476,7 @@ checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
 dependencies = [
  "core2",
  "serde",
- "unsigned-varint 0.8.0",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5403,15 +5488,14 @@ checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
 [[package]]
 name = "multistream-select"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0df8e5eec2298a62b326ee4f0d7fe1a6b90a09dfcf9df37b38f947a8c42f19"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "bytes",
  "futures",
- "log",
  "pin-project",
  "smallvec",
- "unsigned-varint 0.7.2",
+ "tracing",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -5512,6 +5596,12 @@ dependencies = [
  "cfg-if",
  "libc",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "nom"
@@ -6307,6 +6397,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6534,14 +6647,13 @@ dependencies = [
 [[package]]
 name = "quick-protobuf-codec"
 version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a0580ab32b169745d7a39db2ba969226ca16738931be152a3209b409de2474"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.69",
- "unsigned-varint 0.8.0",
+ "thiserror 2.0.3",
+ "unsigned-varint",
 ]
 
 [[package]]
@@ -7353,8 +7465,7 @@ dependencies = [
 [[package]]
 name = "rw-stream-sink"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c9026ff5d2f23da5e45bbc283f156383001bfb09c4e44256d02c1a685fe9a1"
+source = "git+https://github.com/libp2p/rust-libp2p.git?rev=930118ef5a6566f058d22e1614a8e96b4c287262#930118ef5a6566f058d22e1614a8e96b4c287262"
 dependencies = [
  "futures",
  "pin-project",
@@ -7919,6 +8030,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.89",
+]
+
+[[package]]
+name = "snow"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "850948bee068e713b8ab860fe1adc4d109676ab4c3b621fd8147f06b261f2f85"
+dependencies = [
+ "aes-gcm",
+ "blake2",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "rand_core",
+ "ring 0.17.8",
+ "rustc_version 0.4.1",
+ "sha2",
+ "subtle",
 ]
 
 [[package]]
@@ -9003,16 +9131,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6889a77d49f1f013504cec6bf97a2c730394adedaeb1deb5ea08949a50541105"
 
 [[package]]
 name = "unsigned-varint"
@@ -9134,12 +9266,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "vsss-rs"
@@ -9643,6 +9769,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-parser"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9672,6 +9810,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
 dependencies = [
  "xml-rs",
+]
+
+[[package]]
+name = "yamux"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed0164ae619f2dc144909a9f082187ebb5893693d8c0196e8085283ccd4b776"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand",
+ "static_assertions",
+]
+
+[[package]]
+name = "yamux"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31b5e376a8b012bee9c423acdbb835fc34d45001cfa3106236a624e4b738028"
+dependencies = [
+ "futures",
+ "log",
+ "nohash-hasher",
+ "parking_lot 0.12.3",
+ "pin-project",
+ "rand",
+ "static_assertions",
+ "web-time",
 ]
 
 [[package]]

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -46,7 +46,7 @@ itertools = "0.13.0"
 jsonrpsee = {version = "0.22.4", features = ["client"]}
 k256 = "0.13.4"
 lazy_static = "1.5.0"
-libp2p = {version = "0.54.0", features = ["identify"]}
+libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "930118ef5a6566f058d22e1614a8e96b4c287262", features = ["identify"]}
 log = "0.4.22"
 octocrab = "0.42.1"
 primitive-types = "0.12.2"

--- a/z2/docs/converter.md
+++ b/z2/docs/converter.md
@@ -29,7 +29,7 @@
 
   cat > config.toml <<-EOF
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWNYaasyfY1wFrSHga3WBdZkb7bGhQiUz9926bQvk4HQj2", "/ip4/10.40.5.16/udp/3333/quic-v1" ]
+bootstrap_address = [ "12D3KooWNYaasyfY1wFrSHga3WBdZkb7bGhQiUz9926bQvk4HQj2", "/ip4/10.40.5.16/tcp/3333" ]
 
 [[nodes]]
 eth_chain_id = 33101 # change the chain it for your conversion

--- a/z2/resources/chain-specs/zq2-devnet.toml
+++ b/z2/resources/chain-specs/zq2-devnet.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWFvZum3gpEQkj6o9Tg71uLuQZJ4hqXL32c8wPTcpkRnaP", "/ip4/34.124.169.174/udp/3333/quic-v1" ]
+bootstrap_address = [ "12D3KooWFvZum3gpEQkj6o9Tg71uLuQZJ4hqXL32c8wPTcpkRnaP", "/ip4/34.124.169.174/tcp/3333" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/chain-specs/zq2-perftest.toml
+++ b/z2/resources/chain-specs/zq2-perftest.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWEhXxYZtu2FyDNQCJL4wff525Gj8knCdRvE7gcNMDVp9V", "/ip4/34.143.150.198/udp/3333/quic-v1" ]
+bootstrap_address = [ "12D3KooWEhXxYZtu2FyDNQCJL4wff525Gj8knCdRvE7gcNMDVp9V", "/ip4/34.143.150.198/tcp/3333" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/chain-specs/zq2-protomainnet.toml
+++ b/z2/resources/chain-specs/zq2-protomainnet.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWLVoS2hGUZCh9fxaXHWYEu8qR8AexjUQgEkhwuuu1tD2P", "/ip4/34.142.187.75/udp/3333/quic-v1" ]
+bootstrap_address = [ "12D3KooWLVoS2hGUZCh9fxaXHWYEu8qR8AexjUQgEkhwuuu1tD2P", "/ip4/34.142.187.75/tcp/3333" ]
 
 [[nodes]]
 eth_chain_id = 32770

--- a/z2/resources/chain-specs/zq2-uccbtest.toml
+++ b/z2/resources/chain-specs/zq2-uccbtest.toml
@@ -1,5 +1,5 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWEGBpHkiRyiZzc4e52JhKMh5mCf9cMCmDRJ67cior5g7T", "/ip4/34.124.239.96/udp/3333/quic-v1" ]
+bootstrap_address = [ "12D3KooWEGBpHkiRyiZzc4e52JhKMh5mCf9cMCmDRJ67cior5g7T", "/ip4/34.124.239.96/tcp/3333" ]
 
 [[nodes]]
 eth_chain_id = 33469

--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -1,7 +1,7 @@
 p2p_port = 3333
 
 {%- if set_bootstrap_address == "true" %}
-bootstrap_address = [ "{{ bootstrap_peer_id }}", "/ip4/{{ bootstrap_public_ip }}/udp/3333/quic-v1" ]
+bootstrap_address = [ "{{ bootstrap_peer_id }}", "/ip4/{{ bootstrap_public_ip }}/tcp/3333" ]
 {%- endif %}
 
 [[nodes]]

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -45,7 +45,7 @@ hyper = "1.5.0"
 itertools = "0.13.0"
 jsonrpsee = { version = "0.24.3", features = ["jsonrpsee-http-client", "server"] }
 k256 = {version = "0.13.4", features = ["serde", "pem"] }
-libp2p = { version = "0.54.0", features = ["cbor", "dns", "gossipsub", "macros", "tokio", "request-response", "kad", "identify", "serde", "autonat", "quic"] }
+libp2p = { git = "https://github.com/libp2p/rust-libp2p.git", rev = "930118ef5a6566f058d22e1614a8e96b4c287262", features = ["cbor", "dns", "gossipsub", "macros", "tokio", "request-response", "kad", "identify", "serde", "autonat", "tcp", "noise", "yamux"] }
 lru = "0.12"
 lz4 = "1.24"
 once_cell = "1.20.2"


### PR DESCRIPTION
We now use the libp2p from github, since it includes some fixes and other features that make our networks more stable.

Also, we stop using QUIC and use TCP everywhere - We are suspicious this was the cause of the node hangs we saw in the devnet.