### PR TITLE
feat: DEVOPS-1784 Allow IAP cidr access to TCP 4202 port

### DIFF
--- a/infra/tf/main.tf
+++ b/infra/tf/main.tf
@@ -73,6 +73,11 @@ resource "google_compute_firewall" "allow_ingress_from_iap" {
     protocol = "tcp"
     ports    = ["22"]
   }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["4202"]
+  }
 }
 
 resource "google_compute_firewall" "allow_p2p" {


### PR DESCRIPTION
ID range: ["35.235.240.0/20"]
Port: TCP ["4202"]
target_tags = [var.chain_name]