### PR TITLE
Remove _stakerKeys from Deposit contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
 dependencies = [
  "anstyle",
+ "memchr",
  "unicode-width 0.2.0",
 ]
 
@@ -3114,9 +3115,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d817beee8c566a99f4267f25ff63d0de46c442948496ecef91ead56e3383090c"
+checksum = "f67e3eab56847dcf269eb186226f95874b171e262952cff6c910da36b1469e10"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3146,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bec784a3a809ba2ee723fcfeb737a6ac90b4fd1e4d048c2d49fed6723bd35547"
+checksum = "865b00448dc2a5d56bae287c36fa716379ffcdd937aefb7758bd20b62024d234"
 dependencies = [
  "foundry-compilers-artifacts-solc",
  "foundry-compilers-artifacts-vyper",
@@ -3156,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-solc"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44549c33e5a03408c8d40c36d764b7e84d261258ef481c19e4a612e609fdf8a4"
+checksum = "668972ba511f80895ea12c75cd12fccd6627c26e64763799d83978b4e0916cae"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3178,9 +3179,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-artifacts-vyper"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a438605ae74689752b2f717165daac15766f1b2a166d2095715d5f9407084b52"
+checksum = "5a24f7f2a7458171e055c0cb33272f5eccaefbd96d791d74177d9a1fca048f74"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -3193,9 +3194,9 @@ dependencies = [
 
 [[package]]
 name = "foundry-compilers-core"
-version = "0.12.8"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04ac6d85c3e2d12585f8e698b12ed4880b02716ec7fde5d62de9a194e62f4e36"
+checksum = "8005271a079bc6470c61d4145d2e390a827b1ccbb96abb7b69b088f17ffb95e0"
 dependencies = [
  "alloy-primitives",
  "cfg-if",
@@ -8231,9 +8232,9 @@ dependencies = [
 
 [[package]]
 name = "solar-ast"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5aeaf7a4bd326242c909bd287291226a540b62b36fa5824880248f4b1d4d6af"
+checksum = "5d3f6c4a476a16dcd36933a70ecdb0a807f8949cc5f3c4c1984e3748666bd714"
 dependencies = [
  "alloy-primitives",
  "bumpalo",
@@ -8250,18 +8251,18 @@ dependencies = [
 
 [[package]]
 name = "solar-config"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d00d672a40a1a3620d7696f01a2d3301abf883d8168e1a9da3bf83f0c8e343"
+checksum = "d40434a61f2c14a9e3777fbc478167bddee9828532fc26c57e416e9277916b09"
 dependencies = [
  "strum",
 ]
 
 [[package]]
 name = "solar-data-structures"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6e4eb0b72ed7adbb808897c85de08ea99609774a58c72e3dce55c758043ca2"
+checksum = "71d07263243b313296eca18f18eda3a190902dc3284bf67ceff29b8b54dac3e6"
 dependencies = [
  "bumpalo",
  "index_vec",
@@ -8274,9 +8275,9 @@ dependencies = [
 
 [[package]]
 name = "solar-interface"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21fb8925638f3da1bba7a9a6ebeac3511e5c6354f921f2bb2e1ddce4ac70c107"
+checksum = "9a87009b6989b2cc44d8381e3b86ff3b90280d54a60321919b6416214cd602f3"
 dependencies = [
  "annotate-snippets",
  "anstream",
@@ -8284,7 +8285,7 @@ dependencies = [
  "const-hex",
  "derive_builder",
  "dunce",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "itoa",
  "lasso",
  "match_cfg",
@@ -8295,16 +8296,16 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.9",
  "tracing",
  "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "solar-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0cc54b74e214647c1bbfc098d080cc5deac77f8dcb99aca91747276b01a15ad"
+checksum = "970d7c774741f786d62cab78290e47d845b0b9c0c9d094a1642aced1d7946036"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8313,14 +8314,14 @@ dependencies = [
 
 [[package]]
 name = "solar-parse"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82c3659c15975cd80e5e1c44591278c230c59ad89082d797837499a4784e1b"
+checksum = "2e1e2d07fae218aca1b4cca81216e5c9ad7822516d48a28f11e2eaa8ffa5b249"
 dependencies = [
  "alloy-primitives",
  "bitflags 2.6.0",
  "bumpalo",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "memchr",
  "num-bigint",
  "num-rational",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -91,7 +91,7 @@ alloy = { version = "0.6.4", default-features = false, features = ["network", "r
 async-trait = "0.1.84"
 criterion = "0.5.1"
 ethers = { version = "2.0.14", default-features = false, features = ["legacy"] }
-foundry-compilers = { version = "0.12.8", features = ["svm-solc"] }
+foundry-compilers = { version = "0.12.9", features = ["svm-solc"] }
 fs_extra = "1.3.0"
 indicatif = { version = "0.17.9", features = ["rayon"] }
 pprof = { version = "0.14.0", default-features = false, features = ["criterion", "flamegraph"] }

--- a/zilliqa/src/contracts/deposit_v4.sol
+++ b/zilliqa/src/contracts/deposit_v4.sol
@@ -11,6 +11,8 @@ using Deque for Deque.Withdrawals;
 /// @param required expected length
 error UnexpectedArgumentLength(string argument, uint256 required);
 
+/// Message sender does not control the key it is attempting to modify
+error Unauthorised();
 /// Maximum number of stakers has been reached
 error TooManyStakers();
 /// Key already staked
@@ -84,8 +86,6 @@ contract Deposit is UUPSUpgradeable {
         Committee[3] _committee;
         // All stakers. Keys into this map are stored by the `Committee`.
         mapping(bytes => Staker) _stakersMap;
-        // Mapping from `controlAddress` to `blsPubKey` for each staker.
-        mapping(address => bytes) _stakerKeys;
         // The latest epoch for which the committee was calculated. It is implied that no changes have (yet) occurred in
         // future epochs, either because those epochs haven't happened yet or because they have happened, but no deposits
         // or withdrawals were made.
@@ -369,8 +369,6 @@ contract Deposit is UUPSUpgradeable {
     ) public onlyControlAddress(blsPubKey) {
         DepositStorage storage $ = _getDepositStorage();
         $._stakersMap[blsPubKey].controlAddress = controlAddress;
-        delete $._stakerKeys[msg.sender];
-        $._stakerKeys[controlAddress] = blsPubKey;
     }
 
     function getPeerId(
@@ -509,7 +507,6 @@ contract Deposit is UUPSUpgradeable {
             revert StakeAmountTooLow();
         }
 
-        $._stakerKeys[msg.sender] = blsPubKey;
         Staker storage staker = $._stakersMap[blsPubKey];
         staker.peerId = peerId;
         staker.rewardAddress = rewardAddress;
@@ -539,60 +536,66 @@ contract Deposit is UUPSUpgradeable {
         emit StakerAdded(blsPubKey, nextUpdate(), msg.value);
     }
 
-    function depositTopup() public payable {
-        DepositStorage storage $ = _getDepositStorage();
-        bytes storage stakerKey = $._stakerKeys[msg.sender];
-        if (stakerKey.length == 0) {
-            revert KeyNotStaked();
+    function depositTopup(bytes calldata blsPubKey) public payable {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
         }
+        DepositStorage storage $ = _getDepositStorage();
 
         updateLatestComputedEpoch();
 
         Committee storage futureCommittee = $._committee[
             (currentEpoch() + 2) % 3
         ];
-        if (futureCommittee.stakers[stakerKey].index == 0) {
+        if (futureCommittee.stakers[blsPubKey].index == 0) {
             revert KeyNotStaked();
         }
+        if ($._stakersMap[blsPubKey].controlAddress != msg.sender) {
+            revert Unauthorised();
+        }
         futureCommittee.totalStake += msg.value;
-        futureCommittee.stakers[stakerKey].balance += msg.value;
+        futureCommittee.stakers[blsPubKey].balance += msg.value;
 
         emit StakeChanged(
-            stakerKey,
+            blsPubKey,
             nextUpdate(),
-            futureCommittee.stakers[stakerKey].balance
+            futureCommittee.stakers[blsPubKey].balance
         );
     }
 
-    function unstake(uint256 amount) public {
-        DepositStorage storage $ = _getDepositStorage();
-        bytes storage stakerKey = $._stakerKeys[msg.sender];
-        if (stakerKey.length == 0) {
-            revert KeyNotStaked();
+    function unstake(bytes calldata blsPubKey, uint256 amount) public {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
         }
-        Staker storage staker = $._stakersMap[stakerKey];
+        DepositStorage storage $ = _getDepositStorage();
+
 
         updateLatestComputedEpoch();
 
         Committee storage futureCommittee = $._committee[
             (currentEpoch() + 2) % 3
         ];
-        if (futureCommittee.stakers[stakerKey].index == 0) {
+        if (futureCommittee.stakers[blsPubKey].index == 0) {
             revert KeyNotStaked();
         }
 
+        Staker storage staker = $._stakersMap[blsPubKey];
+        if (staker.controlAddress != msg.sender) {
+            revert Unauthorised();
+        }
+
         require(
-            futureCommittee.stakers[stakerKey].balance >= amount,
+            futureCommittee.stakers[blsPubKey].balance >= amount,
             "amount is greater than staked balance"
         );
 
-        if (futureCommittee.stakers[stakerKey].balance - amount == 0) {
+        if (futureCommittee.stakers[blsPubKey].balance - amount == 0) {
             require(futureCommittee.stakerKeys.length > 1, "too few stakers");
 
             // Remove the staker from the future committee, because their staked amount has gone to zero.
             futureCommittee.totalStake -= amount;
 
-            uint256 deleteIndex = futureCommittee.stakers[stakerKey].index - 1;
+            uint256 deleteIndex = futureCommittee.stakers[blsPubKey].index - 1;
             uint256 lastIndex = futureCommittee.stakerKeys.length - 1;
 
             if (deleteIndex != lastIndex) {
@@ -603,32 +606,32 @@ contract Deposit is UUPSUpgradeable {
                 futureCommittee.stakerKeys[deleteIndex] = lastStakerKey;
                 // We need to remember to update the moved staker's `index` too.
                 futureCommittee.stakers[lastStakerKey].index = futureCommittee
-                    .stakers[stakerKey]
+                    .stakers[blsPubKey]
                     .index;
             }
 
             // It is now safe to delete the final staker in the list.
             futureCommittee.stakerKeys.pop();
-            delete futureCommittee.stakers[stakerKey];
+            delete futureCommittee.stakers[blsPubKey];
 
             // Note that we leave the staker in `_stakersMap` forever.
 
-            emit StakerRemoved(stakerKey, nextUpdate());
+            emit StakerRemoved(blsPubKey, nextUpdate());
         } else {
             require(
-                futureCommittee.stakers[stakerKey].balance - amount >=
+                futureCommittee.stakers[blsPubKey].balance - amount >=
                     $.minimumStake,
                 "unstaking this amount would take the validator below the minimum stake"
             );
 
             // Partial unstake. The staker stays in the committee, but with a reduced stake.
             futureCommittee.totalStake -= amount;
-            futureCommittee.stakers[stakerKey].balance -= amount;
+            futureCommittee.stakers[blsPubKey].balance -= amount;
 
             emit StakeChanged(
-                stakerKey,
+                blsPubKey,
                 nextUpdate(),
-                futureCommittee.stakers[stakerKey].balance
+                futureCommittee.stakers[blsPubKey].balance
             );
         }
 
@@ -653,12 +656,12 @@ contract Deposit is UUPSUpgradeable {
         currentWithdrawal.amount += amount;
     }
 
-    function withdraw() public {
-        _withdraw(0);
+    function withdraw(bytes calldata blsPubKey) public {
+        _withdraw(blsPubKey, 0);
     }
 
-    function withdraw(uint256 count) public {
-        _withdraw(count);
+    function withdraw(bytes calldata blsPubKey, uint256 count) public {
+        _withdraw(blsPubKey, count);
     }
 
     /// Unbonding period for withdrawals measured in number of blocks (note that we have 1 second block times)
@@ -668,11 +671,18 @@ contract Deposit is UUPSUpgradeable {
         return 2 weeks;
     }
 
-    function _withdraw(uint256 count) internal {
+    function _withdraw(bytes calldata blsPubKey, uint256 count) internal {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+
         uint256 releasedAmount = 0;
 
-        DepositStorage storage $ = _getDepositStorage();
-        Staker storage staker = $._stakersMap[$._stakerKeys[msg.sender]];
+        Staker storage staker = $._stakersMap[blsPubKey];
+        if (staker.controlAddress != msg.sender) {
+            revert Unauthorised();
+        }
 
         Deque.Withdrawals storage withdrawals = staker.withdrawals;
         count = (count == 0 || count > withdrawals.length())


### PR DESCRIPTION
Removes `_stakerKeys` array. Perform check that staker can be updated by `msg.sender` explicitly.

Delegated_staking tests updated to test these changes [here](https://github.com/Zilliqa/delegated_staking/tree/deposit_v4).

Note that were merging into branch `deposit_v4`.