### PR TITLE
fix: custom toml parsing of Option values

### DIFF
--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -165,7 +165,7 @@ impl Chain {
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
             },
-            _ => ContractUpgradesBlockHeights::default()
+            _ => ContractUpgradesBlockHeights::default(),
         }
     }
 

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -165,9 +165,7 @@ impl Chain {
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
             },
-            _ => ContractUpgradesBlockHeights {
-                deposit_v3: Some(0),
-            },
+            _ => ContractUpgradesBlockHeights::default()
         }
     }
 

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -612,8 +612,7 @@ impl ChainNode {
         );
         ctx.insert(
             "contract_upgrade_block_heights",
-            &serde_json::from_value::<toml::Value>(json!(contract_upgrade_block_heights))?
-                .to_string(),
+            &contract_upgrade_block_heights.to_toml().to_string(),
         );
         // convert json to toml formatting
         let toml_servers: toml::Value = serde_json::from_value(api_servers)?;

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use libp2p::{Multiaddr, PeerId};
 use rand::{distributions::Alphanumeric, Rng};
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use serde_json::json;
 
 use crate::{
     crypto::{Hash, NodePublicKey},
@@ -535,4 +536,22 @@ pub fn total_native_token_supply_default() -> Amount {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ContractUpgradesBlockHeights {
     pub deposit_v3: Option<u64>,
+}
+
+
+impl ContractUpgradesBlockHeights {
+    // toml doesnt like Option types. Map items in struct and remove keys for None values
+    pub fn to_toml(&self) -> toml::Value {
+        toml::Value::Table(
+            json!(self).as_object().unwrap().clone().into_iter()
+                .filter_map(|(k, v)| {
+                    if v.is_null() {
+                        None // Skip null values
+                    } else {
+                        Some((k, toml::Value::Integer(v.as_u64().unwrap() as i64)))
+                    }
+                })
+                .collect()
+        )
+    }
 }

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -538,12 +538,15 @@ pub struct ContractUpgradesBlockHeights {
     pub deposit_v3: Option<u64>,
 }
 
-
 impl ContractUpgradesBlockHeights {
     // toml doesnt like Option types. Map items in struct and remove keys for None values
     pub fn to_toml(&self) -> toml::Value {
         toml::Value::Table(
-            json!(self).as_object().unwrap().clone().into_iter()
+            json!(self)
+                .as_object()
+                .unwrap()
+                .clone()
+                .into_iter()
                 .filter_map(|(k, v)| {
                     if v.is_null() {
                         None // Skip null values
@@ -551,7 +554,7 @@ impl ContractUpgradesBlockHeights {
                         Some((k, toml::Value::Integer(v.as_u64().unwrap() as i64)))
                     }
                 })
-                .collect()
+                .collect(),
         )
     }
 }


### PR DESCRIPTION
`Option::None` failed to parse into toml. Here we remove the key when its value is None.