### PR TITLE
Improve full block production benchmark

### DIFF
--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -14,6 +14,7 @@ use revm::primitives::{Bytes, TxKind};
 use tempfile::tempdir;
 use tokio::sync::mpsc;
 use zilliqa::{
+    cfg::{Amount, GenesisDeposit, NodeConfig},
     consensus::Consensus,
     crypto::{Hash, SecretKey},
     db::Db,
@@ -144,18 +145,17 @@ pub fn process_empty(c: &mut Criterion) {
     group.finish();
 }
 
-pub fn produce_full(c: &mut Criterion) {
-    let mut group = c.benchmark_group("produce-full");
-    group.throughput(criterion::Throughput::Elements(1));
-    let sample_size = 10;
-    group
-        .sample_size(sample_size)
-        .measurement_time(Duration::from_secs(60));
-
-    let secret_key = SecretKey::new().unwrap();
-    let (outbound_message_sender, _a) = mpsc::unbounded_channel();
-    let (local_message_sender, _b) = mpsc::unbounded_channel();
-    let (reset_timeout_sender, _c) = mpsc::unbounded_channel();
+fn consensus(
+    genesis_accounts: &[(Address, u128)],
+    genesis_deposits: &[(SecretKey, u128)],
+    index: usize,
+) -> Consensus {
+    let secret_key = genesis_deposits[index].0;
+    let (outbound_message_sender, a) = mpsc::unbounded_channel();
+    let (local_message_sender, b) = mpsc::unbounded_channel();
+    let (reset_timeout_sender, c) = mpsc::unbounded_channel();
+    // Leak the receivers so they don't get dropped later.
+    std::mem::forget((a, b, c));
     let message_sender = MessageSender {
         our_shard: 0,
         our_peer_id: PeerId::random(),
@@ -165,44 +165,76 @@ pub fn produce_full(c: &mut Criterion) {
     };
     let data_dir = tempdir().unwrap();
     let db = Db::new(Some(data_dir.path()), 0, 1024).unwrap();
-    let signer = LocalSigner::random();
-    let mut consensus = Consensus::new(
+    let mut config: NodeConfig = toml::from_str(
+        r#"
+            consensus.rewards_per_hour = "1"
+            consensus.blocks_per_hour = 1
+            consensus.minimum_stake = "1"
+            consensus.eth_block_gas_limit = 84000000
+            consensus.gas_price = "1"
+        "#,
+    )
+    .unwrap();
+    config.consensus.genesis_accounts = genesis_accounts
+        .iter()
+        .map(|(a, v)| (*a, Amount(*v)))
+        .collect();
+    config.consensus.genesis_deposits = genesis_deposits
+        .iter()
+        .enumerate()
+        .map(|(i, (k, v))| GenesisDeposit {
+            public_key: k.node_public_key(),
+            peer_id: k.to_libp2p_keypair().public().to_peer_id(),
+            stake: Amount(*v),
+            reward_address: Address::right_padding_from(&[i as u8 + 1]),
+            control_address: Address::right_padding_from(&[i as u8 + 1]),
+        })
+        .collect();
+    Consensus::new(
         secret_key,
-        toml::from_str(&format!(
-            r#"
-                consensus.rewards_per_hour = "1"
-                consensus.blocks_per_hour = 1
-                consensus.minimum_stake = "1"
-                consensus.eth_block_gas_limit = 84000000
-                consensus.gas_price = "1"
-                consensus.genesis_accounts = [
-                    [
-                        "{}",
-                        "1_000_000_000_000_000_000_000_000_000",
-                    ],
-                ]
-                consensus.genesis_deposits = [
-                    [
-                        "{}",
-                        "12D3KooWF4Zba8M8gkXS6aUe8oPa3stW5N17aX3eknSjW6bGAefe",
-                        "1",
-                        "0x0000000000000000000000000000000000000001",
-                        "0x0000000000000000000000000000000000000001",
-                    ],
-                ]
-            "#,
-            signer.address(),
-            secret_key.node_public_key()
-        ))
-        .unwrap(),
+        config,
         message_sender,
         reset_timeout_sender,
         Arc::new(db),
     )
-    .unwrap();
+    .unwrap()
+}
 
-    // Fill transaction pool with lots of basic transfers.
-    let txn_count = (sample_size as u64 * 80) * 4000;
+pub fn produce_full(crit: &mut Criterion) {
+    let mut group = crit.benchmark_group("produce-full");
+    group.throughput(criterion::Throughput::Elements(1));
+    let sample_size = 20;
+    group
+        .sample_size(sample_size)
+        .measurement_time(Duration::from_secs(120));
+
+    let signer = LocalSigner::random();
+    let genesis_accounts = vec![(signer.address(), 1_000_000_000_000_000_000_000_000_000)];
+
+    // We will create a dummy network with 2 validators - 'big' which has a large proportion of the stake and 'tiny'
+    // which has a small amount of stake. The intention is that 'big' will always be the block proposer, because the
+    // proposer is selected in proportion to the validators' relative stake. However, 'tiny' will still get to have a
+    // vote on this proposal, despite its vote not being needed to reach a supermajority. The benchmark will execute
+    // the following in each iteration:
+    // 1. Get 'big' to process the previous vote and propose a block
+    // 2. Get 'tiny' to vote on this block
+    // 3. Get 'big' to vote on this block
+    // Step 2 is important, because we want to measure the time it takes a validator to vote on a block it hasn't seen
+    // before. In step 3, 'big' will skip most of the block validation logic because it knows it built the block
+    // itself.
+
+    let secret_key_big = SecretKey::new().unwrap();
+    let secret_key_tiny = SecretKey::new().unwrap();
+    let genesis_deposits = vec![
+        (secret_key_big, 1_000_000_000_000_000_000_000_000_000),
+        (secret_key_tiny, 1),
+    ];
+
+    let mut big = consensus(&genesis_accounts, &genesis_deposits, 0);
+    let mut tiny = consensus(&genesis_accounts, &genesis_deposits, 1);
+
+    // Fill transaction pools with lots of basic transfers.
+    let txn_count = (sample_size as u64 * 40) * 4000;
     let to = Address::random();
     let progress = ProgressBar::new(txn_count).with_message("generating transactions");
     let txns: Vec<_> = (0..txn_count)
@@ -224,55 +256,83 @@ pub fn produce_full(c: &mut Criterion) {
         })
         .collect();
     for txn in txns {
-        let result = consensus.new_transaction(txn).unwrap();
+        let result = big.new_transaction(txn.clone()).unwrap();
+        assert!(result.was_added());
+        let result = tiny.new_transaction(txn).unwrap();
         assert!(result.was_added());
     }
 
     // Trigger a timeout to produce the vote for the genesis block.
-    let (_, message) = consensus.timeout().unwrap().unwrap();
+    let (_, message) = big.timeout().unwrap().unwrap();
     let ExternalMessage::Vote(vote) = message else {
         panic!()
     };
     let mut vote = *vote;
+    let from = big.peer_id();
 
     time::sync_with_fake_time(|| {
-        group.bench_function("produce-full", |b| {
-            b.iter(|| {
-                let proposal = consensus
-                    .vote(black_box(vote))
-                    .unwrap()
-                    .map(|(b, t)| Proposal::from_parts(b, t));
-                // The first vote should immediately result in a proposal. Subsequent views require a timeout before
-                // the proposal is produced. Therefore, we trigger a timeout if there was not a proposal from the vote.
-                let proposal = proposal.unwrap_or_else(|| {
-                    time::advance(Duration::from_secs(10));
-                    let (_, message) = consensus.timeout().unwrap().unwrap();
-                    let ExternalMessage::Proposal(p) = message else {
-                        panic!()
-                    };
-                    p
-                });
+        group.bench_function("produce-full", |bench| {
+            bench.iter(|| {
+                // We wrap each of these steps in a separate function call, so that they are listed separately in
+                // flamegraphs and we are able to measure the time spent in each. The function names are deliberately
+                // alphabetical, so they appear in order in the flamegraph.
 
-                assert_eq!(
-                    proposal.transactions.len(),
-                    4000,
-                    "proposal {} is not full",
-                    proposal.view()
-                );
-                // Deliberately set the `from` to a different peer ID, so we don't decide to 'fast-forward' the
-                // proposal because we know we've already executed it when building it.
-                let (_, next_vote) = consensus
-                    .proposal(PeerId::random(), black_box(proposal), false)
-                    .unwrap()
-                    .unwrap();
-                let ExternalMessage::Vote(next_vote) = next_vote else {
-                    panic!()
-                };
-                vote = *next_vote;
+                // 1. Get 'big' to process the previous vote and propose a block.
+                let proposal = a_big_process_vote(&mut big, vote);
+
+                // 2. Get 'tiny' to vote on this block.
+                b_tiny_process_block(&mut tiny, from, proposal.clone());
+
+                // 3. Get 'big' to vote on this block
+                vote = c_big_process_block(&mut big, from, proposal);
             })
         });
     });
     group.finish();
+}
+
+fn a_big_process_vote(big: &mut Consensus, vote: Vote) -> Proposal {
+    let proposal = big
+        .vote(black_box(vote))
+        .unwrap()
+        .map(|(b, t)| Proposal::from_parts(b, t));
+    // The first vote should immediately result in a proposal. Subsequent views require a timeout before
+    // the proposal is produced. Therefore, we trigger a timeout if there was not a proposal from the vote.
+    let proposal = proposal.unwrap_or_else(|| {
+        time::advance(Duration::from_secs(10));
+        let (_, message) = big.timeout().unwrap().unwrap();
+        let ExternalMessage::Proposal(p) = message else {
+            panic!()
+        };
+        p
+    });
+    assert_eq!(
+        proposal.transactions.len(),
+        4000,
+        "proposal {} is not full",
+        proposal.view()
+    );
+    proposal
+}
+
+fn b_tiny_process_block(tiny: &mut Consensus, from: PeerId, proposal: Proposal) {
+    let (_, tiny_vote) = tiny
+        .proposal(from, black_box(proposal), false)
+        .unwrap()
+        .unwrap();
+    // We assert 'tiny' actually voted but don't do anything with its vote.
+    assert!(matches!(tiny_vote, ExternalMessage::Vote(_)));
+}
+
+fn c_big_process_block(big: &mut Consensus, from: PeerId, proposal: Proposal) -> Vote {
+    let (_, vote) = big
+        .proposal(from, black_box(proposal), false)
+        .unwrap()
+        .unwrap();
+    let ExternalMessage::Vote(vote) = vote else {
+        panic!()
+    };
+    *vote
 }
 
 criterion_group!(


### PR DESCRIPTION
We create a dummy network with 2 validators - 'big' which has a large proportion of the stake and 'tiny' which has a small amount of stake. The intention is that 'big' will always be the block proposer, because the proposer is selected in proportion to the validators' relative stake. However, 'tiny' will still get to have a vote on this proposal, despite its vote not being needed to reach a supermajority. The benchmark will execute the following in each iteration:

1. Get 'big' to process the previous vote and propose a block
2. Get 'tiny' to vote on this block
3. Get 'big' to vote on this block

Step 2 is important, because we want to measure the time it takes a validator to vote on a block it hasn't seen before. In step 3, 'big' will skip most of the block validation logic because it knows it built the block itself.