### PR TITLE
Fix all docker builds being marked as `-dirty`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,2 @@
 .cache
 **/target/
-
-docker-compose.yaml
-Dockerfile


### PR DESCRIPTION
Because we didn't copy `Dockerfile` or `docker-compose.yaml` previously, `git describe` would mark our working directory as `-dirty` leading to a response like `v0.5.3-dirty` from `GetVersion`.