### PR TITLE
Revert "Syncing leader must not propose. (#2450)"

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -452,10 +452,6 @@ impl Consensus {
         self.secret_key.node_public_key()
     }
 
-    pub fn has_early_proposal(&self) -> bool {
-        self.early_proposal.is_some()
-    }
-
     pub fn head_block(&self) -> Block {
         let highest_block_number = self
             .db
@@ -797,7 +793,12 @@ impl Consensus {
                     self.create_next_block_on_timeout = false;
                 }
                 if self.early_proposal.is_some() {
-                    self.recover_early_proposal()?;
+                    let (_, txns, _, _) = self.early_proposal.take().unwrap();
+                    for txn in txns.into_iter().rev() {
+                        self.transaction_pool.insert_ready_transaction(txn)?;
+                    }
+                    warn!("Early proposal exists but we are not leader. Clearing proposal");
+                    self.early_proposal = None;
                 }
 
                 let Some(next_leader) = next_leader else {
@@ -1122,7 +1123,10 @@ impl Consensus {
                 if current_view == 1 {
                     return self.propose_new_block();
                 }
-                return self.ready_for_block_proposal(None);
+
+                self.early_proposal_assemble_at(None)?;
+
+                return self.ready_for_block_proposal();
             }
         } else {
             self.votes.insert(
@@ -1131,7 +1135,7 @@ impl Consensus {
             );
         }
 
-        // Assemble early proposal now if it doesn't already exist
+        // Either way assemble early proposal now if it doesnt already exist
         self.early_proposal_assemble_at(None)?;
 
         Ok(None)
@@ -1237,66 +1241,16 @@ impl Consensus {
         state.set_to_root(previous_state_root_hash.into());
         self.state = state;
 
-        // In some cases, the Proposal is a fork and should be discarded/recovered.
-        if self.sync.am_syncing()? || proposal.view() < self.get_view()? {
-            tracing::warn!(sync = %self.sync.am_syncing()?, prop_view = %proposal.view(), high_view = %self.get_view()?,  "unable to finish proposal");
-            return Ok(None);
-        }
-
         // Return the final proposal
         Ok(Some(proposal))
     }
 
-    /// Recover early proposal
-    ///
-    /// In the event that an early proposal cannot be finalised, this function must be called to recover the transactions
-    /// and re-insert them into the transaction pool.
-    pub fn recover_early_proposal(&mut self) -> Result<()> {
-        if let Some((proposal, applied_txs, _, _)) = self.early_proposal.take() {
-            tracing::debug!(number = %proposal.number(), view = %proposal.view(), "recovering early proposal");
-            // intershard transactions are not meant to be broadcast
-            let (mut broadcasted_transactions, opaque_transactions): (Vec<_>, Vec<_>) = applied_txs
-                .clone()
-                .into_iter()
-                .partition(|tx| !matches!(tx.tx, SignedTransaction::Intershard { .. }));
-
-            // Recover the intershard transactions into the pool.
-            for tx in opaque_transactions {
-                let account_nonce = self.state.get_account(tx.signer)?.nonce;
-                self.transaction_pool.insert_transaction(tx, account_nonce);
-            }
-
-            // Recover the broadcast transactions into the pool.
-            while let Some(txn) = broadcasted_transactions.pop() {
-                self.transaction_pool.insert_ready_transaction(txn)?;
-            }
-        }
-        Ok(())
-    }
-
     /// Assembles the Proposal block early.
-    ///
     /// This is performed before the majority QC is available.
     /// It does all the needed work but with a dummy QC.
-    /// It does not assemble a proposal, if the node is out-of-sync
     fn early_proposal_assemble_at(&mut self, agg: Option<AggregateQc>) -> Result<()> {
         let view = self.get_view()?;
-        if self.early_proposal.is_some() {
-            if self.sync.am_syncing()? {
-                // fell out-of-sync; recover, do not propose
-                tracing::warn!("out-of-sync, recovering proposal");
-                self.recover_early_proposal()?;
-                return Ok(());
-            } else if self.early_proposal.as_ref().unwrap().0.view() != view {
-                // view changed; recover and rebuild early proposal
-                self.recover_early_proposal()?;
-            } else {
-                // Do nothing
-                return Ok(());
-            }
-        } else if self.sync.am_syncing()? {
-            // already out-of-sync, do not start early proposal
-            tracing::warn!("out-of-sync, skipping proposal");
+        if self.early_proposal.is_some() && self.early_proposal.as_ref().unwrap().0.view() == view {
             return Ok(());
         }
 
@@ -1517,17 +1471,11 @@ impl Consensus {
 
     /// Called when consensus will accept our early_block.
     /// Either propose now or set timeout to allow for txs to come in.
-    fn ready_for_block_proposal(
-        &mut self,
-        agg: Option<AggregateQc>,
-    ) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
-        self.early_proposal_assemble_at(agg)?;
-
+    fn ready_for_block_proposal(&mut self) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
         // Check if there's enough time to wait on a timeout and then propagate an empty block in the network before other participants trigger NewView
         let (milliseconds_since_last_view_change, milliseconds_remaining_of_block_time, _) =
             self.get_consensus_timeout_params()?;
 
-        // propose new block now, or later
         if milliseconds_remaining_of_block_time == 0 {
             return self.propose_new_block();
         }
@@ -1535,17 +1483,16 @@ impl Consensus {
         // Reset the timeout and wake up again once it has been at least `block_time` since
         // the last view change. At this point we should be ready to produce a new block.
         self.create_next_block_on_timeout = true;
-        let dur = self
-            .config
-            .consensus
-            .block_time
-            .saturating_sub(Duration::from_millis(milliseconds_since_last_view_change));
+        self.reset_timeout.send(
+            self.config
+                .consensus
+                .block_time
+                .saturating_sub(Duration::from_millis(milliseconds_since_last_view_change)),
+        )?;
         trace!(
-            "will propose new proposal on timeout for view {} in {:?}",
-            self.get_view()?,
-            dur
+            "will propose new proposal on timeout for view {}",
+            self.get_view()?
         );
-        self.reset_timeout.send(dur)?;
 
         Ok(None)
     }
@@ -1672,20 +1619,10 @@ impl Consensus {
     fn propose_new_block(&mut self) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
         // We expect early_proposal to exist already but try create incase it doesn't
         self.early_proposal_assemble_at(None)?;
-        let Some((pending_block, applied_txs, _, _)) = self.early_proposal.take() else {
-            tracing::warn!("out-of-sync, skipped proposal");
-            return Ok(None);
-        };
-
-        let Some(final_block) = self.early_proposal_finish_at(pending_block)? else {
-            // Do not broadcast Proposal, recover early proposal.
-            tracing::warn!("out-of-sync, dropping proposal");
-            self.recover_early_proposal()?;
-            return Ok(None);
-        };
+        let (pending_block, applied_txs, _, _) = self.early_proposal.take().unwrap(); // safe to unwrap due to check above
 
         // intershard transactions are not meant to be broadcast
-        let (broadcasted_transactions, opaque_transactions): (Vec<_>, Vec<_>) = applied_txs
+        let (mut broadcasted_transactions, opaque_transactions): (Vec<_>, Vec<_>) = applied_txs
             .clone()
             .into_iter()
             .partition(|tx| !matches!(tx.tx, SignedTransaction::Intershard { .. }));
@@ -1697,6 +1634,16 @@ impl Consensus {
             let account_nonce = self.state.get_account(tx.signer)?.nonce;
             self.transaction_pool.insert_transaction(tx, account_nonce);
         }
+
+        // finalise the proposal
+        let Some(final_block) = self.early_proposal_finish_at(pending_block)? else {
+            // Do not Propose.
+            // Recover the proposed transactions into the pool.
+            while let Some(txn) = broadcasted_transactions.pop() {
+                self.transaction_pool.insert_ready_transaction(txn)?;
+            }
+            return Ok(None);
+        };
 
         info!(proposal_hash = ?final_block.hash(), ?final_block.header.view, ?final_block.header.number, txns = final_block.transactions.len(), "######### proposing block");
 
@@ -1907,7 +1854,10 @@ impl Consensus {
                     );
 
                     // We now have a valid aggQC so can create early_block with it
-                    return self.ready_for_block_proposal(Some(agg));
+                    self.early_proposal_assemble_at(Some(agg))?;
+
+                    // as a future improvement, process the proposal before broadcasting it
+                    return self.ready_for_block_proposal();
 
                     // we don't want to keep the collected votes if we proposed a new block
                     // we should remove the collected votes if we couldn't reach supermajority within the view

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -661,6 +661,15 @@ impl Consensus {
             return Ok(None);
         }
 
+        if !during_sync && block.view() <= head_block.header.view {
+            warn!(
+                "Rejecting block - view not greater than our current head block! {} vs {}",
+                block.view(),
+                head_block.header.view
+            );
+            return Ok(None);
+        }
+
         if block.gas_limit() > self.config.consensus.eth_block_gas_limit
             || block.gas_used() > block.gas_limit()
         {

--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -276,12 +276,10 @@ pub enum ExternalMessage {
     Acknowledgement,
     /// The following are used for the new sync protocol
     InjectedProposal(InjectedProposal),
-    // 0.6.0
     MetaDataRequest(RequestBlocksByHeight),
     MetaDataResponse(Vec<BlockHeader>),
     MultiBlockRequest(Vec<Hash>),
     MultiBlockResponse(Vec<Proposal>),
-    // 0.7.0
     SyncBlockHeaders(Vec<SyncBlockHeader>),
 }
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -224,6 +224,11 @@ impl Node {
     pub fn handle_broadcast(&mut self, from: PeerId, message: ExternalMessage) -> Result<()> {
         debug!(%from, to = %self.peer_id, %message, "handling broadcast");
         match message {
+            // This just breaks down group block messages into individual messages to stop them blocking threads
+            // for long periods.
+            ExternalMessage::InjectedProposal(p) => {
+                self.handle_injected_proposal(from, p)?;
+            }
             // `NewTransaction`s are always broadcasted.
             ExternalMessage::NewTransaction(t) => {
                 // Don't process again txn sent by this node (it's already in the mempool)
@@ -315,11 +320,6 @@ impl Node {
                 // Acknowledge the proposal.
                 self.request_responses
                     .send((response_channel, ExternalMessage::Acknowledgement))?;
-            }
-            // This just breaks down group block messages into individual messages to stop them blocking threads
-            // for long periods.
-            ExternalMessage::InjectedProposal(p) => {
-                self.handle_injected_proposal(from, p)?;
             }
             msg => {
                 warn!(%msg, "unexpected message type");
@@ -945,12 +945,7 @@ impl Node {
                 self.message_sender.broadcast_proposal(message)?;
             }
         }
-        if self.consensus.sync.sync_from_proposal(proposal)? && self.consensus.has_early_proposal()
-        {
-            // Entered active-syncing after, early-proposal - recover
-            tracing::warn!("out-of-sync, proposal recovery");
-            self.consensus.recover_early_proposal()?;
-        }
+        self.consensus.sync.sync_from_proposal(proposal)?;
         Ok(())
     }
 

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -384,7 +384,15 @@ impl P2pNode {
                             debug!(%from, %dest, %message, ?request_id, "sending direct message");
                             let id = format!("{:?}", request_id);
                             if from == dest {
-                                self.send_to(&topic.hash(), |c| c.requests.send((from, id, message, ResponseChannel::Local)))?;
+                                match message {
+                                    // Route sync messages as broadcast, to allow other requests to be prioritized.
+                                    ExternalMessage::InjectedProposal(_) => {
+                                        self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message)))?;
+                                    },
+                                    _ => {
+                                        self.send_to(&topic.hash(), |c| c.requests.send((from, id, message, ResponseChannel::Local)))?;
+                                    }
+                                };
                             } else {
                                 let libp2p_request_id = self.swarm.behaviour_mut().request_response.send_request(&dest, (shard_id, message));
                                 self.pending_requests.insert(libp2p_request_id, (shard_id, request_id));

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1033,14 +1033,20 @@ impl Network {
                                     self.pending_responses
                                         .insert(response_channel.clone(), source);
 
-                                    inner
-                                        .handle_request(
-                                            source,
-                                            "(synthetic_id)",
-                                            external_message.clone(),
-                                            response_channel,
-                                        )
-                                        .unwrap();
+                                    match external_message {
+                                        // Re-route Injections from Requests to Broadcasts
+                                        ExternalMessage::InjectedProposal(_) => inner
+                                            .handle_broadcast(source, external_message.clone())
+                                            .unwrap(),
+                                        _ => inner
+                                            .handle_request(
+                                                source,
+                                                "(synthetic_id)",
+                                                external_message.clone(),
+                                                response_channel,
+                                            )
+                                            .unwrap(),
+                                    }
                                 }
                             });
                         }


### PR DESCRIPTION
This reverts commit 02890d0d76233199d1b27a6ae0da639c765ea6b7.

We suspect this may be causing the equivocation problems in proto-mainnet. We aren't completely sure it is the cause but @86667 and I are suspicious enough to think its worth trying.