### PR TITLE
Fix local docker compose runs

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,7 @@ version: "3"
 services:
   node0:
     depends_on:
+      - node2
       - node3 
     environment:
       RUST_BACKTRACE: 1
@@ -24,6 +25,7 @@ services:
 
   node1:
     depends_on:
+      - node2
       - node3
     environment:
       RUST_BACKTRACE: 1

--- a/infra/config_docker.toml
+++ b/infra/config_docker.toml
@@ -1,6 +1,12 @@
 bootstrap_address = [
-    "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
-    "/ip4/198.51.100.103/tcp/5643",
+    [
+        "12D3KooWLA4xVjiGszqmYJmt8E1NTurVeCujDi17FoSzSDDDKUjT",
+        "/ip4/198.51.100.102/tcp/5643",
+    ],
+    [
+        "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
+        "/ip4/198.51.100.103/tcp/5643",
+    ],
 ]
 p2p_port = 5643
 

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -500,7 +500,7 @@ impl Setup {
             println!("🎱 Generating configuration for node {node_index}...");
             let mut cfg = zilliqa::cfg::Config {
                 otlp_collector_endpoint: Some("http://localhost:4317".to_string()),
-                bootstrap_address: None,
+                bootstrap_address: Default::default(),
                 nodes: Vec::new(),
                 p2p_port: 0,
                 external_address: None,

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -32,10 +32,51 @@ pub struct Config {
     /// The address of another node to dial when this node starts. To join the network, a node must know about at least
     /// one other existing node in the network.
     #[serde(default)]
-    pub bootstrap_address: Option<(PeerId, Multiaddr)>,
+    pub bootstrap_address: OneOrMany<(PeerId, Multiaddr)>,
     /// The base address of the OTLP collector. If not set, metrics will not be exported.
     #[serde(default)]
     pub otlp_collector_endpoint: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct OneOrMany<T>(pub Vec<T>);
+
+impl<T> Default for OneOrMany<T> {
+    fn default() -> Self {
+        Self(vec![])
+    }
+}
+
+impl<T: Serialize> Serialize for OneOrMany<T> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if self.0.len() == 1 {
+            self.0[0].serialize(serializer)
+        } else {
+            self.0.serialize(serializer)
+        }
+    }
+}
+
+impl<'de, T: Deserialize<'de>> Deserialize<'de> for OneOrMany<T> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Inner<T> {
+            One(T),
+            Many(Vec<T>),
+        }
+
+        match Inner::deserialize(deserializer)? {
+            Inner::One(t) => Ok(OneOrMany(vec![t])),
+            Inner::Many(t) => Ok(OneOrMany(t)),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
This adds support for multiple bootstrap peers. We use this in the local docker compose set up to ensure all nodes have at least one other node to talk to at startup, which they can use to find their own external address via autonat.

This also means we can remove the incorrect code where we always trust our observed external address once a single peer reports one. Instead, the external address candidates are passed to autonat and confirmed later.

The configuration change is backwards compatible, because we support either a single entry or a list of bootstrap peers now.

Fixes #2114.