### PR TITLE
Fix caller of `scilla_call`s with `keep_origin = 1`

### DIFF
--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -433,6 +433,7 @@ impl Default for Forks {
         vec![Fork {
             at_height: 0,
             failed_scilla_call_from_gas_exempt_caller_causes_revert: true,
+            call_mode_1_sets_caller_to_parent_caller: true,
         }]
         .try_into()
         .unwrap()
@@ -460,6 +461,16 @@ pub struct Fork {
     /// precompile and the inner Scilla call fails, the entire transaction will revert. If false, the normal EVM
     /// semantics apply where the caller can decide how to act based on the success of the inner call.
     pub failed_scilla_call_from_gas_exempt_caller_causes_revert: bool,
+    /// If true, if a call is made to the `scilla_call` precompile with `call_mode` / `keep_origin` set to `1`, the
+    /// `_sender` of the inner Scilla call will be set to the caller of the current call-stack. If false, the `_sender`
+    /// will be set to the original transaction signer.
+    ///
+    /// For example:
+    /// A (EOA) -> B (EVM) -> C (EVM) -> D (Scilla)
+    ///
+    /// When this flag is true, `D` will see the `_sender` as `B`. When this flag is false, `D` will see the `_sender`
+    /// as `A`.
+    pub call_mode_1_sets_caller_to_parent_caller: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -429,6 +429,9 @@ pub struct ExternalContext<'a, I> {
     pub scilla_call_gas_exempt_addrs: &'a [Address],
     // This flag is only used for zq1 whitelisted contracts, and it's used to detect if the entire transaction should be marked as failed
     pub enforce_transaction_failure: bool,
+    /// The caller of each call in the call-stack. This is needed because the `scilla_call` precompile needs to peek
+    /// into the call-stack. This will always be non-empty and the first entry will be the transaction signer.
+    pub callers: Vec<Address>,
 }
 
 impl<I: Inspector<PendingState>> GetInspector<PendingState> for ExternalContext<'_, I> {
@@ -520,6 +523,7 @@ impl State {
             fork: self.forks.get(current_block.number),
             scilla_call_gas_exempt_addrs: &self.scilla_call_gas_exempt_addrs,
             enforce_transaction_failure: false,
+            callers: vec![from_addr],
         };
         let pending_state = PendingState::new(self.clone());
         let mut evm = Evm::builder()

--- a/zilliqa/tests/it/contracts/ScillaInterop.sol
+++ b/zilliqa/tests/it/contracts/ScillaInterop.sol
@@ -11,6 +11,35 @@ library ScillaConnector {
      * @dev Calls a ZRC2 contract function with two arguments
      * @param target The address of the ZRC2 contract
      * @param tran_name The name of the function to call
+     */
+    function call(address target, string memory tran_name) internal {
+        bytes memory encodedArgs = abi.encode(
+            target,
+            tran_name,
+            CALL_SCILLA_WITH_THE_SAME_SENDER
+        );
+        uint256 argsLength = encodedArgs.length;
+
+        assembly {
+            let ok := call(
+                gas(),
+                SCILLA_CALL_PRECOMPILE_ADDRESS,
+                0,
+                add(encodedArgs, 0x20),
+                argsLength,
+                0x20,
+                0
+            )
+            if iszero(ok) {
+                revert(0, 0)
+            }
+        }
+    }
+
+    /**
+     * @dev Calls a ZRC2 contract function with two arguments
+     * @param target The address of the ZRC2 contract
+     * @param tran_name The name of the function to call
      * @param arg1 The first argument to the function
      * @param arg2 The second argument to the function
      */
@@ -313,6 +342,13 @@ contract ScillaInterop {
         address key2
     ) public view returns (uint128) {
         return scillaContract.readNestedMapUint128(varName, key1, key2);
+    }
+
+    function callScillaNoArgs(
+        address scillaContract,
+        string memory transitionName
+    ) public {
+        scillaContract.call(transitionName);
     }
 
     function callScilla(


### PR DESCRIPTION
Despite the name `keep_origin`, the flag actually means "keep the caller of the previous call, like in an EVM `DELEGATECALL`". This fixes the behaviour to match that definition.

It is worth noting that the `keep_origin` flag is entirely pointless and complicates the precompile implementation massively. The exact same behaviour can be achieved by calling the precompile with `DELEGATECALL`, so there was no need for us to add this flag. However, contracts are now using it in the wild so we are stuck with it.