### PR TITLE
Add benchmarks for Scilla and ERC-20 transfers

### DIFF
--- a/.github/workflows/base_benchmarks.yaml
+++ b/.github/workflows/base_benchmarks.yaml
@@ -14,6 +14,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: bencherdev/bencher@main
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/.github/workflows/pr_benchmarks.yaml
+++ b/.github/workflows/pr_benchmarks.yaml
@@ -16,6 +16,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - uses: bencherdev/bencher@main
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4368,7 +4368,6 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "rayon",
  "unicode-width 0.2.0",
  "web-time",
 ]
@@ -10385,7 +10384,6 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_core",
- "rayon",
  "revm",
  "revm-inspectors",
  "rusqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,13 +146,30 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.18"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0713007d14d88a6edb8e248cddab783b698dbb954a28b8eee4bab21cfb7e578"
+checksum = "c618bd382f0bc2ac26a7e4bfae01c9b015ca8f21b37ca40059ae35a7e62b3dc6"
 dependencies = [
+ "alloy-dyn-abi",
+ "alloy-json-abi",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-sol-types",
+]
+
+[[package]]
+name = "alloy-dyn-abi"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41056bde53ae10ffbbf11618efbe1e0290859e5eab0fe9ef82ebdb62f12a866f"
+dependencies = [
+ "alloy-json-abi",
+ "alloy-primitives",
+ "alloy-sol-type-parser",
+ "alloy-sol-types",
+ "const-hex",
+ "itoa",
+ "winnow",
 ]
 
 [[package]]
