### PR TITLE
Fix boundaries for histogram metrics

### DIFF
--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -89,6 +89,7 @@ macro_rules! declare_module {
             let enabled = $enabled_apis.iter().any(|n| n.enabled($name));
             let rpc_server_duration = meter
                 .f64_histogram(opentelemetry_semantic_conventions::metric::RPC_SERVER_DURATION)
+                .with_boundaries(vec![0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0])
                 .with_unit("s")
                 .build();
             module

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -185,6 +185,9 @@ impl NodeLauncher {
         let messaging_process_duration = meter
             .f64_histogram(MESSAGING_PROCESS_DURATION)
             .with_unit("s")
+            .with_boundaries(vec![
+                0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0,
+            ])
             .build();
 
         loop {


### PR DESCRIPTION
The default boundaries are too wide to be useful. Instead we use the standard boundaries for HTTP requests which will provide more useful results.