### PR TITLE
feat: set withdrawalPeriod at initialise of deposit_v5 and add deposit contract tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ perf.*
 # Provisioning files
 provision_*.py
 config.toml
+
+# Solidity Compiler files
+cache/
+out/

--- a/.solhint.json
+++ b/.solhint.json
@@ -5,6 +5,7 @@
     "avoid-low-level-calls": "off",
     "reason-string": ["warn",{"maxLength":70}],
     "func-visibility": ["warn", { "ignoreConstructors": true }],
-    "gas-custom-errors": "off" 
+    "gas-custom-errors": "off",
+    "one-contract-per-file": "off" 
   }
 }

--- a/infra/config_docker.toml
+++ b/infra/config_docker.toml
@@ -95,4 +95,4 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 # Gas parameters
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
-consensus.contract_upgrade_block_heights = { deposit_v4 = 0 }
+consensus.contract_upgrade_block_heights = { deposit_v5 = 0 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,0 +1,3 @@
+@openzeppelin/contracts/=vendor/openzeppelin-contracts/contracts/
+@openzeppelin/lib/=vendor/openzeppelin-contracts/lib/
+@openzeppelin/contracts-upgradeable/=vendor/openzeppelin-contracts-upgradeable/contracts/

--- a/z2/resources/chain-specs/zq2-devnet.toml
+++ b/z2/resources/chain-specs/zq2-devnet.toml
@@ -11,6 +11,7 @@ allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
 consensus.genesis_accounts = [ ["0xe422f041d1c2c9c2624ebb46ea312af342b444c0", "900_000_000_000_000_000_000_000_000" ] ]
 consensus.genesis_deposits = [ ["9989b9c2217fea9f3c837debc853faeb05651894f3c1747df1a735091b52cd9f3e0a7ee62a72f1fe1530e50f3fa91467", "12D3KooWFvZum3gpEQkj6o9Tg71uLuQZJ4hqXL32c8wPTcpkRnaP", "20_000_000_000_000_000_000_000_000", "0x0000000000000000000000000000000000000000", "0xe422f041d1c2c9c2624ebb46ea312af342b444c0"] ]
+consensus.staker_withdrawal_period = 300
 
 # Reward parameters
 consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"

--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -8,6 +8,9 @@ allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
 consensus.genesis_accounts = [ ["{{ genesis_address }}", "900_000_000_000_000_000_000_000_000" ] ]
 consensus.genesis_deposits = [ ["{{ bootstrap_bls_public_key }}", "{{ bootstrap_peer_id }}", "20_000_000_000_000_000_000_000_000", "0x0000000000000000000000000000000000000000", "{{ genesis_address }}"] ]
+{%- if staker_withdrawal_period %}
+consensus.staker_withdrawal_period = {{ staker_withdrawal_period }}
+{%- endif %}
 
 # Reward parameters
 consensus.rewards_per_hour = "51_000_000_000_000_000_000_000"

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -170,7 +170,8 @@ impl Chain {
                 deposit_v3: Some(3600),
                 // estimated: 2025-01-28T20:25:00Z
                 deposit_v4: Some(428400),
-                deposit_v5: None,
+                // estimated: 2025-02-21T18:56:00Z
+                deposit_v5: Some(1731600),
             },
             Self::Zq2ProtoMainnet => ContractUpgradesBlockHeights {
                 // estimated: 2024-12-20T23:33:12Z
@@ -259,7 +260,7 @@ impl Chain {
 
         Ok(log_level.unwrap_or("zilliqa=trace"))
     }
-    
+
     pub fn get_staker_withdrawal_period(&self) -> Option<u64> {
         match self {
             Chain::Zq2Devnet => Some(5 * 60), // 5 minutes

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -259,4 +259,11 @@ impl Chain {
 
         Ok(log_level.unwrap_or("zilliqa=trace"))
     }
+    
+    pub fn get_staker_withdrawal_period(&self) -> Option<u64> {
+        match self {
+            Chain::Zq2Devnet => Some(5 * 60), // 5 minutes
+            _ => None,
+        }
+    }
 }

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -170,17 +170,20 @@ impl Chain {
                 deposit_v3: Some(3600),
                 // estimated: 2025-01-28T20:25:00Z
                 deposit_v4: Some(428400),
+                deposit_v5: None,
             },
             Self::Zq2ProtoMainnet => ContractUpgradesBlockHeights {
                 // estimated: 2024-12-20T23:33:12Z
                 deposit_v3: Some(5342400),
                 // estimated: 2025-02-12T13:25:00Z
                 deposit_v4: Some(7966800),
+                deposit_v5: None,
             },
             Self::Zq2ProtoTestnet => ContractUpgradesBlockHeights {
                 deposit_v3: Some(8406000),
                 // estimated: 2025-02-03T13:55:00Z
                 deposit_v4: Some(10890000),
+                deposit_v5: None,
             },
             _ => ContractUpgradesBlockHeights::default(),
         }

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -888,6 +888,10 @@ impl ChainNode {
                     .collect::<Result<Vec<_>>>()?,
             );
         }
+        ctx.insert(
+            "staker_withdrawal_period",
+            &self.chain()?.get_staker_withdrawal_period(),
+        );
 
         if let Some(checkpoint_url) = self.chain.checkpoint_url() {
             if self.role == NodeRole::Validator {

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -19,7 +19,8 @@ use tokio::fs;
 use zilliqa::{
     api,
     cfg::{
-        genesis_fork_default, max_rpc_response_size_default, state_cache_size_default, ApiServer,
+        genesis_fork_default, max_rpc_response_size_default, staker_withdrawal_period_default,
+        state_cache_size_default, ApiServer,
     },
     crypto::{SecretKey, TransactionPublicKey},
 };
@@ -525,6 +526,7 @@ impl Setup {
                     main_shard_id: None,
                     local_address: local_address_default(),
                     consensus_timeout: consensus_timeout_default(),
+                    staker_withdrawal_period: staker_withdrawal_period_default(),
                     genesis_deposits: Vec::new(),
                     eth_block_gas_limit: EvmGas(84000000),
                     gas_price: 4_761_904_800_000u128.into(),

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -348,6 +348,10 @@ pub struct ConsensusConfig {
     /// The maximum time to wait for consensus to proceed as normal, before proposing a new view.
     #[serde(default = "consensus_timeout_default")]
     pub consensus_timeout: Duration,
+    /// The minimum number of blocks a staker must wait before being able to withdraw unstaked funds
+    /// Note that this is the withdrawal period that the deposit_v5 contract is initialised with. Previous versions of the deposit contract will not use this value.
+    #[serde(default = "staker_withdrawal_period_default")]
+    pub staker_withdrawal_period: u64,
     /// The initially staked deposits in the deposit contract at genesis, composed of
     /// (public key, peerId, amount, reward address) tuples.
     #[serde(default)]
@@ -444,6 +448,7 @@ impl Default for ConsensusConfig {
             is_main: default_true(),
             main_shard_id: None,
             consensus_timeout: consensus_timeout_default(),
+            staker_withdrawal_period: staker_withdrawal_period_default(),
             genesis_deposits: vec![],
             genesis_accounts: vec![],
             block_time: block_time_default(),
@@ -600,6 +605,11 @@ pub fn total_native_token_supply_default() -> Amount {
     Amount::from(21_000_000_000_000_000_000_000_000_000)
 }
 
+pub fn staker_withdrawal_period_default() -> u64 {
+    // 2 weeks worth of blocks with 1 second block time
+    2 * 7 * 24 * 60 * 60
+}
+
 /// The default implementation returns a single fork at the genesis block, with the most up-to-date
 /// execution logic.
 pub fn genesis_fork_default() -> Fork {
@@ -617,9 +627,21 @@ pub fn genesis_fork_default() -> Fork {
 pub struct ContractUpgradesBlockHeights {
     pub deposit_v3: Option<u64>,
     pub deposit_v4: Option<u64>,
+    pub deposit_v5: Option<u64>,
 }
 
 impl ContractUpgradesBlockHeights {
+    pub fn new(
+        deposit_v3: Option<u64>,
+        deposit_v4: Option<u64>,
+        deposit_v5: Option<u64>,
+    ) -> ContractUpgradesBlockHeights {
+        Self {
+            deposit_v3,
+            deposit_v4,
+            deposit_v5,
+        }
+    }
     // toml doesn't like Option types. Map items in struct and remove keys for None values
     pub fn to_toml(&self) -> toml::Value {
         toml::Value::Table(
@@ -644,7 +666,8 @@ impl Default for ContractUpgradesBlockHeights {
     fn default() -> Self {
         Self {
             deposit_v3: None,
-            deposit_v4: Some(0),
+            deposit_v4: None,
+            deposit_v5: Some(0),
         }
     }
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1198,10 +1198,7 @@ impl Consensus {
 
         if self.block_is_first_in_epoch(proposal.header.number) {
             // Update state with any contract upgrades for this block
-            state.contract_upgrade_apply_state_change(
-                &self.config.consensus.contract_upgrade_block_heights,
-                proposal.header,
-            )?;
+            state.contract_upgrade_apply_state_change(&self.config.consensus, proposal.header)?;
         }
 
         // Finalise the proposal with final QC and state.
@@ -3003,10 +3000,8 @@ impl Consensus {
         if self.block_is_first_in_epoch(block.header.number) {
             // Update state with any contract upgrades for this block
             let mut state_clone = self.state.clone();
-            state_clone.contract_upgrade_apply_state_change(
-                &self.config.consensus.contract_upgrade_block_heights,
-                block.header,
-            )?;
+            state_clone
+                .contract_upgrade_apply_state_change(&self.config.consensus, block.header)?;
             self.state = state_clone;
         }
 

--- a/zilliqa/src/contracts/README.md
+++ b/zilliqa/src/contracts/README.md
@@ -13,3 +13,9 @@ Then compile with `solc`:
 ```sh
 ZQ_CONTRACT_TEST_BLESS=1 cargo test --features test_contract_bytecode -- contracts::tests::compile_all
 ```
+
+## Run Solidity tests
+
+```sh
+    forge test -C zilliqa/src/contracts/tests
+```

--- a/zilliqa/src/contracts/deposit_v5.sol
+++ b/zilliqa/src/contracts/deposit_v5.sol
@@ -375,6 +375,10 @@ contract Deposit is UUPSUpgradeable {
         bytes calldata blsPubKey,
         address signingAddress
     ) public onlyControlAddress(blsPubKey) {
+        require(
+            signingAddress != address(0),
+            "signingAddress cannot be set to zero address"
+        );
         DepositStorage storage $ = _getDepositStorage();
         $._stakersMap[blsPubKey].signingAddress = signingAddress;
         emit StakerUpdated(blsPubKey);

--- a/zilliqa/src/contracts/deposit_v5.sol
+++ b/zilliqa/src/contracts/deposit_v5.sol
@@ -153,7 +153,9 @@ contract Deposit is UUPSUpgradeable {
 
     // explicitly set version number in contract code
     // solhint-disable-next-line no-empty-blocks
-    function reinitialize(uint256 _withdrawalPeriod) public reinitializer(VERSION) {
+    function reinitialize(
+        uint256 _withdrawalPeriod
+    ) public reinitializer(VERSION) {
         DepositStorage storage $ = _getDepositStorage();
         $.withdrawalPeriod = _withdrawalPeriod;
     }
@@ -677,7 +679,6 @@ contract Deposit is UUPSUpgradeable {
     function withdrawalPeriod() public view returns (uint256) {
         DepositStorage storage $ = _getDepositStorage();
         return $.withdrawalPeriod;
-
     }
 
     function _withdraw(

--- a/zilliqa/src/contracts/deposit_v5.sol
+++ b/zilliqa/src/contracts/deposit_v5.sol
@@ -1,0 +1,714 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity 0.8.28;
+
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {Deque, Withdrawal} from "./utils/deque.sol";
+
+using Deque for Deque.Withdrawals;
+
+/// Argument has unexpected length
+/// @param argument name of argument
+/// @param required expected length
+error UnexpectedArgumentLength(string argument, uint256 required);
+
+/// Message sender does not control the key it is attempting to modify
+error Unauthorised();
+/// Maximum number of stakers has been reached
+error TooManyStakers();
+/// Key already staked
+error KeyAlreadyStaked();
+/// Key is not staked
+error KeyNotStaked();
+/// Stake amount less than minimum
+error StakeAmountTooLow();
+
+/// Proof of possession verification failed
+error RogueKeyCheckFailed();
+
+struct CommitteeStakerEntry {
+    // The index of the value in the `stakers` array plus 1.
+    // Index 0 is used to mean a value is not present.
+    uint256 index;
+    // Invariant: `balance >= minimumStake`
+    uint256 balance;
+}
+
+struct Committee {
+    // Invariant: Equal to the sum of `balances` in `stakers`.
+    uint256 totalStake;
+    bytes[] stakerKeys;
+    mapping(bytes => CommitteeStakerEntry) stakers;
+}
+
+struct Staker {
+    // The address used for authenticating requests from this staker to the deposit contract.
+    // Invariant: `controlAddress != address(0)`.
+    address controlAddress;
+    // The address which rewards for this staker will be sent to.
+    address rewardAddress;
+    // libp2p peer ID, corresponding to the staker's `blsPubKey`
+    bytes peerId;
+    // Invariants: Items are always sorted by `startedAt`. No two items have the same value of `startedAt`.
+    Deque.Withdrawals withdrawals;
+    // The address whose key with which validators sign cross-chain events
+    address signingAddress;
+}
+
+contract Deposit is UUPSUpgradeable {
+    // Emitted to inform that a new staker identified by `blsPubKey`
+    // is going to be added to the committee `atFutureBlock`, increasing
+    // the total stake by `newStake`
+    event StakerAdded(bytes blsPubKey, uint256 atFutureBlock, uint256 newStake);
+
+    // Emitted to inform that the staker identified by `blsPubKey`
+    // is going to be removed from the committee `atFutureBlock`
+    event StakerRemoved(bytes blsPubKey, uint256 atFutureBlock);
+
+    // Emitted to inform that the deposited stake of the staker
+    // identified by `blsPubKey` is going to change to `newStake`
+    // at `atFutureBlock`
+    event StakeChanged(
+        bytes blsPubKey,
+        uint256 atFutureBlock,
+        uint256 newStake
+    );
+
+    // Emitted to inform that the staker identified by `blsPubKey`
+    // has updated its data that can be refetched using `getStakerData()`
+    event StakerUpdated(bytes blsPubKey);
+
+    // Emitted to inform that a stakers position in the list of stakers (committee.stakerKeys) has changed
+    event StakerMoved(
+        bytes blsPubKey,
+        uint256 newPosition,
+        uint256 atFutureBlock
+    );
+
+    uint64 public constant VERSION = 5;
+
+    /// @custom:storage-location erc7201:zilliqa.storage.DepositStorage
+    struct DepositStorage {
+        // The committee in the current epoch and the 2 epochs following it. The value for the current epoch
+        // is stored at index (currentEpoch() % 3).
+        Committee[3] _committee;
+        // All stakers. Keys into this map are stored by the `Committee`.
+        mapping(bytes => Staker) _stakersMap;
+        // Mapping from `controlAddress` to `blsPubKey` for each staker.
+        // This is legacy do not use. In upgraded contracts there may be some items still in the mapping.
+        mapping(address => bytes) _stakerKeys;
+        // The latest epoch for which the committee was calculated. It is implied that no changes have (yet) occurred in
+        // future epochs, either because those epochs haven't happened yet or because they have happened, but no deposits
+        // or withdrawals were made.
+        uint64 latestComputedEpoch;
+        uint256 minimumStake;
+        uint256 maximumStakers;
+        uint64 blocksPerEpoch;
+        // Unbonding period for withdrawals measured in number of blocks (note that we have 1 second block times)
+        uint256 withdrawalPeriod;
+    }
+
+    modifier onlyControlAddress(bytes calldata blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        if ($._stakersMap[blsPubKey].controlAddress != msg.sender) {
+            revert Unauthorised();
+        }
+        _;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("zilliqa.storage.DepositStorage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant DEPOSIT_STORAGE_LOCATION =
+        0x958a6cf6390bd7165e3519675caa670ab90f0161508a9ee714d3db7edc507400;
+
+    function _getDepositStorage()
+        private
+        pure
+        returns (DepositStorage storage $)
+    {
+        assembly {
+            $.slot := DEPOSIT_STORAGE_LOCATION
+        }
+    }
+
+    function version() public view returns (uint64) {
+        return _getInitializedVersion();
+    }
+
+    function _authorizeUpgrade(
+        // solhint-disable-next-line no-unused-vars
+        address newImplementation
+    ) internal virtual override {
+        require(
+            msg.sender == address(0),
+            "system contract must be upgraded by the system"
+        );
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    // explicitly set version number in contract code
+    // solhint-disable-next-line no-empty-blocks
+    function reinitialize(uint256 withdrawalPeriod) public reinitializer(VERSION) {
+        DepositStorage storage $ = _getDepositStorage();
+        $.withdrawalPeriod = withdrawalPeriod;
+    }
+
+    function currentEpoch() public view returns (uint64) {
+        DepositStorage storage $ = _getDepositStorage();
+        return uint64(block.number / $.blocksPerEpoch);
+    }
+
+    function committee() private view returns (Committee storage) {
+        DepositStorage storage $ = _getDepositStorage();
+        if ($.latestComputedEpoch <= currentEpoch()) {
+            // If the current epoch is after the latest computed epoch, it is implied that no changes have happened to
+            // the committee since the latest computed epoch. Therefore, it suffices to return the committee at that
+            // latest computed epoch.
+            return $._committee[$.latestComputedEpoch % 3];
+        } else {
+            // Otherwise, the committee has been changed. The caller who made the change will have pre-computed the
+            // result for us, so we can just return it.
+            return $._committee[currentEpoch() % 3];
+        }
+    }
+
+    function minimumStake() public view returns (uint256) {
+        DepositStorage storage $ = _getDepositStorage();
+        return $.minimumStake;
+    }
+
+    function maximumStakers() public view returns (uint256) {
+        DepositStorage storage $ = _getDepositStorage();
+        return $.maximumStakers;
+    }
+
+    function blocksPerEpoch() public view returns (uint64) {
+        DepositStorage storage $ = _getDepositStorage();
+        return $.blocksPerEpoch;
+    }
+
+    function leaderFromRandomness(
+        uint256 randomness
+    ) private view returns (bytes memory) {
+        Committee storage currentCommittee = committee();
+        // Get a random number in the inclusive range of 0 to (totalStake - 1)
+        uint256 position = randomness % currentCommittee.totalStake;
+        uint256 cummulativeStake = 0;
+
+        for (uint256 i = 0; i < currentCommittee.stakerKeys.length; i++) {
+            bytes memory stakerKey = currentCommittee.stakerKeys[i];
+            uint256 stakedBalance = currentCommittee.stakers[stakerKey].balance;
+
+            cummulativeStake += stakedBalance;
+
+            if (position < cummulativeStake) {
+                return stakerKey;
+            }
+        }
+
+        revert("Unable to select next leader");
+    }
+
+    function leaderAtView(
+        uint256 viewNumber
+    ) public view returns (bytes memory) {
+        uint256 randomness = uint256(
+            keccak256(bytes.concat(bytes32(viewNumber)))
+        );
+        return leaderFromRandomness(randomness);
+    }
+
+    function getStakers() public view returns (bytes[] memory) {
+        return committee().stakerKeys;
+    }
+
+    function getTotalStake() public view returns (uint256) {
+        return committee().totalStake;
+    }
+
+    function getFutureTotalStake() public view returns (uint256) {
+        DepositStorage storage $ = _getDepositStorage();
+        // if `latestComputedEpoch > currentEpoch()`
+        // then `latestComputedEpoch` determines the future committee we need
+        // otherwise there are no committee changes after `currentEpoch()`
+        // i.e. `latestComputedEpoch` determines the most recent committee
+        return $._committee[$.latestComputedEpoch % 3].totalStake;
+    }
+
+    function getStakersData()
+        public
+        view
+        returns (
+            bytes[] memory stakerKeys,
+            uint256[] memory indices,
+            uint256[] memory balances,
+            Staker[] memory stakers
+        )
+    {
+        DepositStorage storage $ = _getDepositStorage();
+        Committee storage currentCommittee = committee();
+
+        stakerKeys = currentCommittee.stakerKeys;
+        indices = new uint256[](stakerKeys.length);
+        balances = new uint256[](stakerKeys.length);
+        stakers = new Staker[](stakerKeys.length);
+        for (uint256 i = 0; i < stakerKeys.length; i++) {
+            bytes memory key = stakerKeys[i];
+            // The stakerKeys are not sorted by the stakers'
+            // index in the current committee, therefore we
+            // return the indices too, to help identify the
+            // stakers in the bit vectors stored along with
+            // BLS aggregate signatures
+            indices[i] = currentCommittee.stakers[key].index;
+            balances[i] = currentCommittee.stakers[key].balance;
+            stakers[i] = $._stakersMap[key];
+        }
+    }
+
+    function getStakerData(
+        bytes calldata blsPubKey
+    )
+        public
+        view
+        returns (uint256 index, uint256 balance, Staker memory staker)
+    {
+        DepositStorage storage $ = _getDepositStorage();
+        Committee storage currentCommittee = committee();
+        index = currentCommittee.stakers[blsPubKey].index;
+        balance = currentCommittee.stakers[blsPubKey].balance;
+        staker = $._stakersMap[blsPubKey];
+    }
+
+    function getStake(bytes calldata blsPubKey) public view returns (uint256) {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+
+        // We don't need to check if `blsPubKey` is in `stakerKeys` here. If the `blsPubKey` is not a staker, the
+        // balance will default to zero.
+        return committee().stakers[blsPubKey].balance;
+    }
+
+    function getFutureStake(
+        bytes calldata blsPubKey
+    ) public view returns (uint256) {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+
+        // if `latestComputedEpoch > currentEpoch()`
+        // then `latestComputedEpoch` determines the future committee we need
+        // otherwise there are no committee changes after `currentEpoch()`
+        // i.e. `latestComputedEpoch` determines the most recent committee
+        Committee storage latestCommittee = $._committee[
+            $.latestComputedEpoch % 3
+        ];
+
+        // We don't need to check if `blsPubKey` is in `stakerKeys` here. If the `blsPubKey` is not a staker, the
+        // balance will default to zero.
+        return latestCommittee.stakers[blsPubKey].balance;
+    }
+
+    function getRewardAddress(
+        bytes calldata blsPubKey
+    ) public view returns (address) {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+        if ($._stakersMap[blsPubKey].controlAddress == address(0)) {
+            revert KeyNotStaked();
+        }
+        return $._stakersMap[blsPubKey].rewardAddress;
+    }
+
+    function getSigningAddress(
+        bytes calldata blsPubKey
+    ) public view returns (address) {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+        if ($._stakersMap[blsPubKey].controlAddress == address(0)) {
+            revert KeyNotStaked();
+        }
+        address signingAddress = $._stakersMap[blsPubKey].signingAddress;
+        // If the staker was an InitialStaker on contract initialisation and have not called setSigningAddress() then there will be no signingAddress.
+        // Default to controlAddress to avoid revert
+        if (signingAddress == address(0)) {
+            signingAddress = $._stakersMap[blsPubKey].controlAddress;
+        }
+        return signingAddress;
+    }
+
+    function getControlAddress(
+        bytes calldata blsPubKey
+    ) public view returns (address) {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+        if ($._stakersMap[blsPubKey].controlAddress == address(0)) {
+            revert KeyNotStaked();
+        }
+        return $._stakersMap[blsPubKey].controlAddress;
+    }
+
+    function setRewardAddress(
+        bytes calldata blsPubKey,
+        address rewardAddress
+    ) public onlyControlAddress(blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+        $._stakersMap[blsPubKey].rewardAddress = rewardAddress;
+        emit StakerUpdated(blsPubKey);
+    }
+
+    function setSigningAddress(
+        bytes calldata blsPubKey,
+        address signingAddress
+    ) public onlyControlAddress(blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+        $._stakersMap[blsPubKey].signingAddress = signingAddress;
+        emit StakerUpdated(blsPubKey);
+    }
+
+    function setControlAddress(
+        bytes calldata blsPubKey,
+        address controlAddress
+    ) public onlyControlAddress(blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+        $._stakersMap[blsPubKey].controlAddress = controlAddress;
+        emit StakerUpdated(blsPubKey);
+    }
+
+    function getPeerId(
+        bytes calldata blsPubKey
+    ) public view returns (bytes memory) {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+        if ($._stakersMap[blsPubKey].controlAddress == address(0)) {
+            revert KeyNotStaked();
+        }
+        return $._stakersMap[blsPubKey].peerId;
+    }
+
+    function updateLatestComputedEpoch() internal {
+        DepositStorage storage $ = _getDepositStorage();
+        // If the latest computed epoch is less than two epochs ahead of the current one, we must fill in the missing
+        // epochs. This just involves copying the committee from the previous epoch to the next one. It is assumed that
+        // the caller will then want to update the future epochs.
+        if ($.latestComputedEpoch < currentEpoch() + 2) {
+            Committee storage latestComputedCommittee = $._committee[
+                $.latestComputedEpoch % 3
+            ];
+            // Note the early exit condition if `latestComputedEpoch + 3` which ensures this loop will not run more
+            // than twice. This is acceptable because we only store 3 committees at a time, so once we have updated two
+            // of them to the latest computed committee, there is no more work to do.
+            for (
+                uint64 i = $.latestComputedEpoch + 1;
+                i <= currentEpoch() + 2 && i < $.latestComputedEpoch + 3;
+                i++
+            ) {
+                // The operation we want to do is: `_committee[i % 3] = latestComputedCommittee` but we need to do it
+                // explicitly because `stakers` is a mapping.
+
+                // Delete old keys from `_committee[i % 3].stakers`.
+                for (
+                    uint256 j = 0;
+                    j < $._committee[i % 3].stakerKeys.length;
+                    j++
+                ) {
+                    delete $._committee[i % 3].stakers[
+                        $._committee[i % 3].stakerKeys[j]
+                    ];
+                }
+
+                $._committee[i % 3].totalStake = latestComputedCommittee
+                    .totalStake;
+                $._committee[i % 3].stakerKeys = latestComputedCommittee
+                    .stakerKeys;
+                for (
+                    uint256 j = 0;
+                    j < latestComputedCommittee.stakerKeys.length;
+                    j++
+                ) {
+                    bytes storage stakerKey = latestComputedCommittee
+                        .stakerKeys[j];
+                    $._committee[i % 3].stakers[
+                        stakerKey
+                    ] = latestComputedCommittee.stakers[stakerKey];
+                }
+            }
+
+            $.latestComputedEpoch = currentEpoch() + 2;
+        }
+    }
+
+    // Returns the next block number at which new stakers are added,
+    // existing ones removed and/or deposits of existing stakers change
+    function nextUpdate() public view returns (uint256 blockNumber) {
+        DepositStorage storage $ = _getDepositStorage();
+        if ($.latestComputedEpoch > currentEpoch())
+            blockNumber = $.latestComputedEpoch * $.blocksPerEpoch;
+    }
+
+    // keep in-sync with zilliqa/src/precompiles.rs
+    function _blsVerify(
+        bytes memory message,
+        bytes memory pubkey,
+        bytes memory signature
+    ) internal view returns (bool) {
+        bytes memory input = abi.encodeWithSelector(
+            hex"a65ebb25", // bytes4(keccak256("blsVerify(bytes,bytes,bytes)"))
+            message,
+            signature,
+            pubkey
+        );
+        uint256 inputLength = input.length;
+        bytes memory output = new bytes(32);
+        bool success;
+        assembly {
+            success := staticcall(
+                gas(),
+                0x5a494c81, // "ZIL\x81"
+                add(input, 0x20),
+                inputLength,
+                add(output, 0x20),
+                32
+            )
+        }
+        require(success, "blsVerify");
+        bool result = abi.decode(output, (bool));
+        return result;
+    }
+
+    function deposit(
+        bytes calldata blsPubKey,
+        bytes calldata peerId,
+        bytes calldata signature,
+        address rewardAddress,
+        address signingAddress
+    ) public payable {
+        if (blsPubKey.length != 48) {
+            revert UnexpectedArgumentLength("bls public key", 48);
+        }
+        if (peerId.length != 38) {
+            revert UnexpectedArgumentLength("peer id", 38);
+        }
+        if (signature.length != 96) {
+            revert UnexpectedArgumentLength("signature", 96);
+        }
+        DepositStorage storage $ = _getDepositStorage();
+
+        bytes memory message = abi.encodePacked(
+            blsPubKey,
+            uint64(block.chainid),
+            msg.sender
+        );
+
+        // Verify bls signature
+        if (!_blsVerify(message, blsPubKey, signature)) {
+            revert RogueKeyCheckFailed();
+        }
+
+        if (msg.value < $.minimumStake) {
+            revert StakeAmountTooLow();
+        }
+
+        Staker storage staker = $._stakersMap[blsPubKey];
+        staker.peerId = peerId;
+        staker.rewardAddress = rewardAddress;
+        staker.signingAddress = signingAddress;
+        staker.controlAddress = msg.sender;
+
+        updateLatestComputedEpoch();
+
+        Committee storage futureCommittee = $._committee[
+            (currentEpoch() + 2) % 3
+        ];
+
+        if (futureCommittee.stakerKeys.length >= $.maximumStakers) {
+            revert TooManyStakers();
+        }
+        if (futureCommittee.stakers[blsPubKey].index != 0) {
+            revert KeyAlreadyStaked();
+        }
+
+        futureCommittee.totalStake += msg.value;
+        futureCommittee.stakers[blsPubKey].balance = msg.value;
+        futureCommittee.stakers[blsPubKey].index =
+            futureCommittee.stakerKeys.length +
+            1;
+        futureCommittee.stakerKeys.push(blsPubKey);
+
+        emit StakerAdded(blsPubKey, nextUpdate(), msg.value);
+    }
+
+    function depositTopup(
+        bytes calldata blsPubKey
+    ) public payable onlyControlAddress(blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+
+        updateLatestComputedEpoch();
+
+        Committee storage futureCommittee = $._committee[
+            (currentEpoch() + 2) % 3
+        ];
+        if (futureCommittee.stakers[blsPubKey].index == 0) {
+            revert KeyNotStaked();
+        }
+
+        futureCommittee.totalStake += msg.value;
+        futureCommittee.stakers[blsPubKey].balance += msg.value;
+
+        emit StakeChanged(
+            blsPubKey,
+            nextUpdate(),
+            futureCommittee.stakers[blsPubKey].balance
+        );
+    }
+
+    function unstake(
+        bytes calldata blsPubKey,
+        uint256 amount
+    ) public onlyControlAddress(blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+
+        updateLatestComputedEpoch();
+
+        Committee storage futureCommittee = $._committee[
+            (currentEpoch() + 2) % 3
+        ];
+        if (futureCommittee.stakers[blsPubKey].index == 0) {
+            revert KeyNotStaked();
+        }
+
+        uint256 currentBalance = futureCommittee.stakers[blsPubKey].balance;
+        require(
+            currentBalance >= amount,
+            "amount is greater than staked balance"
+        );
+
+        if (currentBalance - amount == 0) {
+            require(futureCommittee.stakerKeys.length > 1, "too few stakers");
+
+            // Remove the staker from the future committee, because their staked amount has gone to zero.
+            futureCommittee.totalStake -= amount;
+
+            uint256 deleteIndex = futureCommittee.stakers[blsPubKey].index - 1;
+            uint256 lastIndex = futureCommittee.stakerKeys.length - 1;
+
+            if (deleteIndex != lastIndex) {
+                // Move the last staker in `stakerKeys` to the position of the staker we want to delete.
+                bytes storage lastStakerKey = futureCommittee.stakerKeys[
+                    lastIndex
+                ];
+                futureCommittee.stakerKeys[deleteIndex] = lastStakerKey;
+                // We need to remember to update the moved staker's `index` too.
+                futureCommittee.stakers[lastStakerKey].index = futureCommittee
+                    .stakers[blsPubKey]
+                    .index;
+                emit StakerMoved(lastStakerKey, deleteIndex, nextUpdate());
+            }
+
+            // It is now safe to delete the final staker in the list.
+            futureCommittee.stakerKeys.pop();
+            delete futureCommittee.stakers[blsPubKey];
+
+            // Note that we leave the staker in `_stakersMap` forever.
+
+            emit StakerRemoved(blsPubKey, nextUpdate());
+        } else {
+            require(
+                currentBalance - amount >= $.minimumStake,
+                "unstaking this amount would take the validator below the minimum stake"
+            );
+
+            // Partial unstake. The staker stays in the committee, but with a reduced stake.
+            futureCommittee.totalStake -= amount;
+            futureCommittee.stakers[blsPubKey].balance -= amount;
+
+            emit StakeChanged(
+                blsPubKey,
+                nextUpdate(),
+                futureCommittee.stakers[blsPubKey].balance
+            );
+        }
+
+        // Enqueue the withdrawal for this staker.
+        Deque.Withdrawals storage withdrawals = $
+            ._stakersMap[blsPubKey]
+            .withdrawals;
+        Withdrawal storage currentWithdrawal;
+        // We know `withdrawals` is sorted by `startedAt`. We also know `block.number` is monotonically
+        // non-decreasing. Therefore if there is an existing entry with a `startedAt = block.number`, it must be
+        // at the end of the queue.
+        if (
+            withdrawals.length() != 0 &&
+            withdrawals.back().startedAt == block.number
+        ) {
+            // They have already made a withdrawal at this time, so grab a reference to the existing one.
+            currentWithdrawal = withdrawals.back();
+        } else {
+            // Add a new withdrawal to the end of the queue.
+            currentWithdrawal = withdrawals.pushBack();
+            currentWithdrawal.startedAt = block.number;
+            currentWithdrawal.amount = 0;
+        }
+        currentWithdrawal.amount += amount;
+    }
+
+    function withdraw(bytes calldata blsPubKey) public {
+        _withdraw(blsPubKey, 0);
+    }
+
+    function withdraw(bytes calldata blsPubKey, uint256 count) public {
+        _withdraw(blsPubKey, count);
+    }
+
+    function withdrawalPeriod() public view returns (uint256) {
+        DepositStorage storage $ = _getDepositStorage();
+        return $.withdrawalPeriod;
+
+    }
+
+    function _withdraw(
+        bytes calldata blsPubKey,
+        uint256 count
+    ) internal onlyControlAddress(blsPubKey) {
+        DepositStorage storage $ = _getDepositStorage();
+
+        uint256 releasedAmount = 0;
+
+        Deque.Withdrawals storage withdrawals = $
+            ._stakersMap[blsPubKey]
+            .withdrawals;
+        count = (count == 0 || count > withdrawals.length())
+            ? withdrawals.length()
+            : count;
+
+        while (count > 0) {
+            Withdrawal storage withdrawal = withdrawals.front();
+            if (withdrawal.startedAt + withdrawalPeriod() <= block.number) {
+                releasedAmount += withdrawal.amount;
+                withdrawals.popFront();
+            } else {
+                // Thanks to the invariant on `withdrawals`, we know the elements are ordered by `startedAt`, so we can
+                // break early when we encounter any withdrawal that isn't ready to be released yet.
+                break;
+            }
+            count -= 1;
+        }
+
+        (bool sent, ) = msg.sender.call{value: releasedAmount}("");
+        require(sent, "failed to send");
+    }
+}

--- a/zilliqa/src/contracts/deposit_v5.sol
+++ b/zilliqa/src/contracts/deposit_v5.sol
@@ -153,9 +153,9 @@ contract Deposit is UUPSUpgradeable {
 
     // explicitly set version number in contract code
     // solhint-disable-next-line no-empty-blocks
-    function reinitialize(uint256 withdrawalPeriod) public reinitializer(VERSION) {
+    function reinitialize(uint256 _withdrawalPeriod) public reinitializer(VERSION) {
         DepositStorage storage $ = _getDepositStorage();
-        $.withdrawalPeriod = withdrawalPeriod;
+        $.withdrawalPeriod = _withdrawalPeriod;
     }
 
     function currentEpoch() public view returns (uint64) {

--- a/zilliqa/src/contracts/mod.rs
+++ b/zilliqa/src/contracts/mod.rs
@@ -182,6 +182,64 @@ pub mod deposit_v4 {
         Lazy::new(|| CONTRACT.abi.function("blocksPerEpoch").unwrap().clone());
 }
 
+pub mod deposit_v5 {
+    use ethabi::{Constructor, Function};
+    use once_cell::sync::Lazy;
+
+    use super::{contract, Contract};
+
+    pub static CONTRACT: Lazy<Contract> =
+        Lazy::new(|| contract("src/contracts/deposit_v5.sol", "Deposit"));
+    pub static CONSTRUCTOR: Lazy<Constructor> =
+        Lazy::new(|| CONTRACT.abi.constructor().unwrap().clone());
+    pub static REINITIALIZE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("reinitialize").unwrap().clone());
+    pub static UPGRADE_TO_AND_CALL: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("upgradeToAndCall").unwrap().clone());
+    pub static VERSION: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("version").unwrap().clone());
+
+    pub static BYTECODE: Lazy<Vec<u8>> = Lazy::new(|| CONTRACT.bytecode.clone());
+    pub static LEADER_AT_VIEW: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("leaderAtView").unwrap().clone());
+    pub static DEPOSIT: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("deposit").unwrap().clone());
+    pub static DEPOSIT_TOPUP: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("depositTopup").unwrap().clone());
+    pub static UNSTAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("unstake").unwrap().clone());
+    pub static CURRENT_EPOCH: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("currentEpoch").unwrap().clone());
+    pub static GET_STAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getStake").unwrap().clone());
+    pub static GET_REWARD_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getRewardAddress").unwrap().clone());
+    pub static GET_SIGNING_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getSigningAddress").unwrap().clone());
+    pub static GET_CONTROL_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getControlAddress").unwrap().clone());
+    pub static SET_SIGNING_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("setSigningAddress").unwrap().clone());
+    pub static SET_CONTROL_ADDRESS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("setControlAddress").unwrap().clone());
+    pub static GET_PEER_ID: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getPeerId").unwrap().clone());
+    pub static GET_STAKERS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getStakers").unwrap().clone());
+    pub static GET_TOTAL_STAKE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("getTotalStake").unwrap().clone());
+    pub static COMMITTEE: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("committee").unwrap().clone());
+    pub static MIN_DEPOSIT: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("minimumStake").unwrap().clone());
+    pub static MAX_STAKERS: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("maximumStakers").unwrap().clone());
+    pub static BLOCKS_PER_EPOCH: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("blocksPerEpoch").unwrap().clone());
+    pub static WITHDRAWAL_PERIOD: Lazy<Function> =
+        Lazy::new(|| CONTRACT.abi.function("withdrawalPeriod").unwrap().clone());
+}
+
 pub mod shard {
     use ethabi::Constructor;
     use once_cell::sync::Lazy;
@@ -301,6 +359,7 @@ mod tests {
                 "src/contracts/deposit_v2.sol",
                 "src/contracts/deposit_v3.sol",
                 "src/contracts/deposit_v4.sol",
+                "src/contracts/deposit_v5.sol",
                 "src/contracts/utils/deque.sol",
                 "src/contracts/intershard_bridge.sol",
                 "src/contracts/shard.sol",

--- a/zilliqa/src/contracts/tests/deposit.sol
+++ b/zilliqa/src/contracts/tests/deposit.sol
@@ -8,21 +8,24 @@ import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.s
 // Testing contract for deposit_v4 development
 /* solhint-disable no-console,func-name-mixedcase,explicit-types */
 
-
 contract PopVerifyPrecompile {
-    function popVerify(bytes memory, bytes memory) public pure returns(bool) {
+    function popVerify(bytes memory, bytes memory) public pure returns (bool) {
         return true;
     }
 }
 
 contract BlsVerifyPrecompile {
-    function blsVerify(bytes memory, bytes memory, bytes memory) public pure returns(bool) {
+    function blsVerify(
+        bytes memory,
+        bytes memory,
+        bytes memory
+    ) public pure returns (bool) {
         return true;
     }
 }
 
 contract DepositTest is Test {
-    address payable internal  proxy;
+    address payable internal proxy;
     DepositInit internal depositInitContract;
     Deposit internal depositContract;
     uint8 internal contractVersion = 5;
@@ -35,10 +38,17 @@ contract DepositTest is Test {
         0x092E5E57955437876dA9Df998C96e2BE19341670
     ];
     bytes[2] internal blsPubKeys = [
-        bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f1"),
-        bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f2")
+        bytes(
+            hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f1"
+        ),
+        bytes(
+            hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f2"
+        )
     ];
-    bytes internal peerId = bytes(hex"002408011220bed0be7a6dfa10c2335148e04927155a726174d6bac61a09ad8e2f72ac697eda");
+    bytes internal peerId =
+        bytes(
+            hex"002408011220bed0be7a6dfa10c2335148e04927155a726174d6bac61a09ad8e2f72ac697eda"
+        );
 
     // bytes[] expected_stakerKeys_storage;
     // uint256[] expected_indices_storage;
@@ -160,7 +170,10 @@ contract DepositTest is Test {
         unstake(0, unstakeAmount2);
 
         checkGetStake(blsPubKeys[ownerInt], depositAmount);
-        checkGetFutureStake(blsPubKeys[ownerInt], depositAmount - unstakeAmount1 - unstakeAmount2);
+        checkGetFutureStake(
+            blsPubKeys[ownerInt],
+            depositAmount - unstakeAmount1 - unstakeAmount2
+        );
         checkGetStakerDataWithdrawals(blsPubKeys[ownerInt], 1);
 
         // Roll ahead one block
@@ -171,20 +184,29 @@ contract DepositTest is Test {
         unstake(0, unstakeAmount3);
 
         checkGetStake(blsPubKeys[ownerInt], depositAmount);
-        checkGetFutureStake(blsPubKeys[ownerInt], depositAmount - unstakeAmount1 - unstakeAmount2 - unstakeAmount3);
+        checkGetFutureStake(
+            blsPubKeys[ownerInt],
+            depositAmount - unstakeAmount1 - unstakeAmount2 - unstakeAmount3
+        );
         // should now be 2 withdrawals
         checkGetStakerDataWithdrawals(blsPubKeys[ownerInt], 2);
 
         // Roll ahead withdrawal period
         vm.roll(block.number + depositContract.withdrawalPeriod());
 
-        checkGetStake(blsPubKeys[ownerInt], depositAmount - unstakeAmount1 - unstakeAmount2 - unstakeAmount3);
+        checkGetStake(
+            blsPubKeys[ownerInt],
+            depositAmount - unstakeAmount1 - unstakeAmount2 - unstakeAmount3
+        );
 
         // Withdraw only one of the unstakings
         uint256 balanceBefore = owners[ownerInt].balance;
         withdraw(ownerInt, 1);
 
-        assertEq(balanceBefore + unstakeAmount1 + unstakeAmount2, owners[ownerInt].balance);
+        assertEq(
+            balanceBefore + unstakeAmount1 + unstakeAmount2,
+            owners[ownerInt].balance
+        );
     }
 
     function test_getters() public {
@@ -240,24 +262,31 @@ contract DepositTest is Test {
         checkGetStakerData(blsPubKeys[1], 2, depositOwner1Amount);
 
         // getRewardAddress
-        assertEq(depositContract.getRewardAddress(blsPubKeys[0]),stakers[0]);
-        assertEq(depositContract.getRewardAddress(blsPubKeys[1]),stakers[1]);
+        assertEq(depositContract.getRewardAddress(blsPubKeys[0]), stakers[0]);
+        assertEq(depositContract.getRewardAddress(blsPubKeys[1]), stakers[1]);
         // getSigningAddress
-        assertEq(depositContract.getSigningAddress(blsPubKeys[0]),stakers[0]);
-        assertEq(depositContract.getSigningAddress(blsPubKeys[1]),stakers[1]);
+        assertEq(depositContract.getSigningAddress(blsPubKeys[0]), stakers[0]);
+        assertEq(depositContract.getSigningAddress(blsPubKeys[1]), stakers[1]);
         // getControlAddress
-        assertEq(depositContract.getSigningAddress(blsPubKeys[0]),stakers[0]);
-        assertEq(depositContract.getSigningAddress(blsPubKeys[1]),stakers[1]);
+        assertEq(depositContract.getSigningAddress(blsPubKeys[0]), stakers[0]);
+        assertEq(depositContract.getSigningAddress(blsPubKeys[1]), stakers[1]);
         // getPeerId
-        assertEq(depositContract.getPeerId(blsPubKeys[0]),peerId);
-        assertEq(depositContract.getPeerId(blsPubKeys[1]),peerId);
+        assertEq(depositContract.getPeerId(blsPubKeys[0]), peerId);
+        assertEq(depositContract.getPeerId(blsPubKeys[1]), peerId);
     }
 
-    function checkGetStake(bytes memory blsPubKey, uint256 expectedAmount) public view {
+    function checkGetStake(
+        bytes memory blsPubKey,
+        uint256 expectedAmount
+    ) public view {
         uint256 gasBefore = gasleft();
         uint256 stake = depositContract.getStake(blsPubKey);
         if (printGasUsage) {
-            console.log("\ngetStake(): %s   Gas used: %s", stake, gasBefore - gasleft());
+            console.log(
+                "\ngetStake(): %s   Gas used: %s",
+                stake,
+                gasBefore - gasleft()
+            );
         }
         assertEq(stake, expectedAmount);
     }
@@ -266,16 +295,27 @@ contract DepositTest is Test {
         uint256 gasBefore = gasleft();
         uint256 totalStake = depositContract.getTotalStake();
         if (printGasUsage) {
-            console.log("\ngetTotalStake(): %s   Gas used: %s", totalStake, gasBefore - gasleft());
+            console.log(
+                "\ngetTotalStake(): %s   Gas used: %s",
+                totalStake,
+                gasBefore - gasleft()
+            );
         }
         assertEq(totalStake, expectedAmount);
     }
 
-    function checkGetFutureStake(bytes memory blsPubKey, uint256 expectedAmount) public view {
+    function checkGetFutureStake(
+        bytes memory blsPubKey,
+        uint256 expectedAmount
+    ) public view {
         uint256 gasBefore = gasleft();
         uint256 stake = depositContract.getFutureStake(blsPubKey);
         if (printGasUsage) {
-            console.log("\ngetFutureStake(): %s   Gas used: %s", stake, gasBefore - gasleft());
+            console.log(
+                "\ngetFutureStake(): %s   Gas used: %s",
+                stake,
+                gasBefore - gasleft()
+            );
         }
         assertEq(stake, expectedAmount);
     }
@@ -284,23 +324,24 @@ contract DepositTest is Test {
         uint256 gasBefore = gasleft();
         uint256 totalStake = depositContract.getFutureTotalStake();
         if (printGasUsage) {
-            console.log("\ngetFutureTotalStake(): %s   Gas used: %s", totalStake, gasBefore - gasleft());
+            console.log(
+                "\ngetFutureTotalStake(): %s   Gas used: %s",
+                totalStake,
+                gasBefore - gasleft()
+            );
         }
         assertEq(totalStake, expectedAmount);
     }
 
     function checkGetStakerData(
         bytes memory blsPubKey,
-        uint256 expectedIndex, 
+        uint256 expectedIndex,
         uint256 expectedBalance
-        // Staker memory expectedStakers
-    ) public view {
+    ) public view // Staker memory expectedStakers
+    {
         uint256 gasBefore = gasleft();
-        (
-            uint256 index,
-            uint256 balance,
-            // Staker memory stakerData
-        ) = depositContract.getStakerData(blsPubKey);
+        (uint256 index, uint256 balance, ) = // Staker memory stakerData
+        depositContract.getStakerData(blsPubKey);
         if (printGasUsage) {
             console.log("\ngetStakerData Gas used: %s", gasBefore - gasleft());
         }
@@ -314,11 +355,9 @@ contract DepositTest is Test {
         uint256 withdrawals
     ) public view {
         uint256 gasBefore = gasleft();
-        (
-            ,
-            ,
-            Staker memory stakerData
-        ) = depositContract.getStakerData(blsPubKey);
+        (, , Staker memory stakerData) = depositContract.getStakerData(
+            blsPubKey
+        );
         if (printGasUsage) {
             console.log("\ngetStakerData Gas used: %s", gasBefore - gasleft());
         }
@@ -326,59 +365,67 @@ contract DepositTest is Test {
     }
 
     // function checkGetStakersData(
-    //     bytes[] memory expected_stakerKeys, 
-    //     uint256[] memory expected_indices, 
+    //     bytes[] memory expected_stakerKeys,
+    //     uint256[] memory expected_indices,
     //     uint256[] memory expectedBalances
     //     // Staker[] memory expectedStakers
     // ) public view {
     //     uint256 gasBefore = gasleft();
-        // (
-        //     bytes[] memory stakerKeys,
-        //     uint256[] memory indices,
-        //     uint256[] memory balances,
-        //     // Staker[] memory stakerData
-        // ) = deposit_contract.getStakersData();
-        // if (print_gas_usage) {
-        //     console.log("\ngetStakersData length: %s Gas used: %s", stakerKeys.length, gasBefore - gasleft());
-        // }
-        // for (uint256 i = 0; i < stakerKeys.length; i++) {
-        //     assertEq(stakerKeys[i], expected_stakerKeys[i]);
-        //     assertEq(indices[i], expected_indices[i]);
-        //     assertEq(balances[i], expectedBalances[i]);
+    // (
+    //     bytes[] memory stakerKeys,
+    //     uint256[] memory indices,
+    //     uint256[] memory balances,
+    //     // Staker[] memory stakerData
+    // ) = deposit_contract.getStakersData();
+    // if (print_gas_usage) {
+    //     console.log("\ngetStakersData length: %s Gas used: %s", stakerKeys.length, gasBefore - gasleft());
+    // }
+    // for (uint256 i = 0; i < stakerKeys.length; i++) {
+    //     assertEq(stakerKeys[i], expected_stakerKeys[i]);
+    //     assertEq(indices[i], expected_indices[i]);
+    //     assertEq(balances[i], expectedBalances[i]);
 
-        //     // assertEq(stakerData[i], expectedStakers[i]);
-        //     console.log("stakerKey");
-        //     console.logBytes(stakerKeys[i]);
-        //     console.log("indices %s", indices[i]);
-        //     console.log("balances %s", balances[i]);        
-        // }
+    //     // assertEq(stakerData[i], expectedStakers[i]);
+    //     console.log("stakerKey");
+    //     console.logBytes(stakerKeys[i]);
+    //     console.log("indices %s", indices[i]);
+    //     console.log("balances %s", balances[i]);
+    // }
     // }
 
     function deposit(uint ownerInt, uint amount) public {
         vm.startPrank(owners[ownerInt]);
         uint256 gasBefore = gasleft();
-        depositContract.deposit{
-            value: amount
-        }(
+        depositContract.deposit{value: amount}(
             blsPubKeys[ownerInt],
             peerId,
-            bytes(hex"90ec9a22e030a42d9b519b322d31b8090f796b3f75fc74261b04d0dcc632fd8c5b7a074c5ba61f0845b310fa9931d01c079eebe82813d7021ef4172e01a7d3710a5f9a4634e9a03a51e985836021c356a1eb476a14f558cbae1f4264edca5dac"),
+            bytes(
+                hex"90ec9a22e030a42d9b519b322d31b8090f796b3f75fc74261b04d0dcc632fd8c5b7a074c5ba61f0845b310fa9931d01c079eebe82813d7021ef4172e01a7d3710a5f9a4634e9a03a51e985836021c356a1eb476a14f558cbae1f4264edca5dac"
+            ),
             address(stakers[ownerInt]),
             address(stakers[ownerInt])
         );
         if (printGasUsage) {
-            console.log("\ndeposit owner%s. Amount: %s   Gas used: %s", ownerInt, amount, gasBefore - gasleft());
+            console.log(
+                "\ndeposit owner%s. Amount: %s   Gas used: %s",
+                ownerInt,
+                amount,
+                gasBefore - gasleft()
+            );
         }
     }
 
     function depositTopUp(uint ownerInt, uint amount) public {
         vm.startPrank(owners[ownerInt]);
         uint256 gasBefore = gasleft();
-        depositContract.depositTopup{
-            value: amount
-        }(blsPubKeys[ownerInt]);
+        depositContract.depositTopup{value: amount}(blsPubKeys[ownerInt]);
         if (printGasUsage) {
-            console.log("\ndepositTopUp owner%s. Amount: %s Gas used: %s", ownerInt, amount, gasBefore - gasleft());
+            console.log(
+                "\ndepositTopUp owner%s. Amount: %s Gas used: %s",
+                ownerInt,
+                amount,
+                gasBefore - gasleft()
+            );
         }
     }
 
@@ -387,7 +434,12 @@ contract DepositTest is Test {
         uint256 gasBefore = gasleft();
         depositContract.unstake(blsPubKeys[ownerInt], amount);
         if (printGasUsage) {
-            console.log("\nunstake owner%s. Amount: %s Gas used: %s", ownerInt, amount, gasBefore - gasleft());
+            console.log(
+                "\nunstake owner%s. Amount: %s Gas used: %s",
+                ownerInt,
+                amount,
+                gasBefore - gasleft()
+            );
         }
     }
 
@@ -396,7 +448,12 @@ contract DepositTest is Test {
         uint256 gasBefore = gasleft();
         depositContract.withdraw(blsPubKeys[ownerInt], count);
         if (printGasUsage) {
-            console.log("\nwithdraw owner%s. Count: %s Gas used: %s", ownerInt, count, gasBefore - gasleft());
+            console.log(
+                "\nwithdraw owner%s. Count: %s Gas used: %s",
+                ownerInt,
+                count,
+                gasBefore - gasleft()
+            );
         }
     }
 }

--- a/zilliqa/src/contracts/tests/deposit.sol
+++ b/zilliqa/src/contracts/tests/deposit.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity ^0.8.26;
+import {Deposit, Staker} from "../deposit_v5.sol";
+import {DepositInit, InitialStaker} from "../deposit_v1.sol";
+import {Test, Vm, console2 as console} from "@openzeppelin/lib/forge-std/src/Test.sol";
+import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+// Testing contract for deposit_v4 development
+
+contract PopVerifyPrecompile {
+    function popVerify(bytes memory, bytes memory) public pure returns(bool) {
+        return true;
+    }
+}
+
+contract BlsVerifyPrecompile {
+    function blsVerify(bytes memory, bytes memory, bytes memory) public pure returns(bool) {
+        return true;
+    }
+}
+
+contract DepositTest is Test {
+    address payable proxy;
+    DepositInit deposit_init_contract;
+    Deposit deposit_contract;
+    uint8 contract_version = 5;
+    bool print_gas_usage = true;
+    address owner1 = vm.addr(uint256(1));
+    address owner2 = vm.addr(uint256(2));
+    address[4] stakers = [
+        0xd819fFcE7A58b1E835c25617Db7b46a00888B013,
+        0x092E5E57955437876dA9Df998C96e2BE19341670,
+        0xeA78aAE5Be606D2D152F00760662ac321aB8F017,
+        0x6603A37980DF7ef6D44E994B3183A15D0322B7bF
+    ];
+    bytes blsPubKey1 = bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f1");
+    bytes blsPubKey2 = bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f2");
+
+    constructor() {
+    }
+
+    function test_Deposit() public {
+        vm.chainId(33469);
+        vm.deal(owner1, 40_000_000 ether);
+        vm.deal(owner2, 40_000_000 ether);
+
+        vm.deal(stakers[0], 0);
+        vm.deal(stakers[1], 0);
+        vm.deal(stakers[2], 0);
+
+        vm.startPrank(address(0));
+
+        // Deploy initial version
+        address deposit_contract_initial_addr = address(new DepositInit());
+        deposit_init_contract = DepositInit(deposit_contract_initial_addr);
+
+        bytes memory initializerCall = abi.encodeWithSignature(
+            "initialize(uint256,uint256,uint64,(bytes,bytes,address,address,uint256)[])",
+            uint256(10 ether),
+            uint256(256),
+            uint64(10),
+            new InitialStaker[](0)
+        );
+        proxy = payable(
+            new ERC1967Proxy(deposit_contract_initial_addr, initializerCall)
+        );
+        deposit_init_contract = DepositInit(proxy);
+
+        // Upgrade to deposit_v5
+        address deposit_contract_addr = address(new Deposit());
+        uint256 withdrawalPeriod = uint256(36);
+        bytes memory reinitializerCall = abi.encodeWithSignature(
+            "reinitialize(uint256)",
+            withdrawalPeriod
+        );
+        deposit_init_contract.upgradeToAndCall(
+            deposit_contract_addr,
+            reinitializerCall
+        );
+        deposit_contract = Deposit(proxy);
+
+        // Other setup
+        vm.etch(address(0x5a494c81), address(new BlsVerifyPrecompile()).code);
+
+
+        // Confirm upgrade 
+        assertEq(deposit_contract.version(), contract_version);
+        assertEq(deposit_contract.withdrawalPeriod(), withdrawalPeriod);
+    }
+
+    function checkGetStake(bytes memory blsPubKey, uint256 expected_amount) view public {
+        uint256 gasBefore = gasleft();
+        uint256 stake = deposit_contract.getStake(blsPubKey);
+        if (print_gas_usage) {
+            console.log("\ngetStake(): %s   Gas used: %s", stake, gasBefore - gasleft());
+        }
+        assertEq(stake, expected_amount);
+    }
+
+    function checkGetTotalStake(uint256 expected_amount) public {
+        uint256 gasBefore = gasleft();
+        uint256 total_stake = deposit_contract.getTotalStake();
+        if (print_gas_usage) {
+            console.log("\ngetTotalStake(): %s   Gas used: %s", total_stake, gasBefore - gasleft());
+        }
+        assertEq(total_stake, expected_amount);
+    }
+
+    function checkGetFutureStake(bytes memory blsPubKey, uint256 expected_amount) view public {
+        uint256 gasBefore = gasleft();
+        uint256 stake = deposit_contract.getFutureStake(blsPubKey);
+        if (print_gas_usage) {
+            console.log("\ngetFutureStake(): %s   Gas used: %s", stake, gasBefore - gasleft());
+        }
+        assertEq(stake, expected_amount);
+    }
+
+    function checkGetTotalFutureStake(uint256 expected_amount) view public {
+        uint256 gasBefore = gasleft();
+        uint256 total_stake = deposit_contract.getFutureTotalStake();
+        if (print_gas_usage) {
+            console.log("\ngetFutureTotalStake(): %s   Gas used: %s", total_stake, gasBefore - gasleft());
+        }
+        assertEq(total_stake, expected_amount);
+    }
+
+    function getStakersData(bytes[] memory expected_stakerKeys, uint256[] memory expected_indices, uint256[] memory expected_balances, Staker[] memory expected_stakers) view public {
+        uint256 gasBefore = gasleft();
+        (
+            bytes[] memory stakerKeys,
+            uint256[] memory indices,
+            uint256[] memory balances,
+            Staker[] memory stakers
+        ) = deposit_contract.getStakersData();
+        if (print_gas_usage) {
+            console.log("\ngetStakersData length: %s Gas used: %s", stakerKeys.length, gasBefore - gasleft());
+        }
+        for (uint256 i = 0; i < stakerKeys.length; i++) {
+            assertEq(stakerKeys[i], expected_stakerKeys[i]);
+            assertEq(indices[i], expected_indices[i]);
+            assertEq(balances[i], expected_balances[i]);
+
+            // assertEq(stakers[i], expected_stakers[i]);
+            console.log("stakerKey");
+            console.logBytes(stakerKeys[i]);
+            console.log("indices %s", indices[i]);
+            console.log("balances %s", balances[i]);        
+        }
+    }
+
+    function depositTopUp(uint ownerInt, uint amount) public {
+        address owner;
+        bytes memory blsPubKey;
+        if (ownerInt == 1) {
+            owner = owner1;
+            blsPubKey = blsPubKey1;
+        } else {
+            owner = owner2;
+            blsPubKey = blsPubKey2;
+        }
+        vm.startPrank(owner);
+        uint256 gasBefore = gasleft();
+        deposit_contract.depositTopup{
+            value: amount
+        }(blsPubKey);
+        console.log("\ndepositTopUp owner%s. Amount: %s Gas used: %s", ownerInt, amount, gasBefore - gasleft());
+        vm.stopPrank();
+    }
+}

--- a/zilliqa/src/contracts/tests/deposit.sol
+++ b/zilliqa/src/contracts/tests/deposit.sol
@@ -2,10 +2,12 @@
 pragma solidity ^0.8.26;
 import {Deposit, Staker} from "../deposit_v5.sol";
 import {DepositInit, InitialStaker} from "../deposit_v1.sol";
-import {Test, Vm, console2 as console} from "@openzeppelin/lib/forge-std/src/Test.sol";
+import {Test, console2 as console} from "@openzeppelin/lib/forge-std/src/Test.sol";
 import {ERC1967Proxy} from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 
 // Testing contract for deposit_v4 development
+/* solhint-disable no-console,func-name-mixedcase,explicit-types */
+
 
 contract PopVerifyPrecompile {
     function popVerify(bytes memory, bytes memory) public pure returns(bool) {
@@ -20,39 +22,41 @@ contract BlsVerifyPrecompile {
 }
 
 contract DepositTest is Test {
-    address payable proxy;
-    DepositInit deposit_init_contract;
-    Deposit deposit_contract;
-    uint8 contract_version = 5;
-    bool print_gas_usage = true;
-    address owner1 = vm.addr(uint256(1));
-    address owner2 = vm.addr(uint256(2));
-    address[4] stakers = [
+    address payable internal  proxy;
+    DepositInit internal depositInitContract;
+    Deposit internal depositContract;
+    uint8 internal contractVersion = 5;
+    uint256 internal withdrawalPeriod = uint256(36);
+
+    bool internal printGasUsage = false;
+    address[2] internal owners = [vm.addr(uint256(1)), vm.addr(uint256(2))];
+    address[2] internal stakers = [
         0xd819fFcE7A58b1E835c25617Db7b46a00888B013,
-        0x092E5E57955437876dA9Df998C96e2BE19341670,
-        0xeA78aAE5Be606D2D152F00760662ac321aB8F017,
-        0x6603A37980DF7ef6D44E994B3183A15D0322B7bF
+        0x092E5E57955437876dA9Df998C96e2BE19341670
     ];
-    bytes blsPubKey1 = bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f1");
-    bytes blsPubKey2 = bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f2");
+    bytes[2] internal blsPubKeys = [
+        bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f1"),
+        bytes(hex"92370645a6ad97d8a4e4b44b8e6db63ab8409473310ac7b21063809450192bace7fb768d60c697a18bbf98b4ddb511f2")
+    ];
+    bytes internal peerId = bytes(hex"002408011220bed0be7a6dfa10c2335148e04927155a726174d6bac61a09ad8e2f72ac697eda");
+
+    // bytes[] expected_stakerKeys_storage;
+    // uint256[] expected_indices_storage;
+    // uint256[] expected_amounts_storage;
 
     constructor() {
-    }
-
-    function test_Deposit() public {
-        vm.chainId(33469);
-        vm.deal(owner1, 40_000_000 ether);
-        vm.deal(owner2, 40_000_000 ether);
+        vm.deal(address(0), 40_000_000 ether);
+        vm.deal(owners[0], 40_000_000 ether);
+        vm.deal(owners[1], 40_000_000 ether);
 
         vm.deal(stakers[0], 0);
         vm.deal(stakers[1], 0);
-        vm.deal(stakers[2], 0);
 
         vm.startPrank(address(0));
 
         // Deploy initial version
-        address deposit_contract_initial_addr = address(new DepositInit());
-        deposit_init_contract = DepositInit(deposit_contract_initial_addr);
+        address depositContractInitialAddr = address(new DepositInit());
+        depositInitContract = DepositInit(depositContractInitialAddr);
 
         bytes memory initializerCall = abi.encodeWithSignature(
             "initialize(uint256,uint256,uint64,(bytes,bytes,address,address,uint256)[])",
@@ -62,108 +66,337 @@ contract DepositTest is Test {
             new InitialStaker[](0)
         );
         proxy = payable(
-            new ERC1967Proxy(deposit_contract_initial_addr, initializerCall)
+            new ERC1967Proxy(depositContractInitialAddr, initializerCall)
         );
-        deposit_init_contract = DepositInit(proxy);
+        depositInitContract = DepositInit(proxy);
 
         // Upgrade to deposit_v5
-        address deposit_contract_addr = address(new Deposit());
-        uint256 withdrawalPeriod = uint256(36);
+        address depositContractAddr = address(new Deposit());
         bytes memory reinitializerCall = abi.encodeWithSignature(
             "reinitialize(uint256)",
             withdrawalPeriod
         );
-        deposit_init_contract.upgradeToAndCall(
-            deposit_contract_addr,
+        depositInitContract.upgradeToAndCall(
+            depositContractAddr,
             reinitializerCall
         );
-        deposit_contract = Deposit(proxy);
+        depositContract = Deposit(proxy);
 
         // Other setup
         vm.etch(address(0x5a494c81), address(new BlsVerifyPrecompile()).code);
-
-
-        // Confirm upgrade 
-        assertEq(deposit_contract.version(), contract_version);
-        assertEq(deposit_contract.withdrawalPeriod(), withdrawalPeriod);
+        vm.stopPrank();
     }
 
-    function checkGetStake(bytes memory blsPubKey, uint256 expected_amount) view public {
+    function test_contract_upgrade() public {
+        assertEq(depositContract.version(), contractVersion);
+        assertEq(depositContract.withdrawalPeriod(), withdrawalPeriod);
+    }
+
+    function test_deposit() public {
+        // Deposit owner 0
+        uint256 depositOwner0Amount = 20 ether;
+        deposit(0, depositOwner0Amount);
+
+        checkGetStake(blsPubKeys[0], 0);
+        checkGetFutureStake(blsPubKeys[0], depositOwner0Amount);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[0], depositOwner0Amount);
+        checkGetFutureStake(blsPubKeys[0], depositOwner0Amount);
+
+        // Deposit owner 1
+        uint256 depositOwner1Amount = 10 ether;
+        deposit(1, depositOwner1Amount);
+
+        checkGetStake(blsPubKeys[1], 0);
+        checkGetFutureStake(blsPubKeys[1], depositOwner1Amount);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[1], depositOwner1Amount);
+        checkGetFutureStake(blsPubKeys[1], depositOwner1Amount);
+        checkGetTotalStake(depositOwner0Amount + depositOwner1Amount);
+        checkGetTotalFutureStake(depositOwner0Amount + depositOwner1Amount);
+    }
+
+    function test_deposit_top_up() public {
+        uint256 depositAmount = 20 ether;
+        deposit(0, depositAmount);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[0], depositAmount);
+
+        uint256 topUpAmount = 3 ether;
+        depositTopUp(0, topUpAmount);
+
+        checkGetStake(blsPubKeys[0], depositAmount);
+        checkGetFutureStake(blsPubKeys[0], depositAmount + topUpAmount);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[0], depositAmount + topUpAmount);
+    }
+
+    function test_unstake_withdraw() public {
+        uint256 ownerInt = 0;
+        uint256 depositAmount = 20 ether;
+        deposit(ownerInt, depositAmount);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[ownerInt], depositAmount);
+
+        // Unstake twice - these two should roll into the same withdrawal
+        uint256 unstakeAmount1 = 3 ether;
+        unstake(0, unstakeAmount1);
+        uint256 unstakeAmount2 = 1 ether;
+        unstake(0, unstakeAmount2);
+
+        checkGetStake(blsPubKeys[ownerInt], depositAmount);
+        checkGetFutureStake(blsPubKeys[ownerInt], depositAmount - unstakeAmount1 - unstakeAmount2);
+        checkGetStakerDataWithdrawals(blsPubKeys[ownerInt], 1);
+
+        // Roll ahead one block
+        vm.roll(block.number + 1);
+
+        // Unstake again
+        uint256 unstakeAmount3 = 4 ether;
+        unstake(0, unstakeAmount3);
+
+        checkGetStake(blsPubKeys[ownerInt], depositAmount);
+        checkGetFutureStake(blsPubKeys[ownerInt], depositAmount - unstakeAmount1 - unstakeAmount2 - unstakeAmount3);
+        // should now be 2 withdrawals
+        checkGetStakerDataWithdrawals(blsPubKeys[ownerInt], 2);
+
+        // Roll ahead withdrawal period
+        vm.roll(block.number + depositContract.withdrawalPeriod());
+
+        checkGetStake(blsPubKeys[ownerInt], depositAmount - unstakeAmount1 - unstakeAmount2 - unstakeAmount3);
+
+        // Withdraw only one of the unstakings
+        uint256 balanceBefore = owners[ownerInt].balance;
+        withdraw(ownerInt, 1);
+
+        assertEq(balanceBefore + unstakeAmount1 + unstakeAmount2, owners[ownerInt].balance);
+    }
+
+    function test_getters() public {
+        // bytes[] storage expected_stakerKeys = expected_stakerKeys_storage;
+        // uint256[] storage expected_indices = expected_indices_storage;
+        // uint256[] storage expected_amounts = expected_amounts_storage;
+        // checkGetStakersData(expected_stakerKeys, expected_indices,  expected_amounts);
+
+        // Deposit owner 0
+        uint256 depositOwner0Amount = 20 ether;
+        deposit(0, depositOwner0Amount);
+
+        checkGetStake(blsPubKeys[0], 0);
+        checkGetFutureStake(blsPubKeys[0], depositOwner0Amount);
+        checkGetTotalStake(0);
+        checkGetTotalFutureStake(depositOwner0Amount);
+        checkGetStakerData(blsPubKeys[0], 0, 0);
+        // checkGetStakersData(expected_stakerKeys, expected_indices,  expected_amounts);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[0], depositOwner0Amount);
+        checkGetFutureStake(blsPubKeys[0], depositOwner0Amount);
+        checkGetTotalStake(depositOwner0Amount);
+        checkGetTotalFutureStake(depositOwner0Amount);
+        checkGetStakerData(blsPubKeys[0], 1, depositOwner0Amount);
+        // expected_stakerKeys.push(blsPubKeys[0]);
+        // expected_indices.push(uint256(0));
+        // expected_amounts.push(depositOwner0Amount);
+        // checkGetStakersData(expected_stakerKeys, expected_indices, expected_amounts);
+
+        // Deposit owner 1
+        uint256 depositOwner1Amount = 10 ether;
+        deposit(1, depositOwner1Amount);
+
+        checkGetStake(blsPubKeys[1], 0);
+        checkGetFutureStake(blsPubKeys[1], depositOwner1Amount);
+        checkGetTotalStake(depositOwner0Amount);
+        checkGetTotalFutureStake(depositOwner0Amount + depositOwner1Amount);
+        checkGetStakerData(blsPubKeys[0], 1, depositOwner0Amount);
+        checkGetStakerData(blsPubKeys[1], 0, 0);
+        // checkGetStakersData(expected_stakerKeys, expected_indices, expected_amounts);
+
+        // Roll ahead 2 epochs
+        vm.roll(block.number + depositContract.blocksPerEpoch() * 2);
+
+        checkGetStake(blsPubKeys[1], depositOwner1Amount);
+        checkGetFutureStake(blsPubKeys[1], depositOwner1Amount);
+        checkGetTotalStake(depositOwner0Amount + depositOwner1Amount);
+        checkGetTotalFutureStake(depositOwner0Amount + depositOwner1Amount);
+        checkGetStakerData(blsPubKeys[0], 1, depositOwner0Amount);
+        checkGetStakerData(blsPubKeys[1], 2, depositOwner1Amount);
+
+        // getRewardAddress
+        assertEq(depositContract.getRewardAddress(blsPubKeys[0]),stakers[0]);
+        assertEq(depositContract.getRewardAddress(blsPubKeys[1]),stakers[1]);
+        // getSigningAddress
+        assertEq(depositContract.getSigningAddress(blsPubKeys[0]),stakers[0]);
+        assertEq(depositContract.getSigningAddress(blsPubKeys[1]),stakers[1]);
+        // getControlAddress
+        assertEq(depositContract.getSigningAddress(blsPubKeys[0]),stakers[0]);
+        assertEq(depositContract.getSigningAddress(blsPubKeys[1]),stakers[1]);
+        // getPeerId
+        assertEq(depositContract.getPeerId(blsPubKeys[0]),peerId);
+        assertEq(depositContract.getPeerId(blsPubKeys[1]),peerId);
+    }
+
+    function checkGetStake(bytes memory blsPubKey, uint256 expectedAmount) public view {
         uint256 gasBefore = gasleft();
-        uint256 stake = deposit_contract.getStake(blsPubKey);
-        if (print_gas_usage) {
+        uint256 stake = depositContract.getStake(blsPubKey);
+        if (printGasUsage) {
             console.log("\ngetStake(): %s   Gas used: %s", stake, gasBefore - gasleft());
         }
-        assertEq(stake, expected_amount);
+        assertEq(stake, expectedAmount);
     }
 
-    function checkGetTotalStake(uint256 expected_amount) public {
+    function checkGetTotalStake(uint256 expectedAmount) public view {
         uint256 gasBefore = gasleft();
-        uint256 total_stake = deposit_contract.getTotalStake();
-        if (print_gas_usage) {
-            console.log("\ngetTotalStake(): %s   Gas used: %s", total_stake, gasBefore - gasleft());
+        uint256 totalStake = depositContract.getTotalStake();
+        if (printGasUsage) {
+            console.log("\ngetTotalStake(): %s   Gas used: %s", totalStake, gasBefore - gasleft());
         }
-        assertEq(total_stake, expected_amount);
+        assertEq(totalStake, expectedAmount);
     }
 
-    function checkGetFutureStake(bytes memory blsPubKey, uint256 expected_amount) view public {
+    function checkGetFutureStake(bytes memory blsPubKey, uint256 expectedAmount) public view {
         uint256 gasBefore = gasleft();
-        uint256 stake = deposit_contract.getFutureStake(blsPubKey);
-        if (print_gas_usage) {
+        uint256 stake = depositContract.getFutureStake(blsPubKey);
+        if (printGasUsage) {
             console.log("\ngetFutureStake(): %s   Gas used: %s", stake, gasBefore - gasleft());
         }
-        assertEq(stake, expected_amount);
+        assertEq(stake, expectedAmount);
     }
 
-    function checkGetTotalFutureStake(uint256 expected_amount) view public {
+    function checkGetTotalFutureStake(uint256 expectedAmount) public view {
         uint256 gasBefore = gasleft();
-        uint256 total_stake = deposit_contract.getFutureTotalStake();
-        if (print_gas_usage) {
-            console.log("\ngetFutureTotalStake(): %s   Gas used: %s", total_stake, gasBefore - gasleft());
+        uint256 totalStake = depositContract.getFutureTotalStake();
+        if (printGasUsage) {
+            console.log("\ngetFutureTotalStake(): %s   Gas used: %s", totalStake, gasBefore - gasleft());
         }
-        assertEq(total_stake, expected_amount);
+        assertEq(totalStake, expectedAmount);
     }
 
-    function getStakersData(bytes[] memory expected_stakerKeys, uint256[] memory expected_indices, uint256[] memory expected_balances, Staker[] memory expected_stakers) view public {
+    function checkGetStakerData(
+        bytes memory blsPubKey,
+        uint256 expectedIndex, 
+        uint256 expectedBalance
+        // Staker memory expectedStakers
+    ) public view {
         uint256 gasBefore = gasleft();
         (
-            bytes[] memory stakerKeys,
-            uint256[] memory indices,
-            uint256[] memory balances,
-            Staker[] memory stakers
-        ) = deposit_contract.getStakersData();
-        if (print_gas_usage) {
-            console.log("\ngetStakersData length: %s Gas used: %s", stakerKeys.length, gasBefore - gasleft());
+            uint256 index,
+            uint256 balance,
+            // Staker memory stakerData
+        ) = depositContract.getStakerData(blsPubKey);
+        if (printGasUsage) {
+            console.log("\ngetStakerData Gas used: %s", gasBefore - gasleft());
         }
-        for (uint256 i = 0; i < stakerKeys.length; i++) {
-            assertEq(stakerKeys[i], expected_stakerKeys[i]);
-            assertEq(indices[i], expected_indices[i]);
-            assertEq(balances[i], expected_balances[i]);
+        assertEq(index, expectedIndex);
+        assertEq(balance, expectedBalance);
+        // assertEq(stakerData[i], expectedStakers[i]);
+    }
 
-            // assertEq(stakers[i], expected_stakers[i]);
-            console.log("stakerKey");
-            console.logBytes(stakerKeys[i]);
-            console.log("indices %s", indices[i]);
-            console.log("balances %s", balances[i]);        
+    function checkGetStakerDataWithdrawals(
+        bytes memory blsPubKey,
+        uint256 withdrawals
+    ) public view {
+        uint256 gasBefore = gasleft();
+        (
+            ,
+            ,
+            Staker memory stakerData
+        ) = depositContract.getStakerData(blsPubKey);
+        if (printGasUsage) {
+            console.log("\ngetStakerData Gas used: %s", gasBefore - gasleft());
+        }
+        assertEq(stakerData.withdrawals.values.length, withdrawals);
+    }
+
+    // function checkGetStakersData(
+    //     bytes[] memory expected_stakerKeys, 
+    //     uint256[] memory expected_indices, 
+    //     uint256[] memory expectedBalances
+    //     // Staker[] memory expectedStakers
+    // ) public view {
+    //     uint256 gasBefore = gasleft();
+        // (
+        //     bytes[] memory stakerKeys,
+        //     uint256[] memory indices,
+        //     uint256[] memory balances,
+        //     // Staker[] memory stakerData
+        // ) = deposit_contract.getStakersData();
+        // if (print_gas_usage) {
+        //     console.log("\ngetStakersData length: %s Gas used: %s", stakerKeys.length, gasBefore - gasleft());
+        // }
+        // for (uint256 i = 0; i < stakerKeys.length; i++) {
+        //     assertEq(stakerKeys[i], expected_stakerKeys[i]);
+        //     assertEq(indices[i], expected_indices[i]);
+        //     assertEq(balances[i], expectedBalances[i]);
+
+        //     // assertEq(stakerData[i], expectedStakers[i]);
+        //     console.log("stakerKey");
+        //     console.logBytes(stakerKeys[i]);
+        //     console.log("indices %s", indices[i]);
+        //     console.log("balances %s", balances[i]);        
+        // }
+    // }
+
+    function deposit(uint ownerInt, uint amount) public {
+        vm.startPrank(owners[ownerInt]);
+        uint256 gasBefore = gasleft();
+        depositContract.deposit{
+            value: amount
+        }(
+            blsPubKeys[ownerInt],
+            peerId,
+            bytes(hex"90ec9a22e030a42d9b519b322d31b8090f796b3f75fc74261b04d0dcc632fd8c5b7a074c5ba61f0845b310fa9931d01c079eebe82813d7021ef4172e01a7d3710a5f9a4634e9a03a51e985836021c356a1eb476a14f558cbae1f4264edca5dac"),
+            address(stakers[ownerInt]),
+            address(stakers[ownerInt])
+        );
+        if (printGasUsage) {
+            console.log("\ndeposit owner%s. Amount: %s   Gas used: %s", ownerInt, amount, gasBefore - gasleft());
         }
     }
 
     function depositTopUp(uint ownerInt, uint amount) public {
-        address owner;
-        bytes memory blsPubKey;
-        if (ownerInt == 1) {
-            owner = owner1;
-            blsPubKey = blsPubKey1;
-        } else {
-            owner = owner2;
-            blsPubKey = blsPubKey2;
-        }
-        vm.startPrank(owner);
+        vm.startPrank(owners[ownerInt]);
         uint256 gasBefore = gasleft();
-        deposit_contract.depositTopup{
+        depositContract.depositTopup{
             value: amount
-        }(blsPubKey);
-        console.log("\ndepositTopUp owner%s. Amount: %s Gas used: %s", ownerInt, amount, gasBefore - gasleft());
-        vm.stopPrank();
+        }(blsPubKeys[ownerInt]);
+        if (printGasUsage) {
+            console.log("\ndepositTopUp owner%s. Amount: %s Gas used: %s", ownerInt, amount, gasBefore - gasleft());
+        }
+    }
+
+    function unstake(uint ownerInt, uint amount) public {
+        vm.startPrank(owners[ownerInt]);
+        uint256 gasBefore = gasleft();
+        depositContract.unstake(blsPubKeys[ownerInt], amount);
+        if (printGasUsage) {
+            console.log("\nunstake owner%s. Amount: %s Gas used: %s", ownerInt, amount, gasBefore - gasleft());
+        }
+    }
+
+    function withdraw(uint ownerInt, uint count) public {
+        vm.startPrank(owners[ownerInt]);
+        uint256 gasBefore = gasleft();
+        depositContract.withdraw(blsPubKeys[ownerInt], count);
+        if (printGasUsage) {
+            console.log("\nwithdraw owner%s. Count: %s Gas used: %s", ownerInt, count, gasBefore - gasleft());
+        }
     }
 }

--- a/zilliqa/src/contracts/tests/deposit.sol
+++ b/zilliqa/src/contracts/tests/deposit.sol
@@ -336,12 +336,14 @@ contract DepositTest is Test {
     function checkGetStakerData(
         bytes memory blsPubKey,
         uint256 expectedIndex,
-        uint256 expectedBalance
-    ) public view // Staker memory expectedStakers
-    {
+        uint256 expectedBalance // Staker memory expectedStakers
+    ) public view {
         uint256 gasBefore = gasleft();
-        (uint256 index, uint256 balance, ) = // Staker memory stakerData
-        depositContract.getStakerData(blsPubKey);
+        (
+            uint256 index,
+            uint256 balance, // Staker memory stakerData
+
+        ) = depositContract.getStakerData(blsPubKey);
         if (printGasUsage) {
             console.log("\ngetStakerData Gas used: %s", gasBefore - gasleft());
         }

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -70,9 +70,9 @@ use zilliqa::{
         block_request_limit_default, eth_chain_id_default, failed_request_sleep_duration_default,
         genesis_fork_default, max_blocks_in_flight_default, max_rpc_response_size_default,
         scilla_address_default, scilla_ext_libs_path_default, scilla_stdlib_dir_default,
-        state_cache_size_default, state_rpc_limit_default, total_native_token_supply_default,
-        Amount, ApiServer, Checkpoint, ConsensusConfig, ContractUpgradesBlockHeights,
-        GenesisDeposit, NodeConfig,
+        staker_withdrawal_period_default, state_cache_size_default, state_rpc_limit_default,
+        total_native_token_supply_default, Amount, ApiServer, Checkpoint, ConsensusConfig,
+        ContractUpgradesBlockHeights, GenesisDeposit, NodeConfig,
     },
     crypto::{SecretKey, TransactionPublicKey},
     db,
@@ -329,14 +329,13 @@ impl Network {
             })
             .collect();
 
-        let contract_upgrade_block_heights = ContractUpgradesBlockHeights {
-            deposit_v3: deposit_v3_upgrade_block_height,
-            deposit_v4: None,
-        };
+        let contract_upgrade_block_heights =
+            ContractUpgradesBlockHeights::new(deposit_v3_upgrade_block_height, None, None);
 
         let config = NodeConfig {
             eth_chain_id: shard_id,
             consensus: ConsensusConfig {
+                staker_withdrawal_period: staker_withdrawal_period_default(),
                 genesis_deposits: genesis_deposits.clone(),
                 is_main: send_to_parent.is_none(),
                 consensus_timeout: Duration::from_secs(5),
@@ -467,10 +466,8 @@ impl Network {
     }
 
     pub fn add_node_with_options(&mut self, options: NewNodeOptions) -> usize {
-        let contract_upgrade_block_heights = ContractUpgradesBlockHeights {
-            deposit_v3: self.deposit_v3_upgrade_block_height,
-            deposit_v4: None,
-        };
+        let contract_upgrade_block_heights =
+            ContractUpgradesBlockHeights::new(self.deposit_v3_upgrade_block_height, None, None);
         let config = NodeConfig {
             eth_chain_id: self.shard_id,
             api_servers: vec![ApiServer {
@@ -483,6 +480,7 @@ impl Network {
             load_checkpoint: options.checkpoint.clone(),
             do_checkpoints: self.do_checkpoints,
             consensus: ConsensusConfig {
+                staker_withdrawal_period: staker_withdrawal_period_default(),
                 genesis_deposits: self.genesis_deposits.clone(),
                 is_main: self.is_main(),
                 consensus_timeout: Duration::from_secs(5),


### PR DESCRIPTION
Adds `deposit_v5` with `withdrawalPeriod` configurable via `reinitialize()`.

Deposit tests are a work-in-progress but largely complete.

 