### PR TITLE
Restart Node when Stuck Syncing

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -130,8 +130,8 @@ def check_sync_status():
     
     # If syncing response is a JSON object
     if isinstance(sync_status, dict):
-        current_block = int(sync_status["currentBlock"])
-        highest_block = int(sync_status["highestBlock"])
+        current_block = int(sync_status["currentBlock"], 16)
+        highest_block = int(sync_status["highestBlock"], 16)
         
         if current_block >= highest_block - 5:
             return jsonify({"message": f"Node is syncing at block {block_number} but behind highest block {highest_block}", "code": 200})

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -493,7 +493,6 @@ pub struct SyncingStruct {
 
 #[derive(Clone, Serialize)]
 #[serde(untagged)]
-#[allow(clippy::large_enum_variant)]
 pub enum SyncingResult {
     Bool(bool),
     Struct(SyncingStruct),

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -463,21 +463,31 @@ pub struct TxPoolContent {
 #[serde(rename_all = "camelCase")]
 pub struct SyncingMeta {
     pub current_phase: String,
-    pub peer_count: String,
-    pub header_downloads: String,
-    pub block_downloads: String,
-    pub buffered_blocks: String,
-    pub empty_count: String,
-    pub retry_count: String,
-    pub timeout_count: String,
+    #[serde(serialize_with = "hex")]
+    pub peer_count: usize,
+    #[serde(serialize_with = "hex")]
+    pub header_downloads: usize,
+    #[serde(serialize_with = "hex")]
+    pub block_downloads: usize,
+    #[serde(serialize_with = "hex")]
+    pub buffered_blocks: usize,
+    #[serde(serialize_with = "hex")]
+    pub empty_count: usize,
+    #[serde(serialize_with = "hex")]
+    pub retry_count: usize,
+    #[serde(serialize_with = "hex")]
+    pub timeout_count: usize,
 }
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncingStruct {
-    pub starting_block: String,
-    pub current_block: String,
-    pub highest_block: String,
+    #[serde(serialize_with = "hex")]
+    pub starting_block: u64,
+    #[serde(serialize_with = "hex")]
+    pub current_block: u64,
+    #[serde(serialize_with = "hex")]
+    pub highest_block: u64,
     pub status: SyncingMeta,
 }
 

--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -463,26 +463,27 @@ pub struct TxPoolContent {
 #[serde(rename_all = "camelCase")]
 pub struct SyncingMeta {
     pub current_phase: String,
-    pub peer_count: usize,
-    pub header_downloads: u64,
-    pub block_downloads: u64,
-    pub buffered_blocks: usize,
-    pub empty_count: u64,
-    pub retry_count: u64,
-    pub timeout_count: u64,
+    pub peer_count: String,
+    pub header_downloads: String,
+    pub block_downloads: String,
+    pub buffered_blocks: String,
+    pub empty_count: String,
+    pub retry_count: String,
+    pub timeout_count: String,
 }
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncingStruct {
-    pub starting_block: u64,
-    pub current_block: u64,
-    pub highest_block: u64,
+    pub starting_block: String,
+    pub current_block: String,
+    pub highest_block: String,
     pub status: SyncingMeta,
 }
 
 #[derive(Clone, Serialize)]
 #[serde(untagged)]
+#[allow(clippy::large_enum_variant)]
 pub enum SyncingResult {
     Bool(bool),
     Struct(SyncingStruct),

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1128,6 +1128,11 @@ impl Consensus {
     /// This should only run after majority QC or aggQC are available.
     /// It applies the rewards and produces the final Proposal.
     fn early_proposal_finish_at(&mut self, mut proposal: Block) -> Result<Option<Block>> {
+        // If we are syncing, we don't finalise and send the proposal
+        if self.sync.am_syncing()? {
+            return Ok(None);
+        }
+
         // Retrieve parent block data
         let parent_block = self
             .get_block(&proposal.parent_hash())?
@@ -1661,7 +1666,7 @@ impl Consensus {
         Ok(Some(pending_block))
     }
 
-    fn are_we_leader_for_view(&mut self, parent_hash: Hash, view: u64) -> bool {
+    pub fn are_we_leader_for_view(&mut self, parent_hash: Hash, view: u64) -> bool {
         match self.leader_for_view(parent_hash, view) {
             Some(leader) => leader == self.public_key(),
             None => false,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1666,7 +1666,7 @@ impl Consensus {
         Ok(Some(pending_block))
     }
 
-    pub fn are_we_leader_for_view(&mut self, parent_hash: Hash, view: u64) -> bool {
+    fn are_we_leader_for_view(&mut self, parent_hash: Hash, view: u64) -> bool {
         match self.leader_for_view(parent_hash, view) {
             Some(leader) => leader == self.public_key(),
             None => false,

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -388,12 +388,15 @@ pub enum InternalMessage {
         TrieStorage,
         Box<Path>,
     ),
+    /// Restart the node
+    RestartShard(u64),
 }
 
 /// Returns a terse, human-readable summary of a message.
 impl Display for InternalMessage {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
+            InternalMessage::RestartShard(id) => write!(f, "RestartShard({id})"),
             InternalMessage::LaunchShard(id) => write!(f, "LaunchShard({id})"),
             InternalMessage::LaunchLink(dest) => write!(f, "LaunchLink({dest})"),
             InternalMessage::IntershardCall(_) => write!(f, "IntershardCall"),

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -957,8 +957,8 @@ impl Node {
             return Ok(());
         }
         trace!("Handling proposal for view {0}", req.block.header.view);
+        self.consensus.sync.mark_received_proposal()?; // decrement first, to avoid getting stuck at Retry1
         let proposal = self.consensus.receive_block(from, req.block)?;
-        self.consensus.sync.mark_received_proposal()?;
         if let Some(proposal) = proposal {
             trace!(
                 " ... broadcasting proposal for view {0}",

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -946,10 +946,7 @@ impl Node {
             } else {
                 self.message_sender.broadcast_proposal(message)?;
             }
-        } else if !self
-            .consensus
-            .are_we_leader_for_view(proposal.hash(), proposal.view() + 1)
-        {
+        } else {
             self.consensus.sync.sync_from_proposal(proposal)?;
         }
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -945,7 +945,7 @@ impl Node {
                 self.message_sender.broadcast_proposal(message)?;
             }
         } else {
-            self.consensus.sync.sync_from_proposal(proposal)?; // proposal is already verified
+            self.consensus.sync.sync_from_proposal(proposal)?;
         }
 
         Ok(())

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -388,7 +388,9 @@ impl Node {
                 self.message_sender
                     .send_message_to_coordinator(InternalMessage::LaunchShard(source))?;
             }
-            InternalMessage::LaunchShard(..) | InternalMessage::ExportBlockCheckpoint(..) => {
+            InternalMessage::LaunchShard(..)
+            | InternalMessage::ExportBlockCheckpoint(..)
+            | InternalMessage::RestartShard(..) => {
                 warn!(
                     "{message} type messages should be handled by the coordinator, not forwarded to a node.",
                 );
@@ -944,7 +946,10 @@ impl Node {
             } else {
                 self.message_sender.broadcast_proposal(message)?;
             }
-        } else {
+        } else if !self
+            .consensus
+            .are_we_leader_for_view(proposal.hash(), proposal.view() + 1)
+        {
             self.consensus.sync.sync_from_proposal(proposal)?;
         }
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -959,7 +959,10 @@ impl Node {
             return Ok(());
         }
         trace!("Handling proposal for view {0}", req.block.header.view);
-        self.consensus.sync.mark_received_proposal()?; // decrement first, to avoid getting stuck at Retry1
+        // decrement first, to avoid getting stuck at Retry1
+        self.consensus
+            .sync
+            .mark_received_proposal(req.block.number())?;
         let proposal = self.consensus.receive_block(from, req.block)?;
         if let Some(proposal) = proposal {
             trace!(

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -370,7 +370,7 @@ impl P2pNode {
                                 .cloned()
                                 .unwrap_or_else(
                                     || Self::generate_child_config(self.config.nodes.first().unwrap(), shard_id));
-                            self.add_shard_node(shard_config.clone()).await?;
+                            self.add_shard_node(shard_config).await?;
                         },
                     }
                 },

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -191,7 +191,8 @@ impl P2pNode {
     }
 
     pub async fn add_shard_node(&mut self, config: NodeConfig) -> Result<()> {
-        let topic = Self::shard_id_to_topic(config.eth_chain_id);
+        let shard_id = config.eth_chain_id;
+        let topic = Self::shard_id_to_topic(shard_id);
         if self.shard_nodes.contains_key(&topic.hash()) {
             info!("LaunchShard message received for a shard we're already running. Ignoring...");
             return Ok(());
@@ -357,6 +358,20 @@ impl P2pNode {
                         InternalMessage::ExportBlockCheckpoint(block, transactions, parent, trie_storage, path) => {
                             self.task_threads.spawn(async move { db::checkpoint_block_with_state(&block, &transactions, &parent, trie_storage, source, path) });
                         }
+                        InternalMessage::RestartShard(shard_id) => {
+                            // remove existing node
+                            let topic = Self::shard_id_to_topic(shard_id);
+                            self.shard_nodes.remove(&topic.hash());
+                            self.shard_peers.remove(&topic.hash());
+                            // restart node
+                            let shard_config = self.config.nodes
+                                .iter()
+                                .find(|shard_config| shard_config.eth_chain_id == shard_id)
+                                .cloned()
+                                .unwrap_or_else(
+                                    || Self::generate_child_config(self.config.nodes.first().unwrap(), shard_id));
+                            self.add_shard_node(shard_config.clone()).await?;
+                        },
                     }
                 },
                 message = self.request_responses_receiver.next() => {

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -434,7 +434,8 @@ impl Sync {
         if self.inject_proposals(proposals)? {
             self.db.pop_sync_segment()?;
         } else {
-            self.state = SyncState::Retry1;
+            // sync is stuck, cancel sync and restart, should be fast for peers that are already near the tip.
+            self.state = SyncState::Phase3;
             return Ok(());
         };
 

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -970,8 +970,8 @@ impl Sync {
                     .first()
                     .unwrap()
                     .number()
-                    .saturating_sub(highest_number)
-                    .gt(&(self.max_blocks_in_flight as u64))
+                    .saturating_sub(self.max_blocks_in_flight as u64)
+                    .gt(&highest_number)
             {
                 tracing::warn!("sync::InjectProposals : node is stuck");
                 return Ok(false);

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -307,23 +307,6 @@ impl Sync {
                     .expect("no highest canonical block"),
             )?
             .expect("missing canonical block");
-
-        if let Some(finalized_view) = self.db.get_finalized_view()? {
-            // Cleanup tip of chain - https://github.com/Zilliqa/zq2/issues/2354
-            while let Some(head_block) = self.db.get_highest_recorded_block()? {
-                if head_block.view() <= highest_block.view()
-                    || head_block.view() <= finalized_view
-                    || head_block.parent_hash() == Hash::ZERO
-                {
-                    break;
-                }
-                tracing::warn!("sync::StartAt : revert block {}", head_block.number());
-                self.db
-                    .remove_transactions_executed_in_block(&head_block.hash())?;
-                self.db.remove_block(&head_block)?;
-            }
-        }
-
         self.started_at = highest_block.number();
         Ok(())
     }

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -381,9 +381,8 @@ impl Sync {
                 let SyncState::Phase2((_, range)) = &self.state else {
                     unimplemented!("sync:MultiBlockResponse");
                 };
-                tracing::info!(
-                    "sync::MultiBlockResponse : received [{:?}] blocks from {from}",
-                    range,
+                tracing::info!(?range, %from,
+                    "sync::MultiBlockResponse : received",
                 );
                 self.blocks_downloaded = self.blocks_downloaded.saturating_add(response.len());
                 self.peers
@@ -525,10 +524,8 @@ impl Sync {
                 };
 
                 // Fire request, to the original peer that sent the segment metadata
-                tracing::info!(
-                    "sync::MissingBlocks : requesting [{:?}] from {}",
-                    range,
-                    peer_info.peer_id,
+                tracing::info!(?range, from = %peer_info.peer_id,
+                    "sync::MissingBlocks : requesting",
                 );
                 self.state = SyncState::Phase2((checksum, range));
 
@@ -621,10 +618,8 @@ impl Sync {
                             start: response.last().unwrap().header.number,
                             end: response.first().unwrap().header.number,
                         };
-                        tracing::info!(
-                            "sync::MetadataResponse : received [{:?}] from {}",
-                            range,
-                            peer_id
+                        tracing::info!(?range, from = %peer_id,
+                            "sync::MetadataResponse : received",
                         );
                         self.headers_downloaded =
                             self.headers_downloaded.saturating_add(response.len());
@@ -767,8 +762,8 @@ impl Sync {
             start: request.from_height,
             end: request.to_height,
         };
-        tracing::debug!(
-            "sync::MetadataRequest : received metadata [{range:?}] request from {from}",
+        tracing::debug!(?range, %from,
+            "sync::MetadataRequest : received",
         );
 
         // Do not respond to stale requests as the client has probably timed-out
@@ -910,10 +905,8 @@ impl Sync {
                     _ => unimplemented!("sync::DoMissingMetadata"),
                 };
 
-                tracing::info!(
-                    "sync::MissingMetadata : requesting [{:?}] from {} ({num}/{num_peers})",
-                    range,
-                    peer_info.peer_id
+                tracing::info!(?range, from = %peer_info.peer_id,
+                    "sync::MissingMetadata : requesting ({num}/{num_peers})",
                 );
                 offset += self.max_batch_size as u64;
 
@@ -998,7 +991,8 @@ impl Sync {
     /// Mark a received proposal
     ///
     /// Mark a proposal as received, and remove it from the chain.
-    pub fn mark_received_proposal(&mut self) -> Result<()> {
+    pub fn mark_received_proposal(&mut self, number: u64) -> Result<()> {
+        tracing::trace!(%number, "sync::MarkReceivedProposal : received");
         self.in_pipeline = self.in_pipeline.saturating_sub(1);
         Ok(())
     }

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -201,8 +201,6 @@ impl Sync {
                 }
                 _ => {}
             }
-        } else {
-            tracing::warn!("sync::RequestFailure : spurious {from}");
         }
         Ok(())
     }

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -963,7 +963,7 @@ impl Sync {
                     .saturating_sub(self.in_pipeline as u64)
                     .gt(&highest_number)
             {
-                tracing::warn!("sync::InjectProposals : node is stuck");
+                tracing::warn!("sync::InjectProposals : node is stuck at {prev_highest}");
                 return Ok(false);
             }
         }

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -12,7 +12,10 @@ use libp2p::PeerId;
 use rusqlite::types::{FromSql, FromSqlResult, ToSql, ToSqlOutput, ValueRef};
 
 use crate::{
-    api::types::eth::{SyncingMeta, SyncingStruct},
+    api::{
+        to_hex::ToHex,
+        types::eth::{SyncingMeta, SyncingStruct},
+    },
     cfg::NodeConfig,
     crypto::Hash,
     db::Db,
@@ -1039,18 +1042,18 @@ impl Sync {
         let peer_count = self.peers.count() + self.in_flight.len();
 
         Ok(Some(SyncingStruct {
-            starting_block: self.started_at,
-            current_block,
-            highest_block: self.highest_block_seen,
+            starting_block: self.started_at.to_hex(),
+            current_block: current_block.to_hex(),
+            highest_block: self.highest_block_seen.to_hex(),
             status: SyncingMeta {
-                peer_count,
+                peer_count: peer_count.to_hex(),
                 current_phase: self.state.to_string(),
-                retry_count: self.retry_count,
-                timeout_count: self.timeout_count,
-                empty_count: self.empty_count,
-                header_downloads: self.headers_downloaded,
-                block_downloads: self.blocks_downloaded,
-                buffered_blocks: self.in_pipeline,
+                retry_count: self.retry_count.to_hex(),
+                timeout_count: self.timeout_count.to_hex(),
+                empty_count: self.empty_count.to_hex(),
+                header_downloads: self.headers_downloaded.to_hex(),
+                block_downloads: self.blocks_downloaded.to_hex(),
+                buffered_blocks: self.in_pipeline.to_hex(),
             },
         }))
     }

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -877,6 +877,7 @@ impl Network {
             AnyMessage::Internal(source_shard, destination_shard, ref internal_message) => {
                 trace!("Handling internal message from node in shard {source_shard}, targetting {destination_shard}");
                 match internal_message {
+                    InternalMessage::RestartShard(_) => todo!(),
                     InternalMessage::LaunchShard(new_network_id) => {
                         let secret_key = self.find_node(source).unwrap().1.secret_key;
                         if let Some(child_network) = self.children.get_mut(new_network_id) {


### PR DESCRIPTION
It is difficult to replicate the issue of a node getting stuck. However there are a couple of observations that:
1. that block is at a fork;
2. the stuck node is the Leader of that block;
3. restarting a stuck node gets past the issue; and
4. given enough time, the stuck node runs phase 2 all the way up to present, then restarts syncing; also gets past the issue.

So, this PR does some things to mitigate the issue.
1. It does not allow a syncing node to broadcast any Proposals i.e. when a Leader falls out of sync, it only syncs. I have a hunch that early proposals might be involved but I cannot prove it.
2. It restarts the Node when stuck syncing - effectively destroys/re-constructs its thread. Since this is only employed during a stuck sync, it is less drastic as the node is already stuck. It determines whether it is stuck at syncing by checking that phase 2 injections have not made progress for > 1000 blocks. It doesn't get triggered if the node is stuck for some other reason e.g. a long timeout.

This PR does some other minor things:
1. Return hex-encoded blocks/numbers in the RPC responses.
2. Not confusing start_at with checkpoint_at.
4. Minor cleanup.