### PR TITLE
Don't run benchmarks in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: rustfmt
         run: cargo +nightly fmt --all --check
       - name: Test
-        run: cargo test --all-targets --all-features
+        run: cargo test --tests --examples --bins --all-features
       - name: Verify working directory is clean
         run: git diff --exit-code
   e2e_test:


### PR DESCRIPTION
The transaction benchmark takes a while to run in debug mode (by design because it generates many transactions). I didn't realise `cargo test --all-targets` would run it, which doubled CI times.