### PR TITLE
Fix transactions where Scilla messages are sent to EVM contracts

### DIFF
--- a/z2/resources/chain-specs/zq2-prototestnet.toml
+++ b/z2/resources/chain-specs/zq2-prototestnet.toml
@@ -19,4 +19,8 @@ consensus.scilla_call_gas_exempt_addrs = ["0x60E6b5b1B8D3E373E1C04dC0b4f5624776b
 consensus.contract_upgrade_block_heights = { deposit_v3 = 8406000 }
 
 api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
-consensus.forks = [{ at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false }, { at_height = 8404000, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true }]
+consensus.forks = [
+    { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false },
+    { at_height = 8404000, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = false },
+    { at_height = 10200000, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true }
+]

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -182,14 +182,16 @@ impl Chain {
     pub fn get_forks(&self) -> Option<Vec<Value>> {
         match self {
             Chain::Zq2ProtoTestnet => Some(vec![
-                json!({ "at_height": 0, "failed_scilla_call_from_gas_exempt_caller_causes_revert": false, "call_mode_1_sets_caller_to_parent_caller": false }),
+                json!({ "at_height": 0, "failed_scilla_call_from_gas_exempt_caller_causes_revert": false, "call_mode_1_sets_caller_to_parent_caller": false, "scilla_messages_can_call_evm_contracts": false }),
                 // estimated: 2024-12-18T14:57:53Z
-                json!({ "at_height": 8404000, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true }),
+                json!({ "at_height": 8404000, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true, "scilla_messages_can_call_evm_contracts": false }),
+                // estimated: 2025-01-15T09:10:37Z
+                json!({ "at_height": 10200000, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true, "scilla_messages_can_call_evm_contracts": true }),
             ]),
             Chain::Zq2ProtoMainnet => Some(vec![
-                json!({ "at_height": 0, "failed_scilla_call_from_gas_exempt_caller_causes_revert": false, "call_mode_1_sets_caller_to_parent_caller": false }),
+                json!({ "at_height": 0, "failed_scilla_call_from_gas_exempt_caller_causes_revert": false, "call_mode_1_sets_caller_to_parent_caller": false, "scilla_messages_can_call_evm_contracts": false }),
                 // estimated: 2024-12-20T23:33:12Z
-                json!({ "at_height": 5342400, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true }),
+                json!({ "at_height": 5342400, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true, "scilla_messages_can_call_evm_contracts": false }),
             ]),
             _ => None,
         }

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -431,6 +431,7 @@ impl Default for Forks {
             at_height: 0,
             failed_scilla_call_from_gas_exempt_caller_causes_revert: true,
             call_mode_1_sets_caller_to_parent_caller: true,
+            scilla_messages_can_call_evm_contracts: true,
         }]
         .try_into()
         .unwrap()
@@ -468,6 +469,10 @@ pub struct Fork {
     /// When this flag is true, `D` will see the `_sender` as `B`. When this flag is false, `D` will see the `_sender`
     /// as `A`.
     pub call_mode_1_sets_caller_to_parent_caller: bool,
+    /// If true, when a Scilla message is sent to an EVM contract, the EVM contract will be treated as if it was an
+    /// EOA (i.e. any ZIL passed will be transferred to the contract and execution will continue). If false, sending a
+    /// Scilla message to an EVM contract will cause the Scilla transaction to fail.
+    pub scilla_messages_can_call_evm_contracts: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/precompiles/scilla.rs
+++ b/zilliqa/src/precompiles/scilla.rs
@@ -566,6 +566,7 @@ fn scilla_call_precompile<I: ScillaInspector>(
         serde_json::to_string(&message).unwrap(),
         &mut external_context.inspector,
         &scilla_ext_libs_path_default(),
+        external_context.fork,
     ) else {
         return fatal("scilla call failed");
     };


### PR DESCRIPTION
The correct behaviour is that EVM contracts should be treated as if they were EOAs in most non-exceptional cases. The exceptional cases are mentioned in #1610 and we'll make another change to this logic to deal with them later. This PR just adds the easy case and treats all EVM contracts as EOAs.

For now, we've just enabled this change in the proto-testnet, where we can easily update the nodes by the time the fork height is reached in ~1.5 days. There are further execution changes being worked on that we can release together in a single fork on the proto-mainnet.