### PR TITLE
Fix default gas for `eth_estimateGas`

### DIFF
--- a/zilliqa/tests/it/staking.rs
+++ b/zilliqa/tests/it/staking.rs
@@ -61,6 +61,9 @@ async fn deposit_stake(
     let tx = TransactionRequest::new()
         .to(H160(contract_addr::DEPOSIT_PROXY.into_array()))
         .value(stake)
+        // Set a high gas limit manually, in case the gas estimate and transaction cross an epoch boundary, in which
+        // case our estimate will be incorrect.
+        .gas(5_000_000)
         .data(
             contracts::deposit::DEPOSIT
                 .encode_input(&[
@@ -111,6 +114,9 @@ async fn deposit_v3_stake(
     let tx = TransactionRequest::new()
         .to(H160(contract_addr::DEPOSIT_PROXY.into_array()))
         .value(stake)
+        // Set a high gas limit manually, in case the gas estimate and transaction cross an epoch boundary, in which
+        // case our estimate will be incorrect.
+        .gas(5_000_000)
         .data(
             contracts::deposit_v3::DEPOSIT
                 .encode_input(&[


### PR DESCRIPTION
In the old version, we would use a value of 5.5 million as the maximum possible gas that a transaction could use when estimating its actual usage. However, transactions can use more than this. The actual maximum is the block gas limit.

We instead use the minimum of the block gas limit and the maximum amount the caller could pay.

Fixes #2507, fixes #2508 
