### PR TITLE
chore: update protomainnet scilla json ordering hardfork height

### DIFF
--- a/z2/resources/chain-specs/zq2-protomainnet.toml
+++ b/z2/resources/chain-specs/zq2-protomainnet.toml
@@ -26,5 +26,6 @@ api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["bloc
 consensus.genesis_fork = { at_height = 0, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false }
 consensus.forks = [
     { at_height = 5342400, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, call_mode_1_sets_caller_to_parent_caller = true },
-    { at_height = 7966800, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true },
+    { at_height = 7685881, scilla_json_preserve_order = true },
+    { at_height = 7966800, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true },
 ]

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -211,8 +211,9 @@ impl Chain {
             Chain::Zq2ProtoMainnet => Some(vec![
                 // estimated: 2024-12-20T23:33:12Z
                 json!({ "at_height": 5342400, "failed_scilla_call_from_gas_exempt_caller_causes_revert": true, "call_mode_1_sets_caller_to_parent_caller": true }),
+                json!({ "at_height": 7685881, "scilla_json_preserve_order": true }),
                 // estimated: 2025-02-12T13:25:00Z
-                json!({ "at_height": 7966800, "scilla_messages_can_call_evm_contracts": true, "scilla_contract_creation_increments_account_balance": true, "scilla_json_preserve_order": true }),
+                json!({ "at_height": 7966800, "scilla_messages_can_call_evm_contracts": true, "scilla_contract_creation_increments_account_balance": true }),
             ]),
             _ => None,
         }


### PR DESCRIPTION
Running a sync revealed that the hardfork height was set too late. A scilla tx was executed in between `v0.6.0` being deployed and the hardfork at height `7966800`.