### PR TITLE
feat: do not start Zilliqa node if Scilla server is not reachable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 FROM ubuntu:22.04
 
 RUN apt update -y && \
-    apt install -y build-essential libev-dev libgmp-dev
+    apt install -y build-essential libev-dev libgmp-dev curl
 
 COPY --chmod=777 ./infra/run.sh /run.sh
 COPY --from=builder /zilliqa/build/zilliqa /zilliqa

--- a/infra/run.sh
+++ b/infra/run.sh
@@ -4,6 +4,24 @@ trap 'kill $(jobs -p) 2>/dev/null' EXIT
 
 # Start Scilla server
 /scilla/0/bin/scilla-server-http --port=$1 &
+sleep 2
+
+# Confirm Scilla Server is responding at specified port 
+RETRY_COUNT=0
+RETRIES=5
+while [ $RETRY_COUNT -lt $RETRIES ]; do
+  if curl -s -H 'Content-Type: application/json' -X POST -d '{ "id": "1", "jsonrpc": "2.0", "method": "version", "params": [] }' http://localhost:$1/run | grep -q "scilla_version"; then
+    echo "Scilla server started successfully on port $1"
+    break
+  fi
+  RETRY_COUNT=$((RETRY_COUNT+1))
+  if [ $RETRY_COUNT -eq $RETRIES ]; then
+    echo "Error: Cannot connect to Scilla server at localhost:$1"
+    exit 1
+  fi
+  echo "Waiting for Scilla server to respond (attempt $RETRY_COUNT)..."
+  sleep 2
+done
 
 shift
 


### PR DESCRIPTION
Query Scilla Server before starting Zilliqa node.

I spent too long trying to get this to work without `curl` and without horribly complex bash. If the `curl` install is not acceptable then happy to try again.