### PR TITLE
Ensure state is correct in both EVM and Scilla environments

### DIFF
--- a/config-example.toml
+++ b/config-example.toml
@@ -58,5 +58,3 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 # Gas parameters
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
-
-consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false }

--- a/config-single-node.toml
+++ b/config-single-node.toml
@@ -28,5 +28,3 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
 consensus.local_address = "host.docker.internal"
-
-consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true }

--- a/z2/resources/chain-specs/zq2-protomainnet.toml
+++ b/z2/resources/chain-specs/zq2-protomainnet.toml
@@ -23,7 +23,7 @@ consensus.scilla_call_gas_exempt_addrs = ["0x95347b860Bd49818AFAccCA8403C55C23e7
 consensus.contract_upgrade_block_heights = { deposit_v3 = 5342400, deposit_v4 = 7966800 }
 
 api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
-consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false }
+consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false, scilla_call_respects_evm_state_changes = false }
 consensus.forks = [
     { at_height = 5342400, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, call_mode_1_sets_caller_to_parent_caller = true },
     { at_height = 7685881, scilla_json_preserve_order = true },

--- a/z2/resources/chain-specs/zq2-prototestnet.toml
+++ b/z2/resources/chain-specs/zq2-prototestnet.toml
@@ -23,9 +23,10 @@ consensus.scilla_call_gas_exempt_addrs = ["0x60E6b5b1B8D3E373E1C04dC0b4f5624776b
 consensus.contract_upgrade_block_heights = { deposit_v3 = 8406000, deposit_v4 = 10890000 }
 
 api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
-consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false }
+consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false, scilla_call_respects_evm_state_changes = false }
 consensus.forks = [
     { at_height = 8404000, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, call_mode_1_sets_caller_to_parent_caller = true },
     { at_height = 10200000, scilla_messages_can_call_evm_contracts = true },
     { at_height = 11152000, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true },
+    { at_height = 12693600, scilla_call_respects_evm_state_changes = true },
 ]

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -192,7 +192,8 @@ impl Chain {
                 "failed_scilla_call_from_gas_exempt_caller_causes_revert": false,
                 "scilla_messages_can_call_evm_contracts": false,
                 "scilla_contract_creation_increments_account_balance": false,
-                "scilla_json_preserve_order": false
+                "scilla_json_preserve_order": false,
+                "scilla_call_respects_evm_state_changes": false,
             })),
             _ => None,
         }
