### PR TITLE
fix: remove check for proposal view being more than head block's view

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -665,15 +665,6 @@ impl Consensus {
             return Ok(None);
         }
 
-        if block.view() <= head_block.header.view {
-            warn!(
-                "Rejecting block - view not greater than our current head block! {} vs {}",
-                block.view(),
-                head_block.header.view
-            );
-            return Ok(None);
-        }
-
         if block.gas_limit() > self.config.consensus.eth_block_gas_limit
             || block.gas_used() > block.gas_limit()
         {


### PR DESCRIPTION
See related issue for motivation.

This check feels incorrect - we should reject blocks whose view is less than our `finalised_view`, but a view less than head block's view is possible in fork scenarios. 

The check for less than `finalised_view` is performed already in `check_block()`.