### PR TITLE
feat: DEVOPS-1867 otlp-collector endpoint generation in the node configs

### DIFF
--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -941,7 +941,10 @@ impl ChainNode {
 
         // Adding the OpenTelemetry collector endpoint to all nodes configurations
         let otlp_collector_endpoint = "http://localhost:4317";
-        let config_file_with_otlp = format!("otlp_collector_endpoint = \"{otlp_collector_endpoint}\"\n{}", config_file);
+        let config_file_with_otlp = format!(
+            "otlp_collector_endpoint = \"{otlp_collector_endpoint}\"\n{}",
+            config_file
+        );
 
         let mut fh = File::create(filename).await?;
         fh.write_all(config_file_with_otlp.as_bytes()).await?;

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -939,8 +939,12 @@ impl ChainNode {
         let rendered_template = self.get_config_toml().await?;
         let config_file = rendered_template.as_str();
 
+        // Adding the OpenTelemetry collector endpoint to all nodes configurations
+        let otlp_collector_endpoint = "http://localhost:4317";
+        let config_file_with_otlp = format!("otlp_collector_endpoint = \"{otlp_collector_endpoint}\"\n{}", config_file);
+
         let mut fh = File::create(filename).await?;
-        fh.write_all(config_file.as_bytes()).await?;
+        fh.write_all(config_file_with_otlp.as_bytes()).await?;
         println!("Configuration file created: {filename}");
 
         Ok(filename.to_owned())

--- a/z2/src/validators.rs
+++ b/z2/src/validators.rs
@@ -162,7 +162,7 @@ pub async fn gen_validator_startup_script(
 
     if let Some(v) = otlp_collector_endpoint {
         let _ = config.spec.as_table_mut().unwrap().insert(
-            String::from("otlp_collector_endpoints"),
+            String::from("otlp_collector_endpoint"),
             toml::Value::String(v.to_string()),
         );
     }


### PR DESCRIPTION
- Generating the otlp_collector_endpoint config in the nodes config.toml - beginning of the file (currently enforcing the otlp is part of all environments and configurations in GCP).
- z2 deployer get-config-file not affected, as the otlp_collector_endpoint is only added at the install/update process.
- Fix on the otlp_collector_endpoint var name for z2 join.

Tests with z2 deployer install:
```
z2 deployer ssh --select zq2-infratest.yaml -- cat /config.toml
Recompiling z2, please wait …
🦆 Running SSH command for zq2-infratest.yaml' ..
Using the project ID prj-d-zq2-devnet-c83bkpsd
Create the instance list for zq2-infratest
◇  Select target nodes
│  zq2-infratest-api-ase1-0-5155
│
Running SSH command on zq2-infratest nodes
🦆 Running the SSH command: 'cat /config.toml' ..
---
zq2-infratest-api-ase1-0-5155
otlp_collector_endpoint = "http://localhost:4317"
p2p_port = 3333
bootstrap_address = [ "12D3KooWFsmJMnsRjFPsGi1EZfcK4N62ia9gTRfKDZHMpRKQWKeZ", "/dns/bootstrap.zq2-infratest.zilstg.dev/tcp/3333" ]
```

Tests with z2 join:
```
cat zq2-infratest.toml
p2p_port = 3333
bootstrap_address = ["12D3KooWLe4CnsLgeEZnfgS44gdDKdsMEayE96qfU2csB8Lijp54", "/dns/bootstrap.zq2-infratest.zilstg.dev/tcp/3333"]
otlp_collector_endpoint = "http://localhost:4317"
```

Tests with z2 deployer get-config-file:
```
z2 deployer get-config-file zq2-infratest.yaml
Recompiling z2, please wait …
🦆 Getting nodes config file for zq2-infratest.yaml ..
Using the project ID prj-d-zq2-devnet-c83bkpsd
Create the instance list for zq2-infratest
Bootstrap picked: zq2-infratest-bootstrap-ase1-2-334d
Using the project ID prj-d-zq2-devnet-c83bkpsd
Using the bootstrap endpoint bootstrap.zq2-infratest.zilstg.dev
Config file for a node role validator in zq2-infratest
---
p2p_port = 3333
bootstrap_address = [ "12D3KooWFsmJMnsRjFPsGi1EZfcK4N62ia9gTRfKDZHMpRKQWKeZ", "/dns/bootstrap.zq2-infratest.zilstg.dev/tcp/3333" ]
```

Tested in devnet:
![image](https://github.com/user-attachments/assets/caff9d97-d556-43d9-a609-e4495f13dc92)
