### PR TITLE
Deposit v3 gas reduction

### DIFF
--- a/zilliqa/src/contracts/deposit_v4.sol
+++ b/zilliqa/src/contracts/deposit_v4.sol
@@ -622,8 +622,7 @@ contract Deposit is UUPSUpgradeable {
             emit StakerRemoved(blsPubKey, nextUpdate());
         } else {
             require(
-                currentBalance - amount >=
-                    $.minimumStake,
+                currentBalance - amount >= $.minimumStake,
                 "unstaking this amount would take the validator below the minimum stake"
             );
 

--- a/zilliqa/src/contracts/deposit_v4.sol
+++ b/zilliqa/src/contracts/deposit_v4.sol
@@ -585,12 +585,13 @@ contract Deposit is UUPSUpgradeable {
             revert KeyNotStaked();
         }
 
+        uint256 currentBalance = futureCommittee.stakers[blsPubKey].balance;
         require(
-            futureCommittee.stakers[blsPubKey].balance >= amount,
+            currentBalance >= amount,
             "amount is greater than staked balance"
         );
 
-        if (futureCommittee.stakers[blsPubKey].balance - amount == 0) {
+        if (currentBalance - amount == 0) {
             require(futureCommittee.stakerKeys.length > 1, "too few stakers");
 
             // Remove the staker from the future committee, because their staked amount has gone to zero.
@@ -621,7 +622,7 @@ contract Deposit is UUPSUpgradeable {
             emit StakerRemoved(blsPubKey, nextUpdate());
         } else {
             require(
-                futureCommittee.stakers[blsPubKey].balance - amount >=
+                currentBalance - amount >=
                     $.minimumStake,
                 "unstaking this amount would take the validator below the minimum stake"
             );

--- a/zilliqa/src/contracts/deposit_v4.sol
+++ b/zilliqa/src/contracts/deposit_v4.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity ^0.8.20;
+pragma solidity 0.8.28;
 
 import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import {Deque, Withdrawal} from "./utils/deque.sol";

--- a/zilliqa/src/contracts/deposit_v4.sol
+++ b/zilliqa/src/contracts/deposit_v4.sol
@@ -84,7 +84,7 @@ contract Deposit is UUPSUpgradeable {
         uint256 atFutureBlock
     );
 
-    uint64 public constant VERSION = 3;
+    uint64 public constant VERSION = 4;
 
     /// @custom:storage-location erc7201:zilliqa.storage.DepositStorage
     struct DepositStorage {
@@ -248,6 +248,7 @@ contract Deposit is UUPSUpgradeable {
         Committee storage currentCommittee = committee();
 
         stakerKeys = currentCommittee.stakerKeys;
+        indices = new uint256[](stakerKeys.length);
         balances = new uint256[](stakerKeys.length);
         stakers = new Staker[](stakerKeys.length);
         for (uint256 i = 0; i < stakerKeys.length; i++) {

--- a/zilliqa/src/contracts/deposit_v4.sol
+++ b/zilliqa/src/contracts/deposit_v4.sol
@@ -192,7 +192,6 @@ contract Deposit is UUPSUpgradeable {
         uint256 position = randomness % currentCommittee.totalStake;
         uint256 cummulativeStake = 0;
 
-        // TODO: Consider binary search for performance. Or consider an alias method for O(1) performance.
         for (uint256 i = 0; i < currentCommittee.stakerKeys.length; i++) {
             bytes memory stakerKey = currentCommittee.stakerKeys[i];
             uint256 stakedBalance = currentCommittee.stakers[stakerKey].balance;
@@ -243,7 +242,6 @@ contract Deposit is UUPSUpgradeable {
             Staker[] memory stakers
         )
     {
-        // TODO clean up doule call to _getDepositStorage() here
         DepositStorage storage $ = _getDepositStorage();
         Committee storage currentCommittee = committee();
 


### PR DESCRIPTION
These changes reduce the reading and writing to storage when writing future committees.

The functions whose gas usage is affected are:

| Call | Before | After |
| --- | --- | --- |
| Deposit owner1 | 348311 | 346633 |
| Deposit owner2 | 584151 | 585667 |
| depositTopUp owner1 | 337149 | 258079 |
| depositTopUp owner2 | 13484 | 13484 |
| 2nd depositTopUp owner1 | 202925 | 34310 |
| 2nd depositTopUp owner2 | 13499 | 13499 |
 