### PR TITLE
Adjust docker compose config files

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,8 +20,8 @@ services:
     ports:
       - "4201:4201"
     networks:
-      testnet:
-        ipv4_address: 198.51.100.100
+      localnet:
+        ipv4_address: 198.52.100.100
 
   node1:
     depends_on:
@@ -37,8 +37,8 @@ services:
     command:
       - 62070b1a3b5b30236e43b4f1bfd617e1af7474635558314d46127a708b9d302e
     networks:
-      testnet:
-        ipv4_address: 198.51.100.101
+      localnet:
+        ipv4_address: 198.52.100.101
 
   node2:
     depends_on:
@@ -53,8 +53,8 @@ services:
     command:
       - 56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364
     networks:
-      testnet:
-        ipv4_address: 198.51.100.102
+      localnet:
+        ipv4_address: 198.52.100.102
 
   node3:
     environment:
@@ -67,8 +67,8 @@ services:
     command:
       - db670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a
     networks:
-      testnet:
-        ipv4_address: 198.51.100.103
+      localnet:
+        ipv4_address: 198.52.100.103
 
   otterscan:
     environment:
@@ -78,8 +78,8 @@ services:
     ports:
       - "5100:80"
     networks:
-      testnet:
-        ipv4_address: 198.51.100.9
+      localnet:
+        ipv4_address: 198.52.100.9
 
   faucet:
     depends_on:
@@ -98,13 +98,13 @@ services:
     # Fast shutdown - Don't gracefully close open connections.
     stop_signal: SIGKILL
     networks:
-      testnet:
-        ipv4_address: 198.51.100.10
+      localnet:
+        ipv4_address: 198.52.100.10
 
 networks:
-  testnet:
+  localnet:
     driver: bridge
     ipam:
       config:
-        - subnet: 198.51.100.0/24
-          gateway: 198.51.100.1
+        - subnet: 198.52.100.0/24
+          gateway: 198.52.100.1

--- a/infra/config_docker.toml
+++ b/infra/config_docker.toml
@@ -1,49 +1,51 @@
 bootstrap_address = [
     [
         "12D3KooWLA4xVjiGszqmYJmt8E1NTurVeCujDi17FoSzSDDDKUjT",
-        "/ip4/198.51.100.102/tcp/5643",
+        "/ip4/198.52.100.102/tcp/5643",
     ],
     [
         "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
-        "/ip4/198.51.100.103/tcp/5643",
+        "/ip4/198.52.100.103/tcp/5643",
     ],
 ]
 p2p_port = 5643
 
 [[nodes]]
+# workaround to have the same short unbonding period for testing as on the devnet until a configurable unbonding period is implemented
+eth_chain_id = 33469
 api_servers = [
     { port = 4201, enabled_apis = [ "admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa" ] },
 ]
 
