### PR TITLE
Corrected eth_gasPrice documentation where it mistakenly said eth_getGasPrice

### DIFF
--- a/docs/api/eth/eth_gasPrice.doc.md
+++ b/docs/api/eth/eth_gasPrice.doc.md
@@ -1,6 +1,6 @@
 # Title
 
-eth_getGasPrice
+eth_gasPrice
 
 # Keywords
 
@@ -34,5 +34,3 @@ curl -d '{
 | `jsonrpc` | string | Required | `"2.0"`          |
 | `method`  | string | Required | `"eth_gasPrice"` |
 | `params`  | empty  | Optional | `[]` if present  |
-
-


### PR DESCRIPTION

- closes #1869