### PR TITLE
Clean up unused imports and dead code

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -1,52 +1,34 @@
-#![allow(unused_imports)]
-
 use std::{
     collections::BTreeMap,
-    fs,
-    path::PathBuf,
     process::{self, Child, ExitStatus, Stdio},
-    str::FromStr,
     sync::Arc,
-    thread::sleep,
     time::Duration,
 };
 
 use alloy::{
     consensus::{TxEip1559, TxEip2930, TxLegacy, EMPTY_ROOT_HASH},
-    primitives::{Address, Parity, PrimitiveSignature, TxKind, B256, U256},
+    primitives::{Address, PrimitiveSignature, TxKind, B256, U256},
 };
 use anyhow::{anyhow, Context, Result};
-use bitvec::{bitarr, bitvec, order::Msb0};
-use clap::{Parser, Subcommand};
+use bitvec::{bitarr, order::Msb0};
 use eth_trie::{EthTrie, MemoryDB, Trie};
-use ethabi::Token;
-use git2::Repository;
 use indicatif::{ProgressBar, ProgressFinish, ProgressIterator, ProgressStyle};
 use itertools::Itertools;
 use libp2p::PeerId;
-use revm::primitives::ResultAndState;
-use serde::{Deserialize, Serialize};
-use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
-use sha3::Keccak256;
-use tempfile::TempDir;
 use tokio::sync::mpsc;