@@ -207,6 +208,8 @@ impl Chain {
                 json!({ "at_height": 10200000, "scilla_messages_can_call_evm_contracts": true }),
                 // estimated: 2025-02-12T12:08:37Z
                 json!({ "at_height": 11152000, "scilla_contract_creation_increments_account_balance": true, "scilla_json_preserve_order": true }),
+                // estimated: 2025-03-07T12:35:25Z
+                json!({ "at_height": 12693600, "scilla_call_respects_evm_state_changes": true }),
             ]),
             Chain::Zq2ProtoMainnet => Some(vec![
                 // estimated: 2024-12-20T23:33:12Z

--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -68,12 +68,6 @@ fn process_empty(c: &mut Criterion) {
                 consensus.minimum_stake = "1"
                 consensus.eth_block_gas_limit = 1000000000
                 consensus.gas_price = "1"
-                consensus.genesis_fork.at_height = 0
-                consensus.genesis_fork.failed_scilla_call_from_gas_exempt_caller_causes_revert = true
-                consensus.genesis_fork.call_mode_1_sets_caller_to_parent_caller = true
-                consensus.genesis_fork.scilla_messages_can_call_evm_contracts = true
-                consensus.genesis_fork.scilla_contract_creation_increments_account_balance = true
-                consensus.genesis_fork.scilla_json_preserve_order = true
                 consensus.genesis_accounts = [
                     [
                         "0x0000000000000000000000000000000000000000",
@@ -194,12 +188,6 @@ fn consensus(
             consensus.minimum_stake = "1"
             consensus.eth_block_gas_limit = 84000000
             consensus.gas_price = "1"
-            consensus.genesis_fork.at_height = 0
-            consensus.genesis_fork.failed_scilla_call_from_gas_exempt_caller_causes_revert = true
-            consensus.genesis_fork.call_mode_1_sets_caller_to_parent_caller = true
-            consensus.genesis_fork.scilla_messages_can_call_evm_contracts = true
-            consensus.genesis_fork.scilla_contract_creation_increments_account_balance = true
-            consensus.genesis_fork.scilla_json_preserve_order = true
         "#,
     )
     .unwrap();

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -502,6 +502,7 @@ pub struct Fork {
     pub scilla_messages_can_call_evm_contracts: bool,
     pub scilla_contract_creation_increments_account_balance: bool,
     pub scilla_json_preserve_order: bool,
+    pub scilla_call_respects_evm_state_changes: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize)]
@@ -529,8 +530,14 @@ pub struct ForkDelta {
     /// the contract balance will be sum of the existing balance and the amount sent in the deployment transaction.
     /// If false, the contract balance will be the amount sent in the deployment transaction.
     pub scilla_contract_creation_increments_account_balance: Option<bool>,
-    // If true then the compiled code is using serde_json with feature "preserve_order"
+    /// If true, JSON maps that are passed to Scilla will be in their original order. If false, the entries will be
+    /// sorted by their keys.
     pub scilla_json_preserve_order: Option<bool>,
+    /// If true, interop calls to the `scilla_call` precompile will correctly see state changes already made by the EVM
+    /// before that point in the transaction's execution. Also both Scilla and EVM will be able to update the same
+    /// accounts without state changes being lost. If false, state changes can be lost if Scilla and EVM attempt to
+    /// update the same account. This can sometimes lead to mined transactions which don't increase the caller's nonce.
+    pub scilla_call_respects_evm_state_changes: Option<bool>,
 }
 
 impl Fork {
@@ -552,6 +559,9 @@ impl Fork {
             scilla_json_preserve_order: delta
                 .scilla_json_preserve_order
                 .unwrap_or(self.scilla_json_preserve_order),
+            scilla_call_respects_evm_state_changes: delta
+                .scilla_call_respects_evm_state_changes
+                .unwrap_or(self.scilla_call_respects_evm_state_changes),
         }
     }
 }
@@ -625,6 +635,7 @@ pub fn genesis_fork_default() -> Fork {
         scilla_messages_can_call_evm_contracts: true,
         scilla_contract_creation_increments_account_balance: true,
         scilla_json_preserve_order: true,
+        scilla_call_respects_evm_state_changes: true,
     }
 }
 
@@ -705,6 +716,7 @@ mod tests {
                 scilla_messages_can_call_evm_contracts: None,
                 scilla_contract_creation_increments_account_balance: Some(false),
                 scilla_json_preserve_order: None,
+                scilla_call_respects_evm_state_changes: None,
             }],
             ..Default::default()
         };
@@ -733,6 +745,7 @@ mod tests {
                     scilla_messages_can_call_evm_contracts: Some(true),
                     scilla_contract_creation_increments_account_balance: None,
                     scilla_json_preserve_order: Some(true),
+                    scilla_call_respects_evm_state_changes: None,
                 },
                 ForkDelta {
                     at_height: 20,
@@ -741,6 +754,7 @@ mod tests {
                     scilla_messages_can_call_evm_contracts: Some(false),
                     scilla_contract_creation_increments_account_balance: Some(true),
                     scilla_json_preserve_order: Some(true),
+                    scilla_call_respects_evm_state_changes: None,
                 },
             ],
             ..Default::default()
@@ -783,6 +797,7 @@ mod tests {
                     scilla_messages_can_call_evm_contracts: None,
                     scilla_contract_creation_increments_account_balance: None,
                     scilla_json_preserve_order: None,
+                    scilla_call_respects_evm_state_changes: None,
                 },
                 ForkDelta {
                     at_height: 10,
@@ -791,6 +806,7 @@ mod tests {
                     scilla_messages_can_call_evm_contracts: None,
                     scilla_contract_creation_increments_account_balance: None,
                     scilla_json_preserve_order: None,
+                    scilla_call_respects_evm_state_changes: None,
                 },
             ],
             ..Default::default()
