### PR TITLE
Sync at fork, and other fixes.

### DIFF
--- a/zilliqa/src/api/types/eth.rs
+++ b/zilliqa/src/api/types/eth.rs
@@ -477,7 +477,7 @@ pub struct SyncingMeta {
     #[serde(serialize_with = "hex")]
     pub retry_count: usize,
     #[serde(serialize_with = "hex")]
-    pub timeout_count: usize,
+    pub error_count: usize,
     #[serde(serialize_with = "hex")]
     pub active_sync_count: usize,
 }
@@ -491,7 +491,7 @@ pub struct SyncingStruct {
     pub current_block: u64,
     #[serde(serialize_with = "hex")]
     pub highest_block: u64,
-    pub status: SyncingMeta,
+    pub stats: SyncingMeta,
 }
 
 #[derive(Clone, Serialize)]

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -1095,6 +1095,17 @@ impl Db {
             .is_some())
     }
 
+    pub fn contains_canonical_block(&self, block_hash: &Hash) -> Result<bool> {
+        Ok(self
+            .db
+            .lock()
+            .unwrap()
+            .prepare_cached("SELECT 1 FROM blocks WHERE is_canonical = TRUE AND block_hash = ?1")?
+            .query_row([block_hash], |row| row.get::<_, i64>(0))
+            .optional()?
+            .is_some())
+    }
+
     fn make_view_range(row: &Row) -> rusqlite::Result<Range<u64>> {
         // Add one to end because the range returned from SQL is inclusive.
         let start: u64 = row.get(0)?;

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -944,10 +944,8 @@ impl Node {
             } else {
                 self.message_sender.broadcast_proposal(message)?;
             }
-        } else {
-            self.consensus.sync.sync_from_proposal(proposal)?;
         }
-
+        self.consensus.sync.sync_from_proposal(proposal)?;
         Ok(())
     }
 

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -384,7 +384,15 @@ impl P2pNode {
                             debug!(%from, %dest, %message, ?request_id, "sending direct message");
                             let id = format!("{:?}", request_id);
                             if from == dest {
-                                self.send_to(&topic.hash(), |c| c.requests.send((from, id, message, ResponseChannel::Local)))?;
+                                match message {
+                                    // Route sync messages as broadcast, to allow other requests to be prioritized.
+                                    ExternalMessage::InjectedProposal(_) => {
+                                        self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message)))?;
+                                    },
+                                    _ => {
+                                        self.send_to(&topic.hash(), |c| c.requests.send((from, id, message, ResponseChannel::Local)))?;
+                                    }
+                                };
                             } else {
                                 let libp2p_request_id = self.swarm.behaviour_mut().request_response.send_request(&dest, (shard_id, message));
                                 self.pending_requests.insert(libp2p_request_id, (shard_id, request_id));

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -681,12 +681,18 @@ impl Sync {
                 block_hash = meta.qc.block_hash;
                 block_num = meta.number;
             } else {
-                // If something does not match, do nothing and it will retry with another peer.
+                // If something does not match, restart from the last known segment.
+                // This is a safety mechanism to prevent a peer from sending us garbage.
                 tracing::error!(
                     "sync::DoMetadataResponse : unexpected metadata hash={block_hash} != {}, num={block_num} != {}",
                     meta.hash,
                     meta.number,
                 );
+                // Unless, it is the first segment, where it will restart the entire sync.
+                // https://github.com/Zilliqa/zq2/issues/2416
+                if self.db.count_sync_segments()? <= 1 {
+                    self.state = SyncState::Phase3; // flush, drop all segments, and restart
+                }
                 return Ok(());
             }
             if meta.hash == response.last().unwrap().header.hash {

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -243,7 +243,7 @@ impl Sync {
 
         match self.state {
             // Check if we are out of sync
-            SyncState::Phase0 if self.in_pipeline == 0 && self.in_flight.is_empty() => {
+            SyncState::Phase0 if self.in_pipeline == 0 => {
                 let parent_hash = self.recent_proposals.back().unwrap().header.qc.block_hash;
                 if !self.db.contains_canonical_block(&parent_hash)? {
                     self.active_sync_count = self.active_sync_count.saturating_add(1);
@@ -257,19 +257,15 @@ impl Sync {
                 }
             }
             // Continue phase 1, until we hit history/genesis.
-            SyncState::Phase1(_)
-                if self.in_pipeline < self.max_batch_size && self.in_flight.is_empty() =>
-            {
+            SyncState::Phase1(_) if self.in_pipeline < self.max_batch_size => {
                 self.request_missing_metadata(None)?;
             }
             // Continue phase 2, until we have all segments.
-            SyncState::Phase2(_)
-                if self.in_pipeline < self.max_blocks_in_flight && self.in_flight.is_empty() =>
-            {
+            SyncState::Phase2(_) if self.in_pipeline < self.max_blocks_in_flight => {
                 self.request_missing_blocks()?;
             }
             // Wait till 99% synced, zip it up!
-            SyncState::Phase3 if self.in_pipeline == 0 && self.in_flight.is_empty() => {
+            SyncState::Phase3 if self.in_pipeline == 0 => {
                 let ancestor_hash = self.recent_proposals.front().unwrap().header.qc.block_hash;
                 if self.db.contains_canonical_block(&ancestor_hash)? {
                     tracing::info!(

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1003,14 +1003,20 @@ impl Network {
                                     self.pending_responses
                                         .insert(response_channel.clone(), source);
 
-                                    inner
-                                        .handle_request(
-                                            source,
-                                            "(synthetic_id)",
-                                            external_message.clone(),
-                                            response_channel,
-                                        )
-                                        .unwrap();
+                                    match external_message {
+                                        // Re-route Injections from Requests to Broadcasts
+                                        ExternalMessage::InjectedProposal(_) => inner
+                                            .handle_broadcast(source, external_message.clone())
+                                            .unwrap(),
+                                        _ => inner
+                                            .handle_request(
+                                                source,
+                                                "(synthetic_id)",
+                                                external_message.clone(),
+                                                response_channel,
+                                            )
+                                            .unwrap(),
+                                    }
                                 }
                             });
                         }


### PR DESCRIPTION
1. Fixes the issue where, if an active-sync started on a losing branch of a fork, it may get stuck since all responses it receives are from the winning branch.
2. Fixes the issue where an active-sync might shoot past a checkpoint, by checking every single header downloaded against the blocks in the DB; and the first canonical block that hits the DB will turn the sync around.
3. Routes syncing blocks to lower-priority broadcast to avoid holding up the Requests queue with sync messages. Will hopefully reduce pressure on busy validators.
4. Minor fixes to syncing stats.