-use tracing::{debug, info, trace, warn};
+use tracing::{debug, trace, warn};
 use zilliqa::{
     block_store::BlockStore,
     cfg::{scilla_ext_libs_path_default, Amount, Config, NodeConfig},
-    consensus::Validator,
-    constants::SCILLA_INVOKE_CHECKER,
-    contracts,
-    crypto::{self, Hash, SecretKey},
+    crypto::{Hash, SecretKey},
     db::Db,
-    exec::{store_external_libraries, BaseFeeCheck, ScillaError, ScillaException},
-    inspector,
-    message::{Block, BlockHeader, QuorumCertificate, Vote, MAX_COMMITTEE_SIZE},
+    exec::store_external_libraries,
+    message::{Block, QuorumCertificate, Vote, MAX_COMMITTEE_SIZE},
     node::{MessageSender, RequestId},
     schnorr,
-    scilla::{storage_key, CheckOutput, ParamValue, Transition, TransitionParam},
-    state::{contract_addr, Account, Code, ContractInit, State},
+    scilla::{storage_key, CheckOutput, ParamValue, Transition},
+    state::{Account, Code, ContractInit, State},
     time::SystemTime,
     transaction::{
         EvmGas, EvmLog, Log, ScillaGas, SignedTransaction, TransactionReceipt, TxZilliqa, ZilAmount,

--- a/z2/src/docgen.rs
+++ b/z2/src/docgen.rs
@@ -1,25 +1,19 @@
 // Code to generate documentation from .tera.md files.
-#![allow(unused_imports)]
 
 use std::{
     cmp::{Ord, Ordering, PartialOrd},
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     convert::TryFrom,
     fmt,
     path::{Path, PathBuf},
     sync::{atomic::AtomicUsize, Arc, Mutex},
 };
 
-use alloy::primitives::{address, Address};
 use anyhow::{anyhow, Context as _, Result};
-use libp2p::PeerId;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tera::Tera;
-use tokio::{
-    fs,
-    sync::{broadcast, mpsc::UnboundedSender},
-};
+use tokio::fs;
 use zilliqa::{
     cfg::{
         allowed_timestamp_skew_default, block_request_batch_size_default,
@@ -28,14 +22,11 @@ use zilliqa::{
         json_rpc_port_default, local_address_default, max_blocks_in_flight_default,
         minimum_time_left_for_empty_block_default, scilla_address_default,
         scilla_ext_libs_path_default, scilla_stdlib_dir_default, state_cache_size_default,
-        state_rpc_limit_default, total_native_token_supply_default, Amount, ConsensusConfig,
-        NodeConfig,
+        state_rpc_limit_default, total_native_token_supply_default, ConsensusConfig, NodeConfig,
     },
     crypto::SecretKey,
-    node::{MessageSender, Node},
     transaction::EvmGas,
 };
-use zqutils::utils;
 
 const SUPPORTED_APIS_PATH_NAME: &str = "index";
 

--- a/z2/src/perf.rs
+++ b/z2/src/perf.rs
@@ -1,32 +1,18 @@
-#![allow(unused_imports)]
-
-use std::{
-    cell::{RefCell, RefMut},
-    fmt, fs,
-    io::{Cursor, Write},
-    iter,
-    path::Path,
-    str::FromStr,
-    sync::RwLock,
-};
+use std::{fmt, fs, iter, str::FromStr};
 
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
-use clap::ValueEnum;
-use ethers::{middleware::Middleware as _, signers::Signer, types::U256};
-use lazy_static::lazy_static;
-use rand::{self, distributions::DistString as _, prelude::*};
+use ethers::{middleware::Middleware as _, signers::Signer};
+use rand::{self, prelude::*};
 use serde::{Deserialize, Serialize};
-use tempfile;
 use tokio::time::{sleep, Duration};
-use url::Url;
 use zilliqa_rs::{
     middlewares::Middleware,
     providers::{Http, Provider},
 };
 
 /// Stolen from z blockchain perf, partly so external contributors can also run it.
-use crate::{perf_mod, utils};
+use crate::perf_mod;
 
 pub struct Perf {
     pub config: Config,

--- a/z2/src/perf_mod/conform.rs
+++ b/z2/src/perf_mod/conform.rs
@@ -1,34 +1,13 @@
-#![allow(unused_imports)]
+use std::{collections::HashMap, path::PathBuf};
 
-use std::{
-    cell::{RefCell, RefMut},
-    collections::HashMap,
-    fs,
-    io::{Cursor, Write},
-    iter,
-    path::PathBuf,
-};
-
-use anyhow::{anyhow, Context as _, Result};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use clap::ValueEnum;
-use futures::task::Poll;
-use lazy_static::lazy_static;
-use rand::{self, distributions::DistString as _, prelude::*};
-use serde::{Deserialize, Serialize};
-use tempfile;
-use tokio::time::{sleep, Duration};
-use url::Url;
-use zilliqa_rs::{
-    middlewares::Middleware,
-    providers::{Http, Provider},
-};
+use rand::{self, prelude::*};
 use zqutils::commands::{reap_on_termination, CommandBuilder};
 
 use crate::{
     perf,
     perf::{AccountKind, PhaseResult, TransactionResult},
-    utils,
 };
 
 pub enum MachineState {

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 use std::{
     collections::{HashMap, HashSet},
     fmt,
@@ -17,7 +16,7 @@ use crate::{
     chain::node::NodeRole,
     kpi,
     node_spec::{Composition, NodeSpec},
-    utils, validators,
+    utils,
 };
 
 const DEFAULT_API_URL: &str = "https://api.zq2-devnet.zilliqa.com";

--- a/z2/src/zq1/db.rs
+++ b/z2/src/zq1/db.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::{
     collections::HashMap, convert::Infallible, fs, num::ParseIntError, path::Path,
     string::FromUtf8Error, sync::Arc,
@@ -223,14 +221,6 @@ impl Db {
         Ok(self
             .contract_init_state_2
             .get_u8(&ReadOptions::new(), format!("{:02x}", account).as_bytes())?)
-    }
-
-    pub(crate) fn put_init_state_2(&self, address: Address, init_data: &[u8]) -> Result<()> {
-        Ok(self.contract_init_state_2.put_u8(
-            &WriteOptions::new(),
-            format!("{:02x}", address).as_bytes(),
-            init_data,
-        )?)
     }
 
     pub fn contract_init_state_2(


### PR DESCRIPTION
The extra imports were causing failures in #1992 because we import deprecated stuff and don't use it.