### PR TITLE
fix: DEVOPS-1850 single quotes in validation identities variable

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -53,7 +53,7 @@ CHECKPOINT_URL="{{ checkpoint_url }}"
 SUBDOMAIN=query_metadata_key("subdomain")
 ZQ2_METRICS_ENABLED=query_metadata_key("private-api") == "metrics"
 ZQ2_METRICS_IMAGE="{{ zq2_metrics_image }}"
-VALIDATOR_IDENTITIES="{{ validator_identities }}"
+VALIDATOR_IDENTITIES='{{ validator_identities }}'
 
 def mount_checkpoint_file():
     if CHECKPOINT_URL is not None and CHECKPOINT_URL != "":


### PR DESCRIPTION
Required to use the list of validators.

Tested in Grafana: 
![image](https://github.com/user-attachments/assets/06f662c6-83cb-4cc9-afc8-112cd41d4953)
