### PR TITLE
(fix) Pass strings to scilla as strings, rather than arrays of their bytes

### DIFF
--- a/zilliqa/src/precompiles/scilla.rs
+++ b/zilliqa/src/precompiles/scilla.rs
@@ -150,7 +150,7 @@ fn read_index(ty: ScillaType, d: &mut Decoder) -> Result<Vec<u8>> {
         ScillaType::Uint64 => serde_json::to_vec(&u64::detokenize(d.decode()?).to_string())?,
         ScillaType::Uint128 => serde_json::to_vec(&u128::detokenize(d.decode()?).to_string())?,
         ScillaType::Uint256 => serde_json::to_vec(&U256::detokenize(d.decode()?).to_string())?,
-        ScillaType::String => String::detokenize(d.decode()?).into_bytes(),
+        ScillaType::String => serde_json::to_vec(&String::detokenize(d.decode()?))?,
         ScillaType::Map(_, _) => {
             return Err(anyhow!("a map cannot be the key of another map"));
         }


### PR DESCRIPTION
Fixes #2163 