### PR TITLE
Fix balance of created Scilla contracts if they already have a non-zero balance

### DIFF
--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -1627,7 +1627,7 @@ fn scilla_create(
     let transitions = contract_info.transitions;
 
     let account = state.load_account(contract_address)?;
-    account.account.balance = txn.amount.get();
+    account.account.balance += txn.amount.get();
     account.account.code = Code::Scilla {
         code: txn.code.clone(),
         init_data,


### PR DESCRIPTION
Added this piece of code to `scilla_create`

```rust
    let mut input = String::new();
    io::stdin()
        .read_line(&mut input)
        .expect("Failed to read line");

    let input = input.trim();

    let contract_address = zil_contract_address(from_addr, txn.nonce - 1);
    println!("ADDR: {contract_address:?}, {}", current_block.number);
    println!("Do you want to continue contract creation? y/n");
    if input == "n" {
        println!("no");
        return Err(anyhow!("contract creation without init data"));
    }
```
At first time I choose not to continue and fund the printed address. Then I redeploy and choose `y` to continue the deployment...