### PR TITLE
Disable Otterscan indices by default

### DIFF
--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -28,3 +28,7 @@ consensus.epochs_per_checkpoint=24
 {%- endif %}
 
 api_servers = {{ api_servers }}
+
+{%- if enable_ots_indices %}
+enable_ots_indices = true
+{%- endif %}

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -527,6 +527,8 @@ impl ChainNode {
         // 4202 is not exposed, so enable everything for local debugging.
         let private_api = json!({ "port": 4202, "enabled_apis": ["admin", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] });
         let api_servers = json!([public_api, private_api]);
+        // Enable Otterscan indices on API nodes.
+        let enable_ots_indices = self.role == NodeRole::Api;
 
         let mut ctx = Context::new();
         ctx.insert("role", &role_name);
@@ -541,6 +543,7 @@ impl ChainNode {
             &whitelisted_evm_contract_addresses,
         );
         ctx.insert("api_servers", &api_servers);
+        ctx.insert("enable_ots_indices", &enable_ots_indices);
 
         Ok(Tera::one_off(spec_config, &ctx, false)?)
     }

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -544,6 +544,7 @@ impl Setup {
                 block_request_batch_size: block_request_batch_size_default(),
                 state_rpc_limit: state_rpc_limit_default(),
                 failed_request_sleep_duration: failed_request_sleep_duration_default(),
+                enable_ots_indices: false,
             };
             println!("🧩  Node {node_index} has RPC port {port}");
 

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -110,6 +110,9 @@ pub struct NodeConfig {
     /// Defaults to 10 seconds.
     #[serde(default = "failed_request_sleep_duration_default")]
     pub failed_request_sleep_duration: Duration,
+    /// Enable additional indices used by some Otterscan APIs. Enabling this will use more disk space and block processing will take longer.
+    #[serde(default)]
+    pub enable_ots_indices: bool,
 }
 
 impl Default for NodeConfig {
@@ -128,6 +131,7 @@ impl Default for NodeConfig {
             block_request_batch_size: block_request_batch_size_default(),
             state_rpc_limit: state_rpc_limit_default(),
             failed_request_sleep_duration: failed_request_sleep_duration_default(),
+            enable_ots_indices: false,
         }
     }
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -517,13 +517,13 @@ impl Node {
                 let other_txn = self
                     .get_transaction_by_hash(other_txn_hash)?
                     .ok_or_else(|| anyhow!("transaction not found: {other_txn_hash}"))?;
-                state.apply_transaction(other_txn, block.header, inspector::noop())?;
+                state.apply_transaction(other_txn, block.header, inspector::noop(), false)?;
             } else {
                 let config = TracingInspectorConfig::from_parity_config(trace_types);
                 let mut inspector = TracingInspector::new(config);
                 let pre_state = state.try_clone()?;
 
-                let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+                let result = state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
                 let TransactionApplyResult::Evm(result, ..) = result else {
                     return Err(anyhow!("not an EVM transaction"));
@@ -568,9 +568,9 @@ impl Node {
                 let other_txn = self
                     .get_transaction_by_hash(other_txn_hash)?
                     .ok_or_else(|| anyhow!("transaction not found: {other_txn_hash}"))?;
-                state.apply_transaction(other_txn, parent.header, inspector::noop())?;
+                state.apply_transaction(other_txn, parent.header, inspector::noop(), false)?;
             } else {
-                let result = state.apply_transaction(txn, block.header, inspector)?;
+                let result = state.apply_transaction(txn, block.header, inspector, true)?;
 
                 return Ok(result);
             }
@@ -635,7 +635,7 @@ impl Node {
             let inspector_config = TracingInspectorConfig::from_geth_config(&config);
             let mut inspector = TracingInspector::new(inspector_config);
 
-            let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+            let result = state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
             let TransactionApplyResult::Evm(result, ..) = result else {
                 return Ok(None);
@@ -661,7 +661,8 @@ impl Node {
                         TracingInspectorConfig::from_geth_call_config(&call_config),
                     );
 
-                    let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+                    let result =
+                        state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
                     let TransactionApplyResult::Evm(result, ..) = result else {
                         return Ok(None);
@@ -681,7 +682,8 @@ impl Node {
                 }
                 GethDebugBuiltInTracerType::FourByteTracer => {
                     let mut inspector = FourByteInspector::default();
-                    let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+                    let result =
+                        state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
                     let TransactionApplyResult::Evm(_, _) = result else {
                         return Ok(None);
@@ -696,7 +698,8 @@ impl Node {
                     let mux_config = tracer_config.into_mux_config()?;
 
                     let mut inspector = MuxInspector::try_from_config(mux_config)?;
-                    let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+                    let result =
+                        state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
                     let TransactionApplyResult::Evm(result, ..) = result else {
                         return Ok(None);
@@ -718,7 +721,8 @@ impl Node {
                     let mut inspector = TracingInspector::new(
                         TracingInspectorConfig::from_geth_prestate_config(&prestate_config),
                     );
-                    let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+                    let result =
+                        state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
                     let TransactionApplyResult::Evm(result, ..) = result else {
                         return Ok(None);
@@ -748,7 +752,7 @@ impl Node {
                     JsInspector::with_transaction_context(js_code, config, transaction_context)
                         .map_err(|e| anyhow!("Unable to create js inspector: {e}"))?;
 
-                let result = state.apply_transaction(txn, block.header, &mut inspector)?;
+                let result = state.apply_transaction(txn, block.header, &mut inspector, true)?;
 
                 let TransactionApplyResult::Evm(result, env) = result else {
                     return Ok(None);

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -357,6 +357,7 @@ impl Network {
             block_request_batch_size: block_request_batch_size_default(),
             state_rpc_limit: state_rpc_limit_default(),
             failed_request_sleep_duration: failed_request_sleep_duration_default(),
+            enable_ots_indices: true,
         };
 
         let (nodes, external_receivers, local_receivers, request_response_receivers): (
@@ -479,6 +480,7 @@ impl Network {
             block_request_batch_size: block_request_batch_size_default(),
             state_rpc_limit: state_rpc_limit_default(),
             failed_request_sleep_duration: failed_request_sleep_duration_default(),
+            enable_ots_indices: true,
         };
 
         let secret_key = options.secret_key_or_random(self.rng.clone());

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -132,6 +132,7 @@ async fn block_and_tx_data_persistence(mut network: Network) {
         block_request_batch_size: block_request_batch_size_default(),
         state_rpc_limit: state_rpc_limit_default(),
         failed_request_sleep_duration: failed_request_sleep_duration_default(),
+        enable_ots_indices: true,
     };
     let mut rng = network.rng.lock().unwrap();
     let result = crate::node(


### PR DESCRIPTION
This significantly improves performance on nodes which don't need to serve the `ots_` APIs.

```
produce-full/produce-full
                        time:   [1.0781 s 1.2170 s 1.3138 s]
                        thrpt:  [0.7612  elem/s 0.8217  elem/s 0.9275  elem/s]
                 change:
                        time:   [-50.851% -43.988% -35.863%] (p = 0.00 < 0.05)
                        thrpt:  [+55.917% +78.532% +103.46%]
                        Performance has improved.
```