### PR TITLE
Revert "Fix balance of created Scilla contracts if they already have a non-zero balance"

### DIFF
--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -1627,7 +1627,7 @@ fn scilla_create(
     let transitions = contract_info.transitions;
 
     let account = state.load_account(contract_address)?;
-    account.account.balance += txn.amount.get();
+    account.account.balance = txn.amount.get();
     account.account.code = Code::Scilla {
         code: txn.code.clone(),
         init_data,


### PR DESCRIPTION
Reverts Zilliqa/zq2#2113

We should instead add this change with a flag in the fork configuration.