### PR TITLE
feat: deposit_v4 config

### DIFF
--- a/infra/config_docker.toml
+++ b/infra/config_docker.toml
@@ -87,4 +87,4 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 # Gas parameters
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
-consensus.contract_upgrade_block_heights = { deposit_v3 = 0 }
+consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }

--- a/infra/config_rpc_disabled.toml
+++ b/infra/config_rpc_disabled.toml
@@ -28,4 +28,4 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 # Gas parameters
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
-consensus.contract_upgrade_block_heights = { deposit_v3 = 0 }
+consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -178,7 +178,8 @@ impl Chain {
             },
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
-                deposit_v4: None,
+                // estimated: 2025-01-29T11:45:00Z
+                deposit_v4: Some(10879200),
             },
             _ => ContractUpgradesBlockHeights::default(),
         }

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -178,8 +178,8 @@ impl Chain {
             },
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
-                // estimated: 2025-01-29T11:45:00Z
-                deposit_v4: Some(10879200),
+                // estimated: 2025-02-03T13:55:00Z
+                deposit_v4: Some(10890000),
             },
             _ => ContractUpgradesBlockHeights::default(),
         }

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -168,13 +168,17 @@ impl Chain {
         match self {
             Self::Zq2Devnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(3600),
+                // estimated: 2025-01-28T20:25:00Z
+                deposit_v4: Some(428400),
             },
             Self::Zq2ProtoMainnet => ContractUpgradesBlockHeights {
                 // estimated: 2024-12-20T23:33:12Z
                 deposit_v3: Some(5342400),
+                deposit_v4: None,
             },
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
+                deposit_v4: None,
             },
             _ => ContractUpgradesBlockHeights::default(),
         }

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -568,6 +568,7 @@ pub fn genesis_fork_default() -> Fork {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ContractUpgradesBlockHeights {
     pub deposit_v3: Option<u64>,
+    pub deposit_v4: Option<u64>,
 }
 
 impl ContractUpgradesBlockHeights {
@@ -594,7 +595,8 @@ impl ContractUpgradesBlockHeights {
 impl Default for ContractUpgradesBlockHeights {
     fn default() -> Self {
         Self {
-            deposit_v3: Some(0),
+            deposit_v3: None,
+            deposit_v4: Some(0),
         }
     }
 }

--- a/zilliqa/src/contracts/mod.rs
+++ b/zilliqa/src/contracts/mod.rs
@@ -126,6 +126,62 @@ pub mod deposit_v3 {
         Lazy::new(|| CONTRACT.abi.function("blocksPerEpoch").unwrap().clone());
 }
 
+pub mod deposit_v4 {
+    use ethabi::{Constructor, Function};
+    use once_cell::sync::Lazy;
+
+    use super::{contract, Contract};
+
+    pub static CONTRACT: Lazy<Contract> =
+        Lazy::new(|| contract("src/contracts/deposit_v4.sol", "Deposit"));
+    pub static CONSTRUCTOR: Lazy<Constructor> =
+        Lazy::new(|| CONTRACT.abi.constructor().unwrap().clone());
+    pub static REINITIALIZE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("reinitialize").unwrap().clone());
+    pub static UPGRADE_TO_AND_CALL: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("upgradeToAndCall").unwrap().clone());
+    pub static VERSION: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("version").unwrap().clone());
+
+    pub static BYTECODE: Lazy<Vec<u8>> = Lazy::new(|| CONTRACT.bytecode.clone());
+    pub static LEADER_AT_VIEW: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("leaderAtView").unwrap().clone());
+    pub static DEPOSIT: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("deposit").unwrap().clone());
+    pub static DEPOSIT_TOPUP: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("depositTopup").unwrap().clone());
+    pub static UNSTAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("unstake").unwrap().clone());
+    pub static CURRENT_EPOCH: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("currentEpoch").unwrap().clone());
+    pub static GET_STAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getStake").unwrap().clone());
+    pub static GET_REWARD_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getRewardAddress").unwrap().clone());
+    pub static GET_SIGNING_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getSigningAddress").unwrap().clone());
+    pub static GET_CONTROL_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getControlAddress").unwrap().clone());
+    pub static SET_SIGNING_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("setSigningAddress").unwrap().clone());
+    pub static SET_CONTROL_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("setControlAddress").unwrap().clone());
+    pub static GET_PEER_ID: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getPeerId").unwrap().clone());
+    pub static GET_STAKERS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getStakers").unwrap().clone());
+    pub static GET_TOTAL_STAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getTotalStake").unwrap().clone());
+    pub static COMMITTEE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("committee").unwrap().clone());
+    pub static MIN_DEPOSIT: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("minimumStake").unwrap().clone());
+    pub static MAX_STAKERS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("maximumStakers").unwrap().clone());
+    pub static BLOCKS_PER_EPOCH: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("blocksPerEpoch").unwrap().clone());
+}
+
 pub mod shard {
     use ethabi::Constructor;
     use once_cell::sync::Lazy;
@@ -244,6 +300,7 @@ mod tests {
                 "src/contracts/deposit_v1.sol",
                 "src/contracts/deposit_v2.sol",
                 "src/contracts/deposit_v3.sol",
+                "src/contracts/deposit_v4.sol",
                 "src/contracts/utils/deque.sol",
                 "src/contracts/intershard_bridge.sol",
                 "src/contracts/shard.sol",

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -184,6 +184,13 @@ impl State {
                 self.upgrade_deposit_contract(block_header, deposit_v3_contract)?;
             }
         }
+        if let Some(deposit_v4_deploy_height) = contract_upgrade_block_heights.deposit_v4 {
+            if deposit_v4_deploy_height == block_header.number {
+                let deposit_v4_contract =
+                    Lazy::<contracts::Contract>::force(&contracts::deposit_v4::CONTRACT);
+                self.upgrade_deposit_contract(block_header, deposit_v4_contract)?;
+            }
+        }
         Ok(())
     }
 

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -186,6 +186,16 @@ impl State {
         }
         if let Some(deposit_v4_deploy_height) = contract_upgrade_block_heights.deposit_v4 {
             if deposit_v4_deploy_height == block_header.number {
+                // The below account mutation fixes the Zero account's nonce in prototestnet and protomainnet. 
+                // Issue #2254 explains how the nonce was incorrect due to a bug in the ZQ1 persistence converter.
+                // This code should run once for these networks in order for the deposit_v4 contract to be deployed, then this code can be removed.
+                if self.chain_id.eth == 33103 || self.chain_id.eth == 32770 {
+                   self.mutate_account(Address::ZERO, |a| {
+                        // Nonce 5 is the next address to not have any code deployed 
+                        a.nonce = 5;
+                    Ok(())
+                })?;
+                }
                 let deposit_v4_contract =
                     Lazy::<contracts::Contract>::force(&contracts::deposit_v4::CONTRACT);
                 self.upgrade_deposit_contract(block_header, deposit_v4_contract)?;

--- a/zilliqa/src/state.rs
+++ b/zilliqa/src/state.rs
@@ -186,15 +186,15 @@ impl State {
         }
         if let Some(deposit_v4_deploy_height) = contract_upgrade_block_heights.deposit_v4 {
             if deposit_v4_deploy_height == block_header.number {
-                // The below account mutation fixes the Zero account's nonce in prototestnet and protomainnet. 
+                // The below account mutation fixes the Zero account's nonce in prototestnet and protomainnet.
                 // Issue #2254 explains how the nonce was incorrect due to a bug in the ZQ1 persistence converter.
                 // This code should run once for these networks in order for the deposit_v4 contract to be deployed, then this code can be removed.
                 if self.chain_id.eth == 33103 || self.chain_id.eth == 32770 {
-                   self.mutate_account(Address::ZERO, |a| {
-                        // Nonce 5 is the next address to not have any code deployed 
+                    self.mutate_account(Address::ZERO, |a| {
+                        // Nonce 5 is the next address to not have any code deployed
                         a.nonce = 5;
-                    Ok(())
-                })?;
+                        Ok(())
+                    })?;
                 }
                 let deposit_v4_contract =
                     Lazy::<contracts::Contract>::force(&contracts::deposit_v4::CONTRACT);

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -330,6 +330,7 @@ impl Network {
 
         let contract_upgrade_block_heights = ContractUpgradesBlockHeights {
             deposit_v3: deposit_v3_upgrade_block_height,
+            deposit_v4: None,
         };
 
         let config = NodeConfig {
@@ -467,6 +468,7 @@ impl Network {
     pub fn add_node_with_options(&mut self, options: NewNodeOptions) -> usize {
         let contract_upgrade_block_heights = ContractUpgradesBlockHeights {
             deposit_v3: self.deposit_v3_upgrade_block_height,
+            deposit_v4: None,
         };
         let config = NodeConfig {
             eth_chain_id: self.shard_id,


### PR DESCRIPTION
- Introduce env var for setting `deposit_v4` contract upgrade block height
- Accounts for a [bug](https://github.com/Zilliqa/zq2/issues/2254) which overwrote the zero account's nonce value in proto nets
- Set upgrade height for devnet and prototestnet