### PR TITLE
feat: DEVOPS-1781 persistence export cron job for checkpoint node

### DIFF
--- a/z2/resources/persistence_export.tera.sh
+++ b/z2/resources/persistence_export.tera.sh
@@ -21,44 +21,28 @@ is_dir_empty() {
     [ -z "$(ls -A $dir)" ]
 }
 
-# Start the backup process
+# Start the persistence export process
 start_time=$(date +%s)
 
 if is_dir_empty "$CHECKPOINT_DIR"; then  
     # Stop zilliqa service
-    log_message "Stopping zilliqa service"
     if ! sudo systemctl stop zilliqa.service; then
         log_message "Error: Failed to stop zilliqa service"
         exit 1
     fi
     
-    # Create backup filename with timestamp
-    backup_name="{{ network_name }}-$(date +%Y%m%d%H%M%S)-persistence"
-    log_message "Creating persitence export: $backup_name"
-    
-    # Create zip archive
-    if ! zip -r "/tmp/$backup_name.zip" /data; then
-        log_message "Error: Failed to create backup archive"
-        # Start zilliqa service before exiting
-        sudo systemctl start zilliqa.service
-        exit 1
-    fi
+    # Create persistence export folder name with timestamp
+    persistence_export_name="{{ network_name }}-$(date +%Y%m%d%H%M%S)-persistence"
+    log_message "Creating persistence export: $persistence_export_name"
     
     # Upload to GCS
-    log_message "Uploading backup to GCS bucket"
-    if ! gsutil -m cp "/tmp/$backup_name.zip" "$GCS_BUCKET/"; then
-        log_message "Error: Failed to upload backup to GCS"
-        # Clean up and start service before exiting
-        rm -f "/tmp/$backup_name.zip"
+    if ! gsutil -m cp -r /data "$GCS_BUCKET/$persistence_export_name/"; then
+        log_message "Error: Failed to upload data to GCS"
         sudo systemctl start zilliqa.service
         exit 1
     fi
     
-    # Clean up temporary file
-    rm -f "/tmp/$backup_name.zip"
-    
     # Start zilliqa service
-    log_message "Starting zilliqa service"
     if ! sudo systemctl start zilliqa.service; then
         log_message "Error: Failed to start zilliqa service"
         exit 1
@@ -67,7 +51,7 @@ if is_dir_empty "$CHECKPOINT_DIR"; then
     # Calculate and log total execution time
     end_time=$(date +%s)
     duration=$((end_time - start_time))
-    log_message "Persitence export completed successfully in $duration seconds"
+    log_message "Persistence export completed successfully in $duration seconds"
 else
-    log_message "Checkpoint files present in $CHECKPOINT_DIR. Skipping persitence export."
+    log_message "Checkpoint files present in $CHECKPOINT_DIR. Skipping persistence export."
 fi

--- a/z2/resources/persistence_export.tera.sh
+++ b/z2/resources/persistence_export.tera.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Directory where checkpoint files are located
+CHECKPOINT_DIR="/data/{{ eth_chain_id }}/checkpoints"
+
+# GCS bucket where the persistence will be exported
+GCS_BUCKET="gs://{{ network_name }}-persistence"
+
+# Log name in Google Cloud Logging
+LOG_NAME="{{ network_name }}-persistence-export-cron-log"
+
+# Function to log messages to Google Cloud Logging
+log_message() {
+    local message="$1"
+    logger -t "$LOG_NAME" "$message"
+}

--- a/z2/resources/persistence_export.tera.sh
+++ b/z2/resources/persistence_export.tera.sh
@@ -14,3 +14,60 @@ log_message() {
     local message="$1"
     logger -t "$LOG_NAME" "$message"
 }
+
+# Function to check if directory is empty
+is_dir_empty() {
+    local dir="$1"
+    [ -z "$(ls -A $dir)" ]
+}
+
+# Start the backup process
+start_time=$(date +%s)
+
+if is_dir_empty "$CHECKPOINT_DIR"; then  
+    # Stop zilliqa service
+    log_message "Stopping zilliqa service"
+    if ! sudo systemctl stop zilliqa.service; then
+        log_message "Error: Failed to stop zilliqa service"
+        exit 1
+    fi
+    
+    # Create backup filename with timestamp
+    backup_name="{{ network_name }}-$(date +%Y%m%d%H%M%S)-persistence"
+    log_message "Creating persitence export: $backup_name"
+    
+    # Create zip archive
+    if ! zip -r "/tmp/$backup_name.zip" /data; then
+        log_message "Error: Failed to create backup archive"
+        # Start zilliqa service before exiting
+        sudo systemctl start zilliqa.service
+        exit 1
+    fi
+    
+    # Upload to GCS
+    log_message "Uploading backup to GCS bucket"
+    if ! gsutil -m cp "/tmp/$backup_name.zip" "$GCS_BUCKET/"; then
+        log_message "Error: Failed to upload backup to GCS"
+        # Clean up and start service before exiting
+        rm -f "/tmp/$backup_name.zip"
+        sudo systemctl start zilliqa.service
+        exit 1
+    fi
+    
+    # Clean up temporary file
+    rm -f "/tmp/$backup_name.zip"
+    
+    # Start zilliqa service
+    log_message "Starting zilliqa service"
+    if ! sudo systemctl start zilliqa.service; then
+        log_message "Error: Failed to start zilliqa service"
+        exit 1
+    fi
+    
+    # Calculate and log total execution time
+    end_time=$(date +%s)
+    duration=$((end_time - start_time))
+    log_message "Persitence export completed successfully in $duration seconds"
+else
+    log_message "Checkpoint files present in $CHECKPOINT_DIR. Skipping persitence export."
+fi


### PR DESCRIPTION
Dedicated cron job installed in the checkpoint node to export the persistence to GCS.

Tests:
- No files in /data
![image](https://github.com/user-attachments/assets/e851d1be-4c84-44e2-a3c5-e72a5b1ec1f2)
![image](https://github.com/user-attachments/assets/0ec86c95-43fa-4104-bfb3-76248f372d60)
- Files in /data/<chain>/checkpoints
![image](https://github.com/user-attachments/assets/dadaaa37-5c8d-47b7-98bc-375f72d36918)