### PR TITLE
feat: handle own proposals immediately rather than wait for the broadcast

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1739,7 +1739,7 @@ impl Consensus {
         &mut self,
         new_view: NewView,
     ) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
-        trace!("Received new view for height: {:?}", new_view.view);
+        trace!("Received new view for view: {:?}", new_view.view);
 
         // Get the committee for the qc hash (should be highest?) for this view
         let committee: Vec<_> = self.committee_for_hash(new_view.qc.block_hash)?;

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -72,9 +72,8 @@ use zilliqa::{
         Fork, GenesisDeposit, NodeConfig, allowed_timestamp_skew_default,
         block_request_batch_size_default, block_request_limit_default, eth_chain_id_default,
         failed_request_sleep_duration_default, genesis_fork_default, max_blocks_in_flight_default,
-        max_rpc_response_size_default, scilla_address_default, scilla_ext_libs_path_default,
-        scilla_stdlib_dir_default, state_cache_size_default, state_rpc_limit_default,
-        total_native_token_supply_default, u64_max,
+        max_rpc_response_size_default, scilla_ext_libs_path_default, state_cache_size_default,
+        state_rpc_limit_default, total_native_token_supply_default, u64_max,
     },
     crypto::{SecretKey, TransactionPublicKey},
     db,
@@ -519,10 +518,10 @@ impl Network {
                 eth_block_gas_limit: EvmGas(84000000),
                 gas_price: 4_761_904_800_000u128.into(),
                 main_shard_id: None,
-                scilla_address: scilla_address_default(),
+                scilla_address: self.scilla_address.clone(),
                 blocks_per_epoch: self.blocks_per_epoch,
                 epochs_per_checkpoint: 1,
-                scilla_stdlib_dir: scilla_stdlib_dir_default(),
+                scilla_stdlib_dir: self.scilla_stdlib_dir.clone(),
                 scilla_ext_libs_path: scilla_ext_libs_path_default(),
                 total_native_token_supply: total_native_token_supply_default(),
                 contract_upgrades,
@@ -1452,7 +1451,7 @@ async fn fund_wallet(network: &mut Network, from_wallet: &Wallet, to_wallet: &Wa
         .await
         .unwrap()
         .tx_hash();
-    network.run_until_receipt(from_wallet, hash, 100).await;
+    network.run_until_receipt(to_wallet, hash, 100).await;
 }
 
 async fn get_reward_address(

--- a/zilliqa/tests/it/persistence.rs
+++ b/zilliqa/tests/it/persistence.rs
@@ -170,11 +170,11 @@ async fn checkpoints_test(mut network: Network) {
         .tx_hash();
     network.run_until_receipt(&wallet, update_tx_hash, 50).await;
     // Scilla
-    let (secret_key, address) = zilliqa_account(&mut network).await;
+    let (secret_key, address) = zilliqa_account(&mut network, &wallet).await;
     let code = scilla_test_contract_code();
     let data = scilla_test_contract_data(address);
     let scilla_contract_address =
-        deploy_scilla_contract(&mut network, &secret_key, &code, &data).await;
+        deploy_scilla_contract(&mut network, &wallet, &secret_key, &code, &data).await;
 
     // Run until block 9 so that we can insert a tx in block 10 (note that this transaction may not *always* appear in the desired block, therefore we do not assert its presence later)
     network.run_until_block(&wallet, 9.into(), 200).await;

--- a/zilliqa/tests/it/staking.rs
+++ b/zilliqa/tests/it/staking.rs
@@ -662,11 +662,9 @@ async fn validators_can_unstake(mut network: Network) {
     // unstake validator's entire stake
     let stake = get_stake(&wallet, &validator_blskey).await;
     let unstake_hash = unstake_amount(&mut network, &validator_control_wallet, stake).await;
-    let unstake_block = wallet
-        .get_transaction_receipt(unstake_hash)
+    let unstake_block = network
+        .run_until_receipt(&wallet, unstake_hash, 100)
         .await
-        .unwrap()
-        .unwrap()
         .block_number
         .unwrap()
         .as_u64();


### PR DESCRIPTION
When a node is leader and receiving `NewView` messages it is possible that it sends two different `Proposal` messages. 

The reason this happens is that we do not execute our own proposals until they are delivered back to us via the broadcast mechanism, leaving an amount of time between broadcast and processing to re-gather repeated `NewView` messages and send off another proposal. 

I have opted to resolve this by executing our own proposals immediately after broadcasting them so that our `tip_info` is updated before any other work is done and thus any other messages for the view in which we proposed are ignored. 