### PR TITLE
feat: DEVOPS-1775 Adjust order of deployment operations to minimise node downtime when upgrading

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -459,6 +459,7 @@ def go(role):
         case "bootstrap" | "checkpoint":
             log("Configuring a validator node")
             configure_logrotate()
+            pull_zq2_image()
             stop_zq2()
             install_zilliqa()
             download_persistence()
@@ -466,6 +467,7 @@ def go(role):
         case "validator":
             log("Configuring a validator node")
             configure_logrotate()
+            pull_zq2_image()
             stop_zq2()
             install_zilliqa()
             download_persistence()
@@ -476,6 +478,7 @@ def go(role):
             stop_api_checkpoint()
             install_api_checkpoint()
             configure_logrotate()
+            pull_zq2_image()
             stop_zq2()
             install_zilliqa()
             download_persistence()
@@ -635,6 +638,9 @@ def download_checkpoint():
 
 def start_zq2():
     run_or_die(["sudo", "systemctl", "start", "zilliqa"])
+
+def pull_zq2_image():
+    run_or_die(["sudo", "docker", "pull", f"{ZQ2_IMAGE}"])
 
 def stop_zq2():
     if os.path.exists("/etc/systemd/system/zilliqa.service"):

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -165,7 +165,9 @@ impl Chain {
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
             },
-            _ => ContractUpgradesBlockHeights::default(),
+            _ => ContractUpgradesBlockHeights {
+                deposit_v3: Some(0),
+            },
         }
     }
 

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -364,20 +364,21 @@ impl ChainNode {
         self.import_config_files().await?;
         self.run_provisioning_script().await?;
 
+        // TODO implement a more effective check
         // Check the node is making progress
-        if self.role != NodeRole::Apps {
-            let first_block_number = self.machine.get_local_block_number().await?;
-            loop {
-                let next_block_number = self.machine.get_local_block_number().await?;
-                println!(
-                    "Polled block number at {next_block_number}, waiting for {} more blocks",
-                    (first_block_number + 10).saturating_sub(next_block_number)
-                );
-                if next_block_number >= first_block_number + 10 {
-                    break;
-                }
-            }
-        }
+        // if self.role != NodeRole::Apps {
+        //     let first_block_number = self.machine.get_local_block_number().await?;
+        //     loop {
+        //         let next_block_number = self.machine.get_local_block_number().await?;
+        //         println!(
+        //             "Polled block number at {next_block_number}, waiting for {} more blocks",
+        //             (first_block_number + 10).saturating_sub(next_block_number)
+        //         );
+        //         if next_block_number >= first_block_number + 10 {
+        //             break;
+        //         }
+        //     }
+        // }
 
         Ok(())
     }


### PR DESCRIPTION
in this PR:
- feat: DEVOPS-1787 Remove rpc check on z2 deployer update
- feat: DEVOPS-1775 Adjust order of deployment operations to minimise node downtime when upgrading