@@ -261,9 +278,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "788bb18e8f61d5d9340b52143f27771daf7e1dccbaf2741621d2493f9debf52e"
+checksum = "ec878088ec6283ce1e90d280316aadd3d6ce3de06ff63d68953c855e7e447e92"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -472,6 +489,7 @@ version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19cc9c7f20b90f9be1a8f71a3d8e283a43745137b0837b1a1cb13159d37cad72"
 dependencies = [
+ "alloy-json-abi",
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
@@ -490,20 +508,22 @@ version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "713b7e6dfe1cb2f55c80fb05fd22ed085a1b4e48217611365ed0ae598a74c6ac"
 dependencies = [
+ "alloy-json-abi",
  "const-hex",
  "dunce",
  "heck",
  "proc-macro2",
  "quote",
+ "serde_json",
  "syn 2.0.96",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.18"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eda2711ab2e1fb517fc6e2ffa9728c9a232e296d16810810e6957b781a1b8bc"
+checksum = "74e60b084fe1aef8acecda2743ff2d93c18ff3eb67a2d3b12f62582a1e66ef5e"
 dependencies = [
  "serde",
  "winnow",

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -93,10 +93,9 @@ criterion = "0.5.1"
 ethers = { version = "2.0.14", default-features = false, features = ["legacy"] }
 foundry-compilers = { version = "0.12.9", features = ["svm-solc"] }
 fs_extra = "1.3.0"
-indicatif = { version = "0.17.9", features = ["rayon"] }
+indicatif = "0.17.9"
 pprof = { version = "0.14.0", default-features = false, features = ["criterion", "flamegraph"] }
 primitive-types = { version = "0.12.2" }
-rayon = "1.10.0"
 semver = "1.0.23"
 ureq = "2.12.1"
 zilliqa = { path = ".", default-features = false, features = ["fake_response_channel", "fake_time"] }

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -26,7 +26,7 @@ anyhow = { version = "1.0.95", features = ["backtrace"] }
 vergen = { version = "8.3.1", features = ["git", "git2"] }
 
 [dependencies]
-alloy = { version = "0.6.4", default-features = false, features = ["consensus", "eips", "k256", "rlp", "rpc-types", "rpc-types-trace", "serde", "sol-types"] }
+alloy = { version = "0.6.4", default-features = false, features = ["consensus", "eips", "json-abi", "dyn-abi", "k256", "rlp", "rpc-types", "rpc-types-trace", "serde", "sol-types"] }
 anyhow = { version = "1.0.95", features = ["backtrace"] }
 async-trait = "0.1.85"
 base64 = "0.22.1"
@@ -85,18 +85,18 @@ serde_repr = "0.1.19"
 thiserror = "2.0.11"
 lru-mem = "0.3.0"
 opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
+semver = "1.0.23"
+foundry-compilers = { version = "0.12.9", features = ["svm-solc"] }
 
 [dev-dependencies]
 alloy = { version = "0.6.4", default-features = false, features = ["network", "rand", "signers", "signer-local"] }
 async-trait = "0.1.85"
 criterion = "0.5.1"
 ethers = { version = "2.0.14", default-features = false, features = ["legacy"] }
-foundry-compilers = { version = "0.12.9", features = ["svm-solc"] }
 fs_extra = "1.3.0"
 indicatif = "0.17.9"
 pprof = { version = "0.14.0", default-features = false, features = ["criterion", "flamegraph"] }
 primitive-types = { version = "0.12.2" }
-semver = "1.0.23"
 ureq = "2.12.1"
 zilliqa = { path = ".", default-features = false, features = ["fake_response_channel", "fake_time"] }
 zilliqa-macros = { path = "../zilliqa-macros" }

--- a/zilliqa/benches/ERC20.sol
+++ b/zilliqa/benches/ERC20.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.28;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract ERC20FixedSupply is ERC20("token", "TKN") {
+    constructor() {
+        _mint(msg.sender, 1_000_000_000);
+    }
+}

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -23,6 +23,7 @@ pub mod scilla;
 mod scilla_proto;
 pub mod serde_util;
 pub mod state;
+pub mod test_util;
 pub mod time;
 pub mod transaction;
 pub mod zq1_proto;

--- a/zilliqa/src/test_util.rs
+++ b/zilliqa/src/test_util.rs
@@ -1,0 +1,56 @@
+use std::path::PathBuf;
+
+use alloy::{json_abi::JsonAbi, primitives::Bytes};
+use foundry_compilers::{
+    artifacts::{EvmVersion, Optimizer, Settings, SolcInput, Source},
+    solc::{Solc, SolcLanguage},
+};
+
+pub fn compile_contract(path: &str, contract: &str) -> (JsonAbi, Bytes) {
+    let path: PathBuf = format!("{}/{}", env!("CARGO_MANIFEST_DIR"), path).into();
+
+    let solc_input = SolcInput::new(
+        SolcLanguage::Solidity,
+        Source::read_all_files(vec![path.clone()]).unwrap(),
+        Settings {
+            remappings: vec![format!(
+                "@openzeppelin/contracts={}/../vendor/openzeppelin-contracts/contracts",
+                env!("CARGO_MANIFEST_DIR")
+            )
+            .parse()
+            .unwrap()],
+            optimizer: Optimizer {
+                enabled: Some(true),
+                runs: Some(2usize.pow(32) - 1),
+                details: None,
+            },
+            ..Default::default()
+        },
+    )
+    .evm_version(EvmVersion::Shanghai); // ensure compatible with EVM version in exec.rs
+
+    let mut solc = Solc::find_or_install(&semver::Version::new(0, 8, 28)).unwrap();
+    solc.allow_paths
+        .insert(PathBuf::from("../vendor/openzeppelin-contracts"));
+    let mut output = solc.compile_exact(&solc_input).unwrap();
+
+    if output.has_error() {
+        for error in output.errors {
+            eprintln!("{error}");
+        }
+        panic!("failed to compile contract");
+    }
+
+    let contract = output
+        .contracts
+        .remove(&path)
+        .unwrap()
+        .remove(contract)
+        .unwrap();
+    let evm = contract.evm.unwrap();
+
+    (
+        contract.abi.unwrap(),
+        evm.bytecode.unwrap().into_bytes().unwrap(),
+    )
+}

--- a/zilliqa/src/time.rs
+++ b/zilliqa/src/time.rs
@@ -87,7 +87,7 @@ mod time_impl {
         CURRENT_TIME.scope(Mutex::new(Duration::ZERO), f)
     }
 
-    pub fn sync_with_fake_time(f: impl FnOnce()) {
+    pub fn sync_with_fake_time<R>(f: impl FnOnce() -> R) -> R {
         CURRENT_TIME.sync_scope(Mutex::new(Duration::ZERO), f)
     }
 


### PR DESCRIPTION
Previously we would generate pre-emptively generate 3.2 million transactions, just in case we ran enough iterations to need them. Instead, we use Criterion's `iter_batched` method to generate the transactions as they are needed. This ensures we don't generate more transactions than we need and that we don't consume loads of memory. The two downsides of this approach are:

* We don't generate transactions in parallel any more, but this doesn't seem to make much difference to the total benchmarking time now that we aren't over-generating transactions.
* The generated flamegraphs now include the transaction generation calls, but drilling down and ignoring them is only one keypress.

I've also renamed the benchmark from `produce-full` to `full-blocks-evm-transfers` since I think it better represents what we are testing.