### PR TITLE
Add exemption for `scilla_gas` precompile gas charges

### DIFF
--- a/z2/src/docgen.rs
+++ b/z2/src/docgen.rs
@@ -388,6 +388,7 @@ pub fn get_implemented_jsonrpc_methods() -> Result<HashMap<ApiMethod, PageStatus
             blocks_per_epoch: 3600,
             epochs_per_checkpoint: 24,
             total_native_token_supply: total_native_token_supply_default(),
+            scilla_call_gas_exempt_addrs: vec![],
         },
         data_dir: None,
         state_cache_size: state_cache_size_default(),

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -534,6 +534,7 @@ impl Setup {
                     epochs_per_checkpoint: 24,
                     rewards_per_hour: 51_000_000_000_000_000_000_000u128.into(),
                     total_native_token_supply: total_native_token_supply_default(),
+                    scilla_call_gas_exempt_addrs: vec![],
                 },
                 block_request_limit: block_request_limit_default(),
                 max_blocks_in_flight: max_blocks_in_flight_default(),

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -286,6 +286,13 @@ pub struct ConsensusConfig {
     /// The total supply of native token in the network in Wei. Any funds which are not immediately assigned to an account (via genesis_accounts and genesis_deposits env vars) will be assigned to the zero account (0x0).
     #[serde(default = "total_native_token_supply_default")]
     pub total_native_token_supply: Amount,
+    /// Calls to the `scilla_call` precompile from these addresses cost a different amount of gas. If the provided gas
+    /// limit is not enough, the call will still succeed and we will charge as much gas as we can. This hack exists due
+    /// to important contracts deployed on Zilliqa 1's mainnet that pass the incorrect gas limit to `scilla_call`.
+    /// Zilliqa 1's implementation was broken and accepted these calls and these contracts are now widely used and
+    /// bridged to other chains.
+    #[serde(default)]
+    pub scilla_call_gas_exempt_addrs: Vec<Address>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -497,6 +497,7 @@ mod tests {
                 scilla_stdlib_dir: scilla_stdlib_dir_default(),
                 scilla_ext_libs_path: scilla_ext_libs_path_default(),
                 total_native_token_supply: total_native_token_supply_default(),
+                scilla_call_gas_exempt_addrs: vec![],
             },
             block_request_limit: block_request_limit_default(),
             max_blocks_in_flight: max_blocks_in_flight_default(),

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -47,6 +47,7 @@ pub struct State {
     pub scilla_ext_libs_path: ScillaExtLibsPath,
     pub block_gas_limit: EvmGas,
     pub gas_price: u128,
+    pub scilla_call_gas_exempt_addrs: Vec<Address>,
     pub chain_id: ChainId,
     pub block_store: Arc<BlockStore>,
 }
@@ -65,6 +66,7 @@ impl State {
             scilla_ext_libs_path: consensus_config.scilla_ext_libs_path.clone(),
             block_gas_limit: consensus_config.eth_block_gas_limit,
             gas_price: *consensus_config.gas_price,
+            scilla_call_gas_exempt_addrs: consensus_config.scilla_call_gas_exempt_addrs.clone(),
             chain_id: ChainId::new(config.eth_chain_id),
             block_store,
         }
@@ -227,6 +229,7 @@ impl State {
             scilla_ext_libs_path: self.scilla_ext_libs_path.clone(),
             block_gas_limit: self.block_gas_limit,
             gas_price: self.gas_price,
+            scilla_call_gas_exempt_addrs: self.scilla_call_gas_exempt_addrs.clone(),
             chain_id: self.chain_id,
             block_store: self.block_store.clone(),
         }

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -40,7 +40,7 @@ use ethers::{
     providers::{HttpClientError, JsonRpcClient, JsonRpcError, Provider},
     signers::LocalWallet,
     types::{Bytes, TransactionReceipt, H256, U64},
-    utils::secret_key_to_address,
+    utils::{get_contract_address, secret_key_to_address},
 };
 use foundry_compilers::{
     artifacts::{EvmVersion, SolcInput, Source},
@@ -337,6 +337,10 @@ impl Network {
                 blocks_per_epoch,
                 epochs_per_checkpoint: 1,
                 total_native_token_supply: total_native_token_supply_default(),
+                scilla_call_gas_exempt_addrs: vec![
+                    // Allow the *third* contract deployed by the genesis key to call `scilla_call` for free.
+                    Address::new(get_contract_address(secret_key_to_address(&genesis_key).0, 2).0),
+                ],
             },
             json_rpc_port: json_rpc_port_default(),
             allowed_timestamp_skew: allowed_timestamp_skew_default(),
@@ -461,6 +465,9 @@ impl Network {
                 scilla_stdlib_dir: scilla_stdlib_dir_default(),
                 scilla_ext_libs_path: scilla_ext_libs_path_default(),
                 total_native_token_supply: total_native_token_supply_default(),
+                scilla_call_gas_exempt_addrs: vec![Address::new(
+                    get_contract_address(secret_key_to_address(&self.genesis_key).0, 2).0,
+                )],
             },
             block_request_limit: block_request_limit_default(),
             max_blocks_in_flight: max_blocks_in_flight_default(),
@@ -569,6 +576,9 @@ impl Network {
                         scilla_stdlib_dir: scilla_stdlib_dir_default(),
                         scilla_ext_libs_path: scilla_ext_libs_path_default(),
                         total_native_token_supply: total_native_token_supply_default(),
+                        scilla_call_gas_exempt_addrs: vec![Address::new(
+                            get_contract_address(secret_key_to_address(&self.genesis_key).0, 2).0,
+                        )],
                     },
                     block_request_limit: block_request_limit_default(),
                     max_blocks_in_flight: max_blocks_in_flight_default(),

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -114,6 +114,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
             scilla_stdlib_dir: scilla_stdlib_dir_default(),
             scilla_ext_libs_path: scilla_ext_libs_path_default(),
             total_native_token_supply: total_native_token_supply_default(),
+            scilla_call_gas_exempt_addrs: vec![],
         },
         allowed_timestamp_skew: allowed_timestamp_skew_default(),
         data_dir: None,


### PR DESCRIPTION
To resolve #1611, this PR adds a configurable exemption for the `scilla_call` precompile gas costs. Most callers will use the existing behaviour where gas is correctly charged. However callers with an address configured in the `scilla_call_gas_exempt_addrs` list will instead be charged as much as we can, but their call won't fail if it runs out of gas.

We expect there are only a handful of contracts we wish to add to this exemption list (definately less than 100), so this felt like the most natural and efficient way to represent this fudge.