### PR TITLE
API updates

### DIFF
--- a/docs/api/zilliqa/dsblocklisting.doc.md
+++ b/docs/api/zilliqa/dsblocklisting.doc.md
@@ -6,12 +6,17 @@ DSBlockListing
 
 ds,block,listing
 
+# Status
+
+Deprecated
+
 # Description
+
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
 
 Returns a paginated list of up to **10** Directory Service (DS) blocks and their
 block hashes for a specified page. The `maxPages` variable that specifies the
 maximum number of pages available is also returned.
-Deprecated in ZQ2; now returns a constant placeholder value.
 
 # Curl
 

--- a/docs/api/zilliqa/getcurrentdscomm.doc.md
+++ b/docs/api/zilliqa/getcurrentdscomm.doc.md
@@ -6,10 +6,15 @@ GetCurrentDSComm
 
 DS,committee,get,current
 
+# Status
+
+Deprecated
+
 # Description
 
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
+
 Gives information on the public keys of DS committee members. Also, returns a parameter indicating the number of dsguards in the network.
-Deprecated in ZQ2; now returns a constant placeholder value.
 
 # Curl
 

--- a/docs/api/zilliqa/getcurrentdsepoch.doc.md
+++ b/docs/api/zilliqa/getcurrentdsepoch.doc.md
@@ -6,11 +6,16 @@ GetCurrentDSEpoch
 
 DS,epoch,get,current
 
+# Status
+
+Deprecated
+
 # Description
+
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
 
 Returns the current number of DS blocks in the network. This is represented as a
 `String`.
-Deprecated in ZQ2; now returns a constant placeholder value.
 
 # Curl
 

--- a/docs/api/zilliqa/getdsblock.doc.md
+++ b/docs/api/zilliqa/getdsblock.doc.md
@@ -6,10 +6,15 @@ GetDSBlock
 
 DS,block,get
 
+# Status
+
+Deprecated
+
 # Description
 
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
+
 Returns the details of a specified Directory Service block.
-Deprecated in ZQ2; now returns a constant placeholder value.
 
 # Curl
 

--- a/docs/api/zilliqa/getdsblockrate.doc.md
+++ b/docs/api/zilliqa/getdsblockrate.doc.md
@@ -6,10 +6,15 @@ GetDSBlockRate
 
 DS,block,get,rate
 
+# Status
+
+Deprecated
+
 # Description
 
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
+
 Returns the current Directory Service blockrate per second.
-Deprecated in ZQ2; now returns a constant placeholder value.
 
 # Curl
 

--- a/docs/api/zilliqa/getdsblockverbose.doc.md
+++ b/docs/api/zilliqa/getdsblockverbose.doc.md
@@ -6,7 +6,13 @@ GetDSBlockVerbose
 
 DS,block,get,verbose
 
+# Status
+
+Deprecated
+
 # Description
+
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
 
 Returns verbose details of a specified Directory Service block.
 Deprecated in ZQ2; now returns a constant placeholder value.

--- a/docs/api/zilliqa/getlatestdsblock.doc.md
+++ b/docs/api/zilliqa/getlatestdsblock.doc.md
@@ -6,10 +6,15 @@ GetLatestDSBlock
 
 DS,block,get,latest
 
+# Status
+
+Deprecated
+
 # Description
 
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
+
 Returns the details of the most recent Directory Service block.
-Deprecated in ZQ2; now returns a constant placeholder value.
 
 # Curl
 

--- a/docs/api/zilliqa/getminerinfo.doc.md
+++ b/docs/api/zilliqa/getminerinfo.doc.md
@@ -8,12 +8,12 @@ miner,info,get
 
 # Status
 
-NotYetDocumented
+Deprecated
 
 # Description
 
 DS nodes no longer exist in ZQ2, so this API now returns placeholder data.
-In Zilliqa 2.0, sharding structure should be accessed via the XShard on-chain query mechanism.
+In Zilliqa 2.0, sharding structure should instead be accessed via the XShard on-chain query mechanism.
 
 # Curl
 

