### PR TITLE
Only inject newer blocks during Phase-3.

### DIFF
--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -1006,6 +1006,12 @@ impl Sync {
     pub fn mark_received_proposal(&mut self, number: u64) -> Result<()> {
         tracing::trace!(%number, "sync::MarkReceivedProposal : received");
         self.in_pipeline = self.in_pipeline.saturating_sub(1);
+        // speed-up block transfers, w/o waiting for proposals
+        if Self::DO_SPECULATIVE {
+            if let SyncState::Phase2(_) = self.state {
+                self.request_missing_blocks()?;
+            }
+        }
         Ok(())
     }
 

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -290,24 +290,24 @@ impl Sync {
         if !matches!(self.state, SyncState::Phase3) {
             anyhow::bail!("sync::RecentBlocks : invalid state");
         }
-        if !self.recent_proposals.is_empty() {
-            // Only inject recent proposals - https://github.com/Zilliqa/zq2/issues/2520
-            let highest_block = self
-                .db
-                .get_highest_recorded_block()?
-                .expect("db is not empty");
+        // Only inject recent proposals - https://github.com/Zilliqa/zq2/issues/2520
+        let highest_block = self
+            .db
+            .get_highest_recorded_block()?
+            .expect("db is not empty");
 
-            // drain, filter and sort cached-blocks.
-            let proposals = self
-                .recent_proposals
-                .drain(..)
-                .filter(|b| b.number() > highest_block.number()) // newer blocks
-                .sorted_by(|a, b| match b.number().cmp(&a.number()) {
-                    Ordering::Equal => b.header.timestamp.cmp(&a.header.timestamp),
-                    o => o,
-                }) // descending sort
-                .collect_vec();
+        // drain, filter and sort cached-blocks.
+        let proposals = self
+            .recent_proposals
+            .drain(..)
+            .filter(|b| b.number() > highest_block.number()) // newer blocks
+            .sorted_by(|a, b| match b.number().cmp(&a.number()) {
+                Ordering::Equal => b.header.timestamp.cmp(&a.header.timestamp),
+                o => o,
+            }) // descending sort
+            .collect_vec();
 
+        if !proposals.is_empty() {
             // extract chain segment, ascending order
             let mut hash = proposals.first().expect("contains newer blocks").hash();
             let mut proposals = proposals


### PR DESCRIPTION
This PR does 2 things:
1. Extracts a chain-segment from the cache-blocks during Phase-3, instead of blindly injecting everything, which can trigger forking issues not handled by `deal_with_fork()`.
2. Speeds-up Phase-2 by driving it even without Proposals.

It's currently deployed in `perftest`