### PR TITLE
chore: fix Solhint to v5.0.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "16"
-      - run: npm install --save-dev prettier prettier-plugin-solidity solhint
+      - run: npm install --save-dev prettier prettier-plugin-solidity solhint@5.0.4
       - run: npx prettier --write --plugin=prettier-plugin-solidity './**/*.sol'
       - run: npx solhint 'zilliqa/src/contracts/**/*.sol' --fix --noPrompt
       - name: Commit changes


### PR DESCRIPTION
Because `v5.0.5`  introduced a breaking change which causes our pipelines to fail.

`Error:   2:1  error  Compiler version ^0.8.20 does not satisfy the ^0.8.24 semver requirement  compiler-version`