--- a/docs/api/zilliqa/getnodetype.doc.md
+++ b/docs/api/zilliqa/getnodetype.doc.md
@@ -8,7 +8,7 @@ node,type,get
 
 # Status
 
-NotDocumented
+Deprecated
 
 # Description
 

--- a/docs/api/zilliqa/getnumdsblocks.doc.md
+++ b/docs/api/zilliqa/getnumdsblocks.doc.md
@@ -8,9 +8,11 @@ DS,get,blocks,count,number
 
 # Status
 
-NotDocumented
+Deprecated
 
 # Description
+
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
 
 Returns the current number of validated Directory Service blocks in the network. This is represented as a `String`.
 
@@ -81,4 +83,3 @@ func GetNumDSBlocks() {
 | `jsonrpc` | string | Required | `"2.0"`            |
 | `method`  | string | Required | `"GetNumDSBlocks"` |
 | `params`  | string | Required | Empty string `""`  |
-

--- a/docs/api/zilliqa/getnumtxnsdsepoch.doc.md
+++ b/docs/api/zilliqa/getnumtxnsdsepoch.doc.md
@@ -6,7 +6,13 @@ GetNumTxnsDSEpoch
 
 get,count,transactions,ds,epoch
 
+# Status
+
+Deprecated
+
 # Description
+
+This API is deprecated in ZQ2. It now returns a placeholder value for backwards compatibility.
 
 Returns the number of validated transactions included in this DS epoch. This is represented as a `String`.
 

--- a/docs/api/zilliqa/getprevdifficulty.doc.md
+++ b/docs/api/zilliqa/getprevdifficulty.doc.md
@@ -8,7 +8,7 @@ get,difficulty
 
 # Status
 
-NeverImplemented
+Deprecated
 
 # Description
 

--- a/docs/api/zilliqa/getprevdsdifficulty.doc.md
+++ b/docs/api/zilliqa/getprevdsdifficulty.doc.md
@@ -8,11 +8,11 @@ get,difficulty,DS
 
 # Status
 
-NeverImplemented
+Deprecated
 
 # Description
 
-This is no longer a valid endpoint in Zilliqa 2.0 and always returns 0 for backwards compatibility.
+This API is deprecated in ZQ2. It now always returns 0 for backwards compatibility.
 
 Returns the minimum DS difficulty of the previous block. This is represented as an `Number`.
 

--- a/docs/api/zilliqa/getstateproof.doc.md
+++ b/docs/api/zilliqa/getstateproof.doc.md
@@ -6,7 +6,13 @@ GetStateProof
 
 state,proof,get
 
+# Status
+
+Deprecated
+
 # Description
+
+This is no longer a valid endpoint in Zilliqa 2.0 and always returns empty vectors for backwards compatibility.
 
 This API returns the state proof for the corresponding TxBlock for a smart contract.
 

--- a/docs/api/zilliqa/gettxblock.doc.md
+++ b/docs/api/zilliqa/gettxblock.doc.md
@@ -6,15 +6,9 @@ GetTxBlock
 
 tx,block,get,number
 
-# Status
-
-PartiallyImplemented
-
 # Description
 
 `GetTxBlock` returns the details of a specified transaction block.
-
-This API is partially implemented - see (<https://github.com/Zilliqa/zq2/issues/79>)
 
 # Curl
 
@@ -133,4 +127,3 @@ func GetTxBlock(t *testing.T) {
 | `jsonrpc` | string | Required | `"2.0"`                                                   |
 | `method`  | string | Required | `"GetTxBlock"`                                            |
 | `params`  | string | Required | Specified TX block number to return. Example: `"1002353"` |
-


### PR DESCRIPTION
- Adds deprecation status tags to deprecated endpoints (mainly ones pertaining to DS blocks)
- Removes partially implemented status tag gettxblock, which is now implemented