### PR TITLE
Fix crash while removing values from maps containing complex types

### DIFF
--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -931,7 +931,7 @@ impl ActiveCall {
             } else {
                 // Remove multiple elements from storage having the same prefix specified by `indices`
 
-                // Collect all paths of indexes up to a value that is not of a map type
+                // Collect all paths of indices up to a value that is not of a map type
                 fn collect_indices(
                     map: BTreeMap<Vec<u8>, StorageValue>,
                     path: Vec<Vec<u8>>,

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -931,12 +931,12 @@ impl ActiveCall {
             } else {
                 // Remove multiple elements from storage having the same prefix specified by `indices`
 
-                let complete_empty_map = StorageValue::Map {
-                    map: BTreeMap::new(),
-                    complete: true,
-                };
-                self.state
-                    .set_storage(self.sender, &name, &indices, StorageValue::complete_map())?;
+                self.state.set_storage(
+                    self.sender,
+                    &name,
+                    &indices,
+                    StorageValue::complete_map(),
+                )?;
             }
         } else if indices.len() == depth {
             let Some(ValType::Bval(value)) = value.val_type else {

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -923,10 +923,48 @@ impl ActiveCall {
         }
 
         if ignore_value {
-            // We only supporting deleting a single value of a map.
-            assert_eq!(indices.len(), depth);
-            let storage_slot = self.state.load_storage(self.sender, &name, &indices)?;
-            *storage_slot = None;
+            assert!(indices.len() <= depth);
+            // Remove single element
+            if indices.len() == depth {
+                let storage_slot = self.state.load_storage(self.sender, &name, &indices)?;
+                *storage_slot = None;
+            } else {
+                // Remove multiple elements from storage having the same prefix specified by `indices`
+
+                // Collect all paths of indexes up to a value that is not of a map type
+                fn collect_indices(
+                    map: BTreeMap<Vec<u8>, StorageValue>,
+                    path: Vec<Vec<u8>>,
+                    all_paths: &mut Vec<Vec<Vec<u8>>>,
+                ) {
+                    for (key, value) in map {
+                        let mut path = path.clone();
+                        path.push(key);
+                        match value {
+                            StorageValue::Map { map, .. } => {
+                                collect_indices(map, path, all_paths);
+                            }
+                            StorageValue::Value(_) => {
+                                all_paths.push(path.clone());
+                            }
+                        }
+                    }
+                }
+
+                let load_map_from_prefix =
+                    self.state
+                        .load_storage_by_prefix(self.sender, &name, &indices)?;
+
+                let mut all_indices = Vec::new();
+                let path = Vec::new();
+
+                collect_indices(load_map_from_prefix, path, &mut all_indices);
+
+                for path in all_indices {
+                    self.state
+                        .set_storage(self.sender, &name, &path, StorageValue::Value(None))?
+                }
+            }
         } else if indices.len() == depth {
             let Some(ValType::Bval(value)) = value.val_type else {
                 return Err(anyhow!("invalid value"));

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -936,7 +936,7 @@ impl ActiveCall {
                     complete: true,
                 };
                 self.state
-                    .set_storage(self.sender, &name, &indices, complete_empty_map)?;
+                    .set_storage(self.sender, &name, &indices, StorageValue::complete_map())?;
             }
         } else if indices.len() == depth {
             let Some(ValType::Bval(value)) = value.val_type else {

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -341,7 +341,7 @@ pub fn scilla_test_contract_code() -> String {
         field welcome_map : Map Uint32 (Map Uint32 String) = Emp Uint32 (Map Uint32 String)
 
         transition removeHello()
-          delete welcome_map[one][two];
+          delete welcome_map[one];
           e = {_eventname : "removeHello"};
           event e
         end

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -2994,7 +2994,7 @@ async fn nested_maps_insert_removal(mut network: Network) {
             0,
             50_000,
             None,
-            Some(&call),
+            Some(call),
         )
         .await;
         let event = &txn["receipt"]["event_logs"][0];
@@ -3039,7 +3039,7 @@ async fn nested_maps_insert_removal(mut network: Network) {
             0,
             50_000,
             None,
-            Some(&call),
+            Some(call),
         )
         .await;
         let event = &txn["receipt"]["event_logs"][0];

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -340,6 +340,12 @@ pub fn scilla_test_contract_code() -> String {
         field welcome_msg : String = "default"
         field welcome_map : Map Uint32 (Map Uint32 String) = Emp Uint32 (Map Uint32 String)
 
+        transition removeHello()
+          delete welcome_map[one][two];
+          e = {_eventname : "removeHello"};
+          event e
+        end
+
         transition setHello (msg : String)
         is_owner = builtin eq owner _sender;
         match is_owner with
@@ -2957,6 +2963,109 @@ async fn get_smart_contract_sub_state(mut network: Network) {
         "foobar"
     );
     assert!(substate2.get("welcome_msg").is_none());
+}
+
+#[zilliqa_macros::test(restrict_concurrency)]
+async fn nested_maps_insert_removal(mut network: Network) {
+    let (secret_key, address) = zilliqa_account(&mut network).await;
+
+    let code = scilla_test_contract_code();
+    let data = scilla_test_contract_data(address);
+    let contract_address = deploy_scilla_contract(&mut network, &secret_key, &code, &data).await;
+
+    // Set nested map to some value
+    {
+        let call = r#"{
+        "_tag": "setHello",
+        "params": [
+            {
+                "vname": "msg",
+                "value": "foobar",
+                "type": "String"
+            }
+        ]
+    }"#;
+
+        let (_, txn) = send_transaction(
+            &mut network,
+            &secret_key,
+            2,
+            ToAddr::Address(contract_address),
+            0,
+            50_000,
+            None,
+            Some(&call),
+        )
+        .await;
+        let event = &txn["receipt"]["event_logs"][0];
+        assert_eq!(event["_eventname"], "setHello");
+    }
+
+    // Confirm the value exists in the nested map
+    {
+        let call = r#"{
+        "_tag": "getHello",
+        "params": []
+    }"#;
+        let (_, txn) = send_transaction(
+            &mut network,
+            &secret_key,
+            3,
+            ToAddr::Address(contract_address),
+            0,
+            50_000,
+            None,
+            Some(call),
+        )
+        .await;
+        for event in txn["receipt"]["event_logs"].as_array().unwrap() {
+            assert_eq!(event["_eventname"], "getHello");
+            assert_eq!(event["params"][0]["value"], "foobar");
+        }
+    }
+
+    // Remove entry from map
+    {
+        let call = r#"{
+        "_tag": "removeHello",
+        "params": []
+    }"#;
+
+        let (_, txn) = send_transaction(
+            &mut network,
+            &secret_key,
+            4,
+            ToAddr::Address(contract_address),
+            0,
+            50_000,
+            None,
+            Some(&call),
+        )
+        .await;
+        let event = &txn["receipt"]["event_logs"][0];
+        assert_eq!(event["_eventname"], "removeHello");
+    }
+
+    // Check and confirm the entry does not exist anymore
+    {
+        let call = r#"{
+        "_tag": "getHello",
+        "params": []
+    }"#;
+        let (_, txn) = send_transaction(
+            &mut network,
+            &secret_key,
+            5,
+            ToAddr::Address(contract_address),
+            0,
+            50_000,
+            None,
+            Some(call),
+        )
+        .await;
+        let event = &txn["receipt"]["event_logs"][0];
+        assert_eq!(event["params"][0]["value"], "failed");
+    }
 }
 
 #[zilliqa_macros::test]


### PR DESCRIPTION
It happened when there was a map containing maps as values, e.g `map<string, map<string, ...>>`. It triggered the assertion and led to node crash. 