@@ -824,6 +840,7 @@ mod tests {
                 scilla_messages_can_call_evm_contracts: true,
                 scilla_contract_creation_increments_account_balance: true,
                 scilla_json_preserve_order: true,
+                scilla_call_respects_evm_state_changes: true,
             },
             forks: vec![],
             ..Default::default()
@@ -845,6 +862,7 @@ mod tests {
                     scilla_messages_can_call_evm_contracts: None,
                     scilla_contract_creation_increments_account_balance: None,
                     scilla_json_preserve_order: None,
+                    scilla_call_respects_evm_state_changes: None,
                 },
                 ForkDelta {
                     at_height: 20,
@@ -853,6 +871,7 @@ mod tests {
                     scilla_messages_can_call_evm_contracts: None,
                     scilla_contract_creation_increments_account_balance: None,
                     scilla_json_preserve_order: None,
+                    scilla_call_respects_evm_state_changes: None,
                 },
             ],
             ..Default::default()

--- a/zilliqa/src/precompiles/scilla.rs
+++ b/zilliqa/src/precompiles/scilla.rs
@@ -584,9 +584,13 @@ fn scilla_call_precompile<I: ScillaInspector>(
 
     let empty_state = PendingState::new(evmctx.db.pre_state.clone());
     // Temporarily move the `PendingState` out of `evmctx`, replacing it with an empty state.
-    let state = std::mem::replace(&mut evmctx.db, empty_state);
+    let mut state = std::mem::replace(&mut evmctx.db, empty_state);
+    let depth = evmctx.journaled_state.depth;
+    if external_context.fork.scilla_call_respects_evm_state_changes {
+        state.evm_state = Some(evmctx.journaled_state.clone());
+    }
     let scilla = evmctx.db.pre_state.scilla();
-    let Ok((result, state)) = scilla_call(
+    let Ok((result, mut state)) = scilla_call(
         state,
         scilla,
         evmctx.env.tx.caller,
@@ -596,7 +600,7 @@ fn scilla_call_precompile<I: ScillaInspector>(
                 .call_mode_1_sets_caller_to_parent_caller
             {
                 // Use the caller of the parent call-stack.
-                external_context.callers[evmctx.journaled_state.depth - 1]
+                external_context.callers[depth - 1]
             } else {
                 // Use the original transaction signer.
                 evmctx.env.tx.caller
@@ -622,6 +626,7 @@ fn scilla_call_precompile<I: ScillaInspector>(
     };
     trace!(?result, "scilla_call complete");
     if !&result.success {
+        evmctx.db = state;
         if result.errors.values().any(|errs| {
             errs.iter()
                 .any(|err| matches!(err, ScillaError::GasNotSufficient))
@@ -631,7 +636,25 @@ fn scilla_call_precompile<I: ScillaInspector>(
             return err("scilla call failed");
         }
     }
-    // Move the new state back into `evmctx`.
+    state.new_state.retain(|address, account| {
+        if !account.touched {
+            return true;
+        }
+        if !account.from_evm {
+            return true;
+        }
+
+        // Apply changes made to EVM accounts back to the EVM `JournaledState`.
+        let before = evmctx.journaled_state.state.get_mut(address).unwrap();
+
+        // The only thing that Scilla is able to update is the balance.
+        if before.info.balance.to::<u128>() != account.account.balance {
+            before.info.balance = account.account.balance.try_into().unwrap();
+            before.mark_touch();
+        }
+
+        false
+    });
     evmctx.db = state;
 
     for log in result.logs {

--- a/zilliqa/tests/it/contracts/ScillaInterop.sol
+++ b/zilliqa/tests/it/contracts/ScillaInterop.sol
@@ -12,11 +12,40 @@ library ScillaConnector {
      * @param target The address of the ZRC2 contract
      * @param tran_name The name of the function to call
      */
-    function call(address target, string memory tran_name) internal {
+    function callScilla(address target, string memory tran_name) internal {
         bytes memory encodedArgs = abi.encode(
             target,
             tran_name,
             CALL_SCILLA_WITH_THE_SAME_SENDER
+        );
+        uint256 argsLength = encodedArgs.length;
+
+        assembly {
+            let ok := call(
+                gas(),
+                SCILLA_CALL_PRECOMPILE_ADDRESS,
+                0,
+                add(encodedArgs, 0x20),
+                argsLength,
+                0x20,
+                0
+            )
+            if iszero(ok) {
+                revert(0, 0)
+            }
+        }
+    }
+
+    function callScilla(
+        address target,
+        string memory tran_name,
+        address arg1
+    ) internal {
+        bytes memory encodedArgs = abi.encode(
+            target,
+            tran_name,
+            CALL_SCILLA_WITH_THE_SAME_SENDER,
+            arg1
         );
         uint256 argsLength = encodedArgs.length;
 
@@ -43,7 +72,7 @@ library ScillaConnector {
      * @param arg1 The first argument to the function
      * @param arg2 The second argument to the function
      */
-    function call(
+    function callScilla(
         address target,
         string memory tran_name,
         address arg1,
@@ -81,7 +110,7 @@ library ScillaConnector {
      * @param arg1 The first argument to the function
      * @param arg2 The second argument to the function
      */
-    function callWithBadGas(
+    function callScillaWithBadGas(
         address target,
         string memory tran_name,
         address arg1,
@@ -120,7 +149,7 @@ library ScillaConnector {
      * @param arg2 The second argument to the function
      * @param arg3 The third argument to the function
      */
-    function call(
+    function callScilla(
         address target,
         string memory tran_name,
         address arg1,
@@ -348,7 +377,26 @@ contract ScillaInterop {
         address scillaContract,
         string memory transitionName
     ) public {
-        scillaContract.call(transitionName);
+        scillaContract.callScilla(transitionName);
+    }
+
+    function sendEtherThenCallScilla(
+        address recipient,
+        address scillaContract,
+        string memory transitionName,
+        address arg1
+    ) public payable {
+        (bool sent, ) = recipient.call{value: msg.value}("");
+        require(sent, "failed");
+        scillaContract.callScilla(transitionName, arg1);
+    }
+
+    function callScillaOneArg(
+        address scillaContract,
+        string memory transitionName,
+        address arg1
+    ) public {
+        scillaContract.callScilla(transitionName, arg1);
     }
 
     function callScilla(
@@ -358,7 +406,7 @@ contract ScillaInterop {
         address arg1,
         uint128 arg2
     ) public returns (uint128) {
-        scillaContract.call(transitionName, arg1, arg2);
+        scillaContract.callScilla(transitionName, arg1, arg2);
 
         return readMapUint128(scillaContract, varName, arg1);
     }
@@ -370,7 +418,7 @@ contract ScillaInterop {
         address arg1,
         uint128 arg2
     ) public returns (uint128) {
-        scillaContract.callWithBadGas(transitionName, arg1, arg2);
+        scillaContract.callScillaWithBadGas(transitionName, arg1, arg2);
 
         return readMapUint128(scillaContract, varName, arg1);
     }


### PR DESCRIPTION
When an interop. transaction is run, we need to be careful to keep track of state changes in both sides of the world.

This PR takes the approach of:
* Let `revm` keep track of EVM state changes as normal.
* When an interop call is made to the Scilla interpreter, we make sure any 'pending' changes from the EVM side are visible to the Scilla contract.
* When the Scilla call finishes, if any 'pending' EVM changes were modified further, we apply those changes to the EVM state journal before transferring control back to `revm`.

This ensures the state we read is consistent and that when we come to apply state delta updates, there is no overlap between the EVM and Scilla state maps.