### PR TITLE
Update chain specification files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9095,6 +9095,7 @@ version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/infra/config_rpc_disabled.toml
+++ b/infra/config_rpc_disabled.toml
@@ -1,3 +1,7 @@
+bootstrap_address = [
+    "12D3KooWESMZ2ttSxDwjfnNe23sHCqsJf6sNEKwgHkdgtCHDsbWU",
+    "/ip4/198.51.100.1/tcp/5643",
+]
 otlp_collector_endpoint = "http://otel-collector:4317"
 
 [[nodes]]
@@ -20,6 +24,9 @@ consensus.genesis_accounts = [
     ["AcE5F1e883d3e02A1b2C78F6909a8C0430C6Fb12", "5000000000000000000000"],
     ["1958b2f7b5c476F5e8FeBdEFeba5EC39E2f20288", "5000000000000000000000"],
 ]
+
+# speed up local/docker epochs
+consensus.blocks_per_epoch = 36
 
 # Reward parameters
 consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -59,7 +59,7 @@ revm = {version = "18.0.0", features = ["optional_balance_check"]}
 rs-leveldb = "0.1.5"
 rustls = "0.23.22"
 serde = {version = "1.0.217", features = ["derive"]}
-serde_json = "1.0.138"
+serde_json = { version = "1.0.138", features = ["preserve_order"] }
 serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 sha3 = "0.10.8"
@@ -70,7 +70,7 @@ tera = "1.19.1"
 thiserror = "2.0.11"
 tokio = {version = "1.43.0", features = ["macros", "rt-multi-thread", "sync", "io-std", "io-util", "process", "fs"]}
 tokio-stream = "0.1.17"