-# These (public key, peerId, stake, rewardAddress) tuples correspond to the private keys of all four nodes in `docker-compose.yaml`.
+# These (public key, peerId, stake, rewardAddress, controlAddress) tuples correspond to the private keys of all four nodes in `docker-compose.yaml`.
 consensus.genesis_deposits = [
     [
         "b27aebb3b54effd7af87c4a064a711554ee0f3f5abf56ca910b46422f2b21603bc383d42eb3b927c4c3b0b8381ca30a3",
         "12D3KooWESMZ2ttSxDwjfnNe23sHCqsJf6sNEKwgHkdgtCHDsbWU",
         "10000000000000000000000000",
         "7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
-        "7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+        "99F7f7C00526426b8dCA99302e96d85A0e5fd400",
     ],
     [
         "b37fd66aef29ca78a82d519a284789d59c2bb3880698b461c6c732d094534707d50e345128db372a1e0a4c5d5c42f49c",
         "12D3KooWJc2nBgNiSi14GcYaGmU8FoQsRkmhfMnaB1mHmPiBPZHd",
         "10000000000000000000000000",
         "2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
-        "2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
+        "983bbdcbe3b81d0cc9537d9be06b288a856bf2cc",
     ],
     [
         "ab035d6cd3321c3b57d14ea09a4f3860899542d2187b5ec87649b1f40980418a096717a671cf62b73880afac252fc5dc",
         "12D3KooWLA4xVjiGszqmYJmt8E1NTurVeCujDi17FoSzSDDDKUjT",
         "10000000000000000000000000",
         "6813Eb9362372EEF6200f3b1dbC3f819671cBA69",
-        "6813Eb9362372EEF6200f3b1dbC3f819671cBA69",
+        "a6b01290029aa94421071d56e38fccc328e3a86d",
     ],
     [
         "985e3a4d367cbfc966d48710806612cc00f6bfd06aa759340cfe13c3990d26a7ddde63f64468cdba5b2ff132a4639a7f",
         "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
         "10000000000000000000000000",
         "1efF47bc3a10a45D4B230B5d10E37751FE6AA718",
-        "1efF47bc3a10a45D4B230B5d10E37751FE6AA718",
+        "c8e0eac58cd06c2549ff52e91c30d9fff5ab8292",
     ],
 ]
 consensus.genesis_accounts = [

--- a/infra/opentelemetry/config_docker.toml
+++ b/infra/opentelemetry/config_docker.toml
@@ -1,6 +1,6 @@
 bootstrap_address = [
     "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
-    "/ip4/198.51.100.103/tcp/5643",
+    "/ip4/198.53.100.103/tcp/5643",
 ]
 p2p_port = 5643
 
@@ -12,35 +12,35 @@ api_servers = [
     { port = 4201, enabled_apis = [ "admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa" ] },
 ]
 
-# These (public key, peerId, stake, rewardAddress) tuples correspond to the private keys of all four nodes in `docker-compose.yaml`.
+# These (public key, peerId, stake, rewardAddress, controlAddress) tuples correspond to the private keys of all four nodes in `docker-compose.yaml`.
 consensus.genesis_deposits = [
     [
         "b27aebb3b54effd7af87c4a064a711554ee0f3f5abf56ca910b46422f2b21603bc383d42eb3b927c4c3b0b8381ca30a3",
         "12D3KooWESMZ2ttSxDwjfnNe23sHCqsJf6sNEKwgHkdgtCHDsbWU",
         "10000000000000000000000000",
         "7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
-        "7E5F4552091A69125d5DfCb7b8C2659029395Bdf",
+        "99F7f7C00526426b8dCA99302e96d85A0e5fd400",
     ],
     [
         "b37fd66aef29ca78a82d519a284789d59c2bb3880698b461c6c732d094534707d50e345128db372a1e0a4c5d5c42f49c",
         "12D3KooWJc2nBgNiSi14GcYaGmU8FoQsRkmhfMnaB1mHmPiBPZHd",
         "10000000000000000000000000",
         "2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
-        "2B5AD5c4795c026514f8317c7a215E218DcCD6cF",
+        "983bbdcbe3b81d0cc9537d9be06b288a856bf2cc",
     ],
     [
         "ab035d6cd3321c3b57d14ea09a4f3860899542d2187b5ec87649b1f40980418a096717a671cf62b73880afac252fc5dc",
         "12D3KooWLA4xVjiGszqmYJmt8E1NTurVeCujDi17FoSzSDDDKUjT",
         "10000000000000000000000000",
         "6813Eb9362372EEF6200f3b1dbC3f819671cBA69",
-        "6813Eb9362372EEF6200f3b1dbC3f819671cBA69",
+        "a6b01290029aa94421071d56e38fccc328e3a86d",
     ],
     [
         "985e3a4d367cbfc966d48710806612cc00f6bfd06aa759340cfe13c3990d26a7ddde63f64468cdba5b2ff132a4639a7f",
         "12D3KooWPXw2dXBRH1bT4vcNos9f6W2KoFTiarqptBuTzxaXg7zu",
         "10000000000000000000000000",
         "1efF47bc3a10a45D4B230B5d10E37751FE6AA718",
-        "1efF47bc3a10a45D4B230B5d10E37751FE6AA718",
+        "c8e0eac58cd06c2549ff52e91c30d9fff5ab8292",
     ],
 ]
 consensus.genesis_accounts = [

--- a/infra/opentelemetry/docker-compose.yaml
+++ b/infra/opentelemetry/docker-compose.yaml
@@ -19,8 +19,8 @@ services:
     ports:
       - "4211:4201"
     networks:
-      testnet_with_otel:
-        ipv4_address: 198.52.100.100
+      localnet_with_otel:
+        ipv4_address: 198.53.100.100
 
   node1_with_otel:
     depends_on:
@@ -35,8 +35,8 @@ services:
     command:
       - 62070b1a3b5b30236e43b4f1bfd617e1af7474635558314d46127a708b9d302e
     networks:
-      testnet_with_otel:
-        ipv4_address: 198.52.100.101
+      localnet_with_otel:
+        ipv4_address: 198.53.100.101
 
   node2_with_otel:
     depends_on:
@@ -51,8 +51,8 @@ services:
     command:
       - 56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364
     networks:
-      testnet_with_otel:
-        ipv4_address: 198.52.100.102
+      localnet_with_otel:
+        ipv4_address: 198.53.100.102
 
   node3_with_otel:
     environment:
@@ -65,8 +65,8 @@ services:
     command:
       - db670cbff28f4b15297d03fafdab8f5303d68b7591bd59e31eaef215dd0f246a
     networks:
-      testnet_with_otel:
-        ipv4_address: 198.52.100.103
+      localnet_with_otel:
+        ipv4_address: 198.53.100.103
 
   otterscan_with_otel:
     environment:
@@ -76,8 +76,8 @@ services:
     ports:
       - "5101:80"
     networks:
-      testnet_with_otel:
-        ipv4_address: 198.52.100.9
+      localnet_with_otel:
+        ipv4_address: 198.53.100.9
 
   faucet_with_otel:
     depends_on:
@@ -96,8 +96,8 @@ services:
     # Fast shutdown - Don't gracefully close open connections.
     stop_signal: SIGKILL
     networks:
-      testnet_with_otel:
-        ipv4_address: 198.52.100.10
+      localnet_with_otel:
+        ipv4_address: 198.53.100.10
 
   otel-collector:
     image: otel/opentelemetry-collector-contrib:latest
@@ -108,7 +108,7 @@ services:
       - "4317:4317"
       - "9011:8888"
     networks:
-      - testnet_with_otel
+      - localnet_with_otel
 
   mimir:
     image: grafana/mimir:latest
@@ -121,7 +121,7 @@ services:
     ports:
       - "9009:9009"
     networks:
-      - testnet_with_otel
+      - localnet_with_otel
 
   grafana:
     image: grafana/grafana-oss:latest
@@ -131,12 +131,12 @@ services:
     ports:
       - "9010:3000"
     networks:
-      - testnet_with_otel
+      - localnet_with_otel
 
 networks:
-  testnet_with_otel:
+  localnet_with_otel:
     driver: bridge
     ipam:
       config:
-        - subnet: 198.52.100.0/24
-          gateway: 198.52.100.1
+        - subnet: 198.53.100.0/24
+          gateway: 198.53.100.1


### PR DESCRIPTION
A few adjustments to make docker compose networks fully functional:
* use the addresses derived from 4 nodes'  private key as control address in the genesis deposits
* use a different IP and network name to avoid conflicts with the Zilstats agent running on the same machine
* use the devnet's chain id to make testing of deposit withdrawals possible within 5 minutes instead of 14 days 