### PR TITLE
Fix repeated withdrawals

### DIFF
--- a/zilliqa/src/contracts/deposit.sol
+++ b/zilliqa/src/contracts/deposit.sol
@@ -666,6 +666,7 @@ contract Deposit {
             // Add a new withdrawal to the end of the queue.
             currentWithdrawal = withdrawals.pushBack();
             currentWithdrawal.startedAt = block.timestamp;
+            currentWithdrawal.amount = 0;
         }
         currentWithdrawal.amount += amount;
     }


### PR DESCRIPTION
This shall fix #1932 which happened because the `currentWithdrawal` in the `unstake()` function "reused" an earlier withdrawal and overwrote its `timestamp` but not its `amount` so the current `amount` was added to the `amount` of that earlier `withdrawal`.