-toml = "0.8.19"
+toml = { version = "0.8.19", features = ["preserve_order"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.18"
 url = "2.5.4"

--- a/z2/docs/join.md
+++ b/z2/docs/join.md
@@ -8,11 +8,12 @@ Join a ZQ2 network
 Usage: z2 join [OPTIONS] --chain <CHAIN_NAME>
 
 Options:
-      --chain <CHAIN_NAME>     Specify the ZQ2 chain you want join [possible values: zq2-richard, zq2-uccbtest, zq2-infratest, zq2-perftest, zq2-devnet, zq2-prototestnet, zq2-protomainnet]
-      --image-tag <IMAGE_TAG>  Specify the tag of the image to run
-  -v, --verbose...             Increase logging verbosity
-  -q, --quiet...               Decrease logging verbosity
-  -h, --help                   Print help
+      --chain <CHAIN_NAME>              Specify the ZQ2 chain you want join [possible values: zq2-richard, zq2-uccbtest, zq2-infratest, zq2-perftest, zq2-devnet, zq2-prototestnet, zq2-protomainnet]
+      --image-tag <IMAGE_TAG>           Specify the tag of the image to run
+      --otlp-endpoint <OTLP_ENDPOINT>   Endpoint of OTLP collector
+  -v, --verbose...                      Increase logging verbosity
+  -q, --quiet...                        Decrease logging verbosity
+  -h, --help                            Print help
 ```
 
 ## Create a startup script and configuration file to join the prototestnet

--- a/z2/resources/chain-specs/zq2-devnet.toml
+++ b/z2/resources/chain-specs/zq2-devnet.toml
@@ -16,6 +16,6 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = []
-consensus.contract_upgrade_block_heights = { deposit_v3 = 3600 }
+consensus.contract_upgrade_block_heights = { deposit_v3 = 3600, deposit_v4 = 428400 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]

--- a/z2/resources/chain-specs/zq2-infratest.toml
+++ b/z2/resources/chain-specs/zq2-infratest.toml
@@ -1,12 +1,12 @@
 p2p_port = 3333
-bootstrap_address = [ "12D3KooWSe8gG2PYGg9qemHNZDsuZcFjkvcU2Fr49bomHGZD2k8x", "/dns/bootstrap.zq2-infratest.zilstg.dev/tcp/3333" ]
+bootstrap_address = [ "12D3KooWLe4CnsLgeEZnfgS44gdDKdsMEayE96qfU2csB8Lijp54", "/dns/bootstrap.zq2-infratest.zilstg.dev/tcp/3333" ]
 
 [[nodes]]
 eth_chain_id = 33103
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
 consensus.genesis_accounts = [ ["0x5e1f6f14a75f12e055599a137229cfa012554695", "900_000_000_000_000_000_000_000_000" ] ]
-consensus.genesis_deposits = [ ["95f1b0d4d47dfdd782e5ea823c2a175098e1a1afd9525c9f7e2f9fec6da080ab654ff27210d20d81331038bd10e0b08e", "12D3KooWSe8gG2PYGg9qemHNZDsuZcFjkvcU2Fr49bomHGZD2k8x", "20_000_000_000_000_000_000_000_000", "0x0000000000000000000000000000000000000000", "0x5e1f6f14a75f12e055599a137229cfa012554695"] ]
+consensus.genesis_deposits = [ ["b462b1237800dd183432290cb6e3691ff3832886db903979f086078e5334e32ee3f8d483ee4a96dcae747fdcc5dd2ba7", "12D3KooWLe4CnsLgeEZnfgS44gdDKdsMEayE96qfU2csB8Lijp54", "20_000_000_000_000_000_000_000_000", "0x0000000000000000000000000000000000000000", "0x5e1f6f14a75f12e055599a137229cfa012554695"] ]
 
 # Reward parameters
 consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"
@@ -16,6 +16,6 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = []
-consensus.contract_upgrade_block_heights = { deposit_v3 = 0 }
+consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]

--- a/z2/resources/chain-specs/zq2-perftest.toml
+++ b/z2/resources/chain-specs/zq2-perftest.toml
@@ -16,6 +16,6 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = []
-consensus.contract_upgrade_block_heights = {}
+consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]

--- a/z2/resources/chain-specs/zq2-protomainnet.toml
+++ b/z2/resources/chain-specs/zq2-protomainnet.toml
@@ -16,11 +16,11 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = ["0x95347b860Bd49818AFAccCA8403C55C23e7BB9ED", "0xe64cA52EF34FdD7e20C0c7fb2E392cc9b4F6D049", "0x63B991C17010C21250a0eA58C6697F696a48cdf3", "0x241c677D9969419800402521ae87C411897A029f", "0x2274005778063684fbB1BfA96a2b725dC37D75f9", "0x598FbD8B68a8B7e75b8B7182c750164f348907Bc", "0x2938fF251Aecc1dfa768D7d0276eB6d073690317", "0x17D5af5658A24bd964984b36d28e879a8626adC3", "0xCcF3Ea256d42Aeef0EE0e39Bfc94bAa9Fa14b0Ba", "0xc6F3dede529Af9D98a11C5B32DbF03Bf34272ED5", "0x7D2fF48c6b59229d448473D267a714d29F078D3E", "0xE9D47623bb2B3C497668B34fcf61E101a7ea4058", "0x03A79429acc808e4261a68b0117aCD43Cb0FdBfa", "0x097C26F8A93009fd9d98561384b5014D64ae17C2", "0x01035e423c40a9ad4F6be2E6cC014EB5617c8Bd6", "0x9C3fE3f471d8380297e4fB222eFb313Ee94DFa0f", "0x20Dd5D5B5d4C72676514A0eA1052d0200003d69D", "0xbfDe2156aF75a29d36614bC1F8005DD816Bd9200"]
-consensus.contract_upgrade_block_heights = { deposit_v3 = 5342400 }
+consensus.contract_upgrade_block_heights = { deposit_v3 = 5342400, deposit_v4 = 7966000 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
-
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
 consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false }
 consensus.forks = [
-    { at_height = 5342400, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true }
+    { at_height = 5342400, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, call_mode_1_sets_caller_to_parent_caller = true },
+    { at_height = 7966000, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true },
 ]

--- a/z2/resources/chain-specs/zq2-prototestnet.toml
+++ b/z2/resources/chain-specs/zq2-prototestnet.toml
@@ -16,12 +16,12 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = ["0x60E6b5b1B8D3E373E1C04dC0b4f5624776bcBB60", "0x7013Da2653453299Efb867EfcCCcB1A6d5FE1384", "0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3", "0xE90Dd366D627aCc5feBEC126211191901A69f8a0", "0x5900Ac075A67742f5eA4204650FEad9E674c664F", "0x28e8d39fc68eaa27c88797eb7d324b4b97d5b844", "0x51b9f3ddb948bcc16b89b48d83b920bc01dbed55", "0x1fD09F6701a1852132A649fe9D07F2A3b991eCfA", "0x878c5008A348A60a5B239844436A7b483fAdb7F2", "0x8895Aa1bEaC254E559A3F91e579CF4a67B70ce02", "0x453b11386FBd54bC532892c0217BBc316fc7b918", "0xaD581eC62eA08831c8FE2Cd7A1113473fE40A057"]
-consensus.contract_upgrade_block_heights = { deposit_v3 = 8406000 }
+consensus.contract_upgrade_block_heights = { deposit_v3 = 8406000, deposit_v4 = 10890000 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
-
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
 consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false }
 consensus.forks = [
-    { at_height = 8404000, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true },
-    { at_height = 10200000, scilla_messages_can_call_evm_contracts = true }
+    { at_height = 8404000, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, call_mode_1_sets_caller_to_parent_caller = true },
+    { at_height = 10200000, scilla_messages_can_call_evm_contracts = true },
+    { at_height = 11152000, scilla_contract_creation_increments_account_balance = true },
 ]

--- a/z2/resources/chain-specs/zq2-richard.toml
+++ b/z2/resources/chain-specs/zq2-richard.toml
@@ -16,6 +16,6 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = []
-consensus.contract_upgrade_block_heights = {}
+consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]

--- a/z2/resources/chain-specs/zq2-uccbtest.toml
+++ b/z2/resources/chain-specs/zq2-uccbtest.toml
@@ -16,6 +16,6 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.scilla_call_gas_exempt_addrs = []
-consensus.contract_upgrade_block_heights = {}
+consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ apis = ["blockNumber"], namespace = "eth" }] }, { enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"], port = 4202 }]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]

--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -4,8 +4,6 @@ p2p_port = 3333
 bootstrap_address = [ "{{ bootstrap_peer_id }}", "/dns/{{ bootstrap_endpoint }}/tcp/3333" ]
 {%- endif %}
 
-otlp_collector_endpoint = "http://localhost:4317"
-
 [[nodes]]
 eth_chain_id = {{ eth_chain_id }}
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
@@ -47,6 +45,14 @@ file = "{{ checkpoint_file }}"
 hash = "{{ checkpoint_hash }}"
 {%- endif %}
 
+{%- if genesis_fork %}
+consensus.genesis_fork = {{ genesis_fork }}
+{%- endif %}
+
 {%- if forks %}
-consensus.forks = {{ forks }}
+consensus.forks = [
+    {%- for fork in forks %}
+    {{ fork }},
+    {%- endfor %}
+]
 {%- endif %}

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -174,7 +174,8 @@ impl Chain {
             Self::Zq2ProtoMainnet => ContractUpgradesBlockHeights {
                 // estimated: 2024-12-20T23:33:12Z
                 deposit_v3: Some(5342400),
-                deposit_v4: None,
+                // estimated: 2025-02-12T13:25:00Z
+                deposit_v4: Some(7966800),
             },
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
@@ -185,19 +186,34 @@ impl Chain {
         }
     }
 
+    pub fn genesis_fork(&self) -> Option<Value> {
+        match self {
+            Chain::Zq2ProtoTestnet | Chain::Zq2ProtoMainnet => Some(json!({
+                "at_height": 0,
+                "call_mode_1_sets_caller_to_parent_caller": false,
+                "failed_scilla_call_from_gas_exempt_caller_causes_revert": false,
+                "scilla_messages_can_call_evm_contracts": false,
+                "scilla_contract_creation_increments_account_balance": false,
+            })),
+            _ => None,
+        }
+    }
+
     pub fn get_forks(&self) -> Option<Vec<Value>> {
         match self {
             Chain::Zq2ProtoTestnet => Some(vec![
-                json!({ "at_height": 0, "failed_scilla_call_from_gas_exempt_caller_causes_revert": false, "call_mode_1_sets_caller_to_parent_caller": false, "scilla_messages_can_call_evm_contracts": false, "scilla_contract_creation_increments_account_balance": false }),
                 // estimated: 2024-12-18T14:57:53Z
-                json!({ "at_height": 8404000, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true, "scilla_messages_can_call_evm_contracts": false, "scilla_contract_creation_increments_account_balance": false }),
+                json!({ "at_height": 8404000, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true }),
                 // estimated: 2025-01-15T09:10:37Z
-                json!({ "at_height": 10200000, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true, "scilla_messages_can_call_evm_contracts": true, "scilla_contract_creation_increments_account_balance": false }),
+                json!({ "at_height": 10200000, "scilla_messages_can_call_evm_contracts": true }),
+                // estimated: 2025-02-12T12:08:37Z
+                json!({ "at_height": 11152000, "scilla_contract_creation_increments_account_balance": true }),
             ]),
             Chain::Zq2ProtoMainnet => Some(vec![
-                json!({ "at_height": 0, "failed_scilla_call_from_gas_exempt_caller_causes_revert": false, "call_mode_1_sets_caller_to_parent_caller": false, "scilla_messages_can_call_evm_contracts": false, "scilla_contract_creation_increments_account_balance": false }),
                 // estimated: 2024-12-20T23:33:12Z
-                json!({ "at_height": 5342400, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true, "scilla_messages_can_call_evm_contracts": false, "scilla_contract_creation_increments_account_balance": false }),
+                json!({ "at_height": 5342400, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true }),
+                // estimated: 2025-02-12T13:25:00Z
+                json!({ "at_height": 7966800, "scilla_messages_can_call_evm_contracts": true, "scilla_contract_creation_increments_account_balance": true }),
             ]),
             _ => None,
         }

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -868,6 +868,12 @@ impl ChainNode {
         let toml_servers: toml::Value = serde_json::from_value(api_servers)?;
         ctx.insert("api_servers", &toml_servers.to_string());
         ctx.insert("enable_ots_indices", &enable_ots_indices);
+        if let Some(genesis_fork) = self.chain()?.genesis_fork() {
+            ctx.insert(
+                "genesis_fork",
+                &serde_json::from_value::<toml::Value>(genesis_fork)?.to_string(),
+            );
+        }
         if let Some(forks) = self.chain()?.get_forks() {
             ctx.insert(
                 "forks",

--- a/z2/src/deployer.rs
+++ b/z2/src/deployer.rs
@@ -140,7 +140,7 @@ async fn execute_install_or_upgrade(
     Ok(())
 }
 
-pub async fn get_config_file(config_file: &str, role: NodeRole) -> Result<()> {
+pub async fn get_config_file(config_file: &str, role: NodeRole, out: Option<&str>) -> Result<()> {
     if role == NodeRole::Apps {
         log::info!(
             "Config file is not present for nodes with role {}",
@@ -157,10 +157,14 @@ pub async fn get_config_file(config_file: &str, role: NodeRole) -> Result<()> {
 
     if let Some(node) = chain_nodes.first() {
         let content = node.get_config_toml().await?;
-        println!("Config file for a node role {} in {}", role, chain.name());
-        println!("---");
-        println!("{}", content);
-        println!("---");
+        if let Some(out) = out {
+            std::fs::write(out, content)?;
+        } else {
+            println!("Config file for a node role {} in {}", role, chain.name());
+            println!("---");
+            println!("{}", content);
+            println!("---");
+        }
     } else {
         log::error!(
             "No nodes available in {} for the role {}",

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -210,9 +210,13 @@ pub async fn run_deployer_upgrade(
     Ok(())
 }
 
-pub async fn run_deployer_get_config_file(config_file: &str, role: NodeRole) -> Result<()> {
+pub async fn run_deployer_get_config_file(
+    config_file: &str,
+    role: NodeRole,
+    out: Option<&str>,
+) -> Result<()> {
     println!("🦆 Getting nodes config file for {config_file} .. ");
-    deployer::get_config_file(config_file, role).await?;
+    deployer::get_config_file(config_file, role, out).await?;
     Ok(())
 }
 

--- a/z2/src/validators.rs
+++ b/z2/src/validators.rs
@@ -137,8 +137,9 @@ pub async fn get_chain_spec_config(chain_name: &str) -> Result<Value> {
 }
 
 pub async fn gen_validator_startup_script(
-    config: &ChainConfig,
+    config: &mut ChainConfig,
     image_tag: &Option<String>,
+    otlp_collector_endpoint: &Option<String>,
 ) -> Result<()> {
     println!("✌️ Generating the validator startup scripts and configuration");
     println!("📋 Chain specification: {}", config.name);
@@ -157,6 +158,13 @@ pub async fn gen_validator_startup_script(
     context.insert("chain_name", &config.name);
     if let Some(v) = image_tag {
         context.insert("image_tag", v)
+    }
+
+    if let Some(v) = otlp_collector_endpoint {
+        let _ = config.spec.as_table_mut().unwrap().insert(
+            String::from("otlp_collector_endpoints"),
+            toml::Value::String(v.to_string()),
+        );
     }
 
     let script = tera_template


### PR DESCRIPTION
We also made some miscellaneous improvements:

* Remove redundant fork configuration from rendered configuration files.
* Add `--out` parameter to `z2 deployer get-config-file` to output the rendered configuration to a file.
* Add `--otlp-endpoint` to `z2 join`.

Also this adds activation heights for the latest hardforks on protomainnet and prototestnet.