### PR TITLE
Fixed missing Genesis deposit balances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You will need to start at least 4 nodes before the network will begin to make pr
 Note: You must include the public key and peer ID of one of the nodes in the config with the argument `-c`
 
 ```
-cargo run --bin zilliqa -- 65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227 -c ./infra/config.toml
+cargo run --bin zilliqa -- 65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227 -c ./infra/config_docker.toml
 cargo run --bin zilliqa -- 62070b1a3b5b30236e43b4f1bfd617e1af7474635558314d46127a708b9d302e  -c ./infra/config_rpc_disabled.toml
 cargo run --bin zilliqa -- 56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364 -c ./infra/config_rpc_disabled.toml
 cargo run --bin zilliqa -- db670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a -c ./infra/config_rpc_disabled.toml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
       dockerfile: Dockerfile
     container_name: zilliqanode0
     volumes:
-      - "./infra/config.toml:/config.toml"
+      - "./infra/config_docker.toml:/config.toml"
     command:
       - 65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227
     ports:
@@ -27,7 +27,7 @@ services:
     container_name: zilliqanode1
     image: zq2-node0
     volumes:
-      - "./infra/config.toml:/config.toml"
+      - "./infra/config_docker.toml:/config.toml"
     command:
       - 62070b1a3b5b30236e43b4f1bfd617e1af7474635558314d46127a708b9d302e
     networks:
@@ -41,7 +41,7 @@ services:
     container_name: zilliqanode2
     image: zq2-node0
     volumes:
-      - "./infra/config.toml:/config.toml"
+      - "./infra/config_docker.toml:/config.toml"
     command:
       - 56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364
     networks:
@@ -55,7 +55,7 @@ services:
     container_name: zilliqanode3
     image: zq2-node0
     volumes:
-      - "./infra/config.toml:/config.toml"
+      - "./infra/config_docker.toml:/config.toml"
     command:
       - db670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a
     networks:

--- a/infra/config_docker.toml
+++ b/infra/config_docker.toml
@@ -1,6 +1,6 @@
 bootstrap_address = [
     "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
-    "/ip4/198.51.100.103/udp/5643/quic-v1",
+    "/ip4/198.51.100.103/tcp/5643",
 ]
 p2p_port = 5643
 
@@ -72,6 +72,9 @@ consensus.genesis_accounts = [
         "5000000000000000000000",
     ],
 ]
+
+# speed up local/docker epochs
+consensus.blocks_per_epoch = 36
 
 # Reward parameters
 consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -9,7 +9,6 @@ use alloy::{
     primitives::{Address, B256},
 };
 use anyhow::{anyhow, Result};
-use contract_addr::DEPOSIT;
 use eth_trie::{EthTrie as PatriciaTrie, Trie};
 use ethabi::Token;
 use serde::{Deserialize, Serialize};
@@ -147,12 +146,6 @@ impl State {
             Ok(())
         })?;
 
-        let total_genesis_deposits = config
-            .consensus
-            .genesis_deposits
-            .iter()
-            .fold(0, |acc, item| acc + item.stake.0);
-
         // Set GENESIS account starting balances
         for (address, balance) in config.consensus.genesis_accounts {
             state.mutate_account(address, |a| {
@@ -160,6 +153,12 @@ impl State {
                 Ok(())
             })?;
         }
+
+        let total_genesis_deposits = config
+            .consensus
+            .genesis_deposits
+            .iter()
+            .fold(0, |acc, item| acc + item.stake.0);
 
         let initial_stakers: Vec<_> = config
             .consensus
@@ -187,10 +186,11 @@ impl State {
         state.force_deploy_contract_evm(deposit_data, Some(contract_addr::DEPOSIT))?;
 
         // Set DEPOSIT contract to total deposited at genesis
-        state.mutate_account(DEPOSIT, |a| {
+        state.mutate_account(contract_addr::DEPOSIT, |a| {
             a.balance = total_genesis_deposits;
             Ok(())
         })?;
+
         //for GenesisDeposit {
         //    public_key,
         //    peer_id,

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -9,6 +9,7 @@ use alloy::{
     primitives::{Address, B256},
 };
 use anyhow::{anyhow, Result};
+use contract_addr::DEPOSIT;
 use eth_trie::{EthTrie as PatriciaTrie, Trie};
 use ethabi::Token;
 use serde::{Deserialize, Serialize};
@@ -139,11 +140,20 @@ impl State {
             .expect(
                 "Genesis accounts + genesis deposits sum to more than total native token supply",
             );
+
+        // Set ZERO account to total available balance
         state.mutate_account(Address::ZERO, |a| {
             a.balance = zero_account_balance;
             Ok(())
         })?;
 
+        let total_genesis_deposits = config
+            .consensus
+            .genesis_deposits
+            .iter()
+            .fold(0, |acc, item| acc + item.stake.0);
+
+        // Set GENESIS account starting balances
         for (address, balance) in config.consensus.genesis_accounts {
             state.mutate_account(address, |a| {
                 a.balance = *balance;
@@ -176,6 +186,11 @@ impl State {
         )?;
         state.force_deploy_contract_evm(deposit_data, Some(contract_addr::DEPOSIT))?;
 
+        // Set DEPOSIT contract to total deposited at genesis
+        state.mutate_account(DEPOSIT, |a| {
+            a.balance = total_genesis_deposits;
+            Ok(())
+        })?;
         //for GenesisDeposit {
         //    public_key,
         //    peer_id,


### PR DESCRIPTION
This PR does two things:
- Fixes config.toml for local/docker, due to TCP changes.
- Sets the Deposit contract to the total deposits at genesis, which was missing.

Before this fix:
```
curl -X POST   -H "Content-Type: application/json"   --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x000000000000000000005a494C4445504F534954", "latest"],"id":1}' http://localhost:4201/
{"jsonrpc":"2.0","id":1,"result":"0x0"}
```

After this fix:
```
curl -X POST   -H "Content-Type: application/json"   --data '{"jsonrpc":"2.0","method":"eth_getBalance","params":["0x000000000000000000005a494C4445504F534954", "latest"],"id":1}' http://localhost:4201/
{"jsonrpc":"2.0","id":1,"result":"0x2116545850052128000000"}
```

The amount 0x2116545850052128000000 is 40000000000000000000000000ZIL, which corresponds to the total deposited amount in the genesis contract for local/docker.