### PR TITLE
Avoid mutating state if accounts have not been updated

### DIFF
--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -973,6 +973,7 @@ impl ActiveCall {
             self.state
                 .set_storage(self.sender, &name, &indices, convert(value)?)?;
         }
+        self.state.touch(self.sender);
 
         Ok(())
     }


### PR DESCRIPTION
When applying EVM state deltas, we use the 'touched' flag to track if an account has been updated by an executed transaction.

We also add a similar flag to Scilla state deltas for the same purpose.