### PR TITLE
Broadcast repeated new view messages to speed up high QC sharing

### DIFF
--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -401,7 +401,7 @@ impl Node {
                     .send_external_message(leader, response)
                     .unwrap();
             } else {
-                self.message_sender.broadcast_proposal(response)?;
+                self.message_sender.broadcast_external_message(response)?;
             }
             return Ok(true);
         }


### PR DESCRIPTION
In some cases where the entire network is down, many nodes will have disjoint values of their high QC. The only way for them to sync the high QCs up is to wait for a supermajority of nodes to become the leader of a missed view, meaning it receives `NewView` messages from everyone else and can updates its own high QC.

To speed this up, we now broadcast `NewView`s. We still send the first `NewView` message directly to the leader, but we broadcast repeated messages.

We also change the `NewView` processing logic to ensure nodes will update their high QC based on received messages, even if they are not the leader of the view.