### PR TITLE
Cancel duplicate CI runs on non-main branches

### DIFF
--- a/.github/workflows/base_benchmarks.yaml
+++ b/.github/workflows/base_benchmarks.yaml
@@ -2,6 +2,10 @@ on:
   push:
     branches: main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   benchmark_base_branch:
     name: Continuous Benchmarking

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,10 @@ on:
     types:
       - checks_requested
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 env:
   CARGO_TERM_COLOR: always
   # Run a decent number of samples for our randomized tests

--- a/.github/workflows/pr_benchmarks.yaml
+++ b/.github/workflows/pr_benchmarks.yaml
@@ -2,6 +2,10 @@ on:
   pull_request:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   benchmark_pr_branch:
     name: Continuous Benchmarking PRs

--- a/.github/workflows/pr_benchmarks_closed.yaml
+++ b/.github/workflows/pr_benchmarks_closed.yaml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: bencherdev/bencher@main
       - name: Archive closed PR branch
+        continue-on-error: true # This will fail if the branch did not exist in bencher. This is fine.
         run: |
           bencher archive \
           --project zq2 \


### PR DESCRIPTION
With this change, if someone pushes a new change to a branch, the previous CI runs will be cancelled in favour of running again on the latest change. This should relieve some pressure on our CI runners.

Also, I included a small change to avoid spurious failures from the "Archive closed PR branch" workflow.