### PR TITLE
Increase SQLite in-memory cache size from 2MB to 256MB.

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -228,12 +228,17 @@ impl Db {
             connection
                 .pragma_update_and_check(None, "journal_size_limit", 1 << 25, |r| r.get(0))?;
 
+        // cache 1-days data (256MB) in-memory
+        connection.pragma_update(None, "cache_size", (1 << 28) / page_size)?;
+        let cache_size: i32 = connection.pragma_query_value(None, "cache_size", |r| r.get(0))?;
+
         tracing::info!(
             ?journal_mode,
             ?journal_size_limit,
             ?synchronous,
             ?temp_store,
             ?page_size,
+            ?cache_size,
             "PRAGMA"
         );
 


### PR DESCRIPTION
This has a small impact on block production times i.e. seems slightly faster.

Before:
```
203,404 | 50 | 59 | 1.18
220,059 | 50 | 60 | 1.20
223,665 | 50 | 62 | 1.24
```

After
```
213,196 | 50 | 58 | 1.16
215,213 | 50 | 58 | 1.16
217,378 | 50 | 59 | 1.18
234,540 | 50 | 60 | 1.20
```

Since it does not adversely impact block production times, I think it's fine to include.
