### PR TITLE
Add `admin_consensusInfo` API

### DIFF
--- a/zilliqa/src/api/admin.rs
+++ b/zilliqa/src/api/admin.rs
@@ -7,6 +7,7 @@ use anyhow::{anyhow, Result};
 use jsonrpsee::{types::Params, RpcModule};
 use serde::{Deserialize, Serialize};
 
+use super::types::{eth::QuorumCertificate, hex};
 use crate::{api::to_hex::ToHex, cfg::EnabledApi, node::Node};
 
 pub fn rpc_module(
@@ -16,8 +17,38 @@ pub fn rpc_module(
     super::declare_module!(
         node,
         enabled_apis,
-        [("admin_generateCheckpoint", checkpoint)]
+        [
+            ("admin_consensusInfo", consensus_info),
+            ("admin_generateCheckpoint", checkpoint),
+        ]
     )
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ConsensusInfo {
+    #[serde(serialize_with = "hex")]
+    view: u64,
+    high_qc: QuorumCertificate,
+    milliseconds_since_last_view_change: u64,
+    milliseconds_until_next_view_change: u64,
+}
+
+fn consensus_info(_: Params, node: &Arc<Mutex<Node>>) -> Result<ConsensusInfo> {
+    let node = node.lock().unwrap();
+
+    let view = node.consensus.get_view()?;
+    let high_qc = QuorumCertificate::from_qc(&node.consensus.high_qc);
+    let (milliseconds_since_last_view_change, exponential_backoff_timeout, _) =
+        node.consensus.get_consensus_timeout_params()?;
+    let milliseconds_until_next_view_change =
+        exponential_backoff_timeout.saturating_sub(milliseconds_since_last_view_change);
+
+    Ok(ConsensusInfo {
+        view,
+        high_qc,
+        milliseconds_since_last_view_change,
+        milliseconds_until_next_view_change,
+    })
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/zilliqa/src/api/to_hex.rs
+++ b/zilliqa/src/api/to_hex.rs
@@ -1,6 +1,9 @@
 use alloy::primitives::{Address, B128, B256, B512, U128, U256, U512};
 
-use crate::transaction::{EvmGas, ScillaGas};
+use crate::{
+    message::BitArray,
+    transaction::{EvmGas, ScillaGas},
+};
 
 /// A version of [hex::ToHex] which is also implemented for integer types. This version also prefixes the produced
 /// string with `"0x"` and omits leading zeroes for quantities (types with fixed lengths).
@@ -84,6 +87,12 @@ impl ToHex for EvmGas {
 impl ToHex for ScillaGas {
     fn to_hex_inner(&self, prefix: bool) -> String {
         self.0.to_hex_inner(prefix)
+    }
+}
+
+impl ToHex for BitArray {
+    fn to_hex_inner(&self, prefix: bool) -> String {
+        self.as_raw_slice().to_hex_inner(prefix)
     }
 }
 

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -25,11 +25,11 @@ pub enum HashOrTransaction {
     Transaction(Transaction),
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct QuorumCertificate {
     #[serde(serialize_with = "hex")]
     pub signature: Vec<u8>,
-    #[serde(serialize_with = "ser_display")]
+    #[serde(serialize_with = "hex")]
     pub cosigned: BitArray,
     #[serde(serialize_with = "hex")]
     pub view: u64,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -610,7 +610,7 @@ impl Consensus {
         Ok(Some(new_view))
     }
 
-    fn get_consensus_timeout_params(&self) -> Result<(u64, u64, u64)> {
+    pub fn get_consensus_timeout_params(&self) -> Result<(u64, u64, u64)> {
         let time_since_last_view_change = SystemTime::now()
             .duration_since(self.view_updated_at)
             .unwrap_or_default()


### PR DESCRIPTION
This returns consensus-specific information that is useful for debugging the current status of a node.

Example:
```
$ xh post :4201 jsonrpc=2.0 id=1 method=admin_consensusInfo -b
{
    "jsonrpc": "2.0",
    "id": "1",
    "result": {
        "view": "0x1e",
        "high_qc": {
            "signature": "0xb82c814efbb00923e78f549e171932b5029d44f789b18d12fb877f01b6466c8658d62ddf9cb1dd1a44ffb3b7c2871bfd13e0ef1f79579f029e186990a94d20ea7526541b6b4d428b0bd3947c7f2d088744c85291d10dcfd05dc69f93991e198f",
            "cosigned": "0xe000000000000000000000000000000000000000000000000000000000000000",
            "view": "0x1c",
            "block_hash": "0x3d0d192ef0235d632c4f115a9021245ac4047980422f12890e7f045157a746f2"
        },
        "milliseconds_since_last_view_change": 46,
        "milliseconds_until_next_view_change": 4954
    }
}
```

Closes #1753 