### PR TITLE
Move sync data from SQL to in-memory

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -6,14 +6,13 @@ use std::{
     ops::{Range, RangeInclusive},
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use alloy::primitives::Address;
 use anyhow::{Context, Result, anyhow};
 use eth_trie::{DB, EthTrie, MemoryDB, Trie};
 use itertools::Itertools;
-use libp2p::PeerId;
 use lru_mem::LruCache;
 use lz4::{Decoder, EncoderBuilder};
 use rusqlite::{
@@ -28,7 +27,6 @@ use crate::{
     exec::{ScillaError, ScillaException, ScillaTransition},
     message::{AggregateQc, Block, BlockHeader, QuorumCertificate},
     state::Account,
-    sync::PeerInfo,
     time::SystemTime,
     transaction::{EvmGas, Log, SignedTransaction, TransactionReceipt},
 };
@@ -337,18 +335,6 @@ impl Db {
             CREATE TABLE IF NOT EXISTS state_trie (key BLOB NOT NULL PRIMARY KEY, value BLOB NOT NULL) WITHOUT ROWID;
             ",
         )?;
-        connection.execute_batch(
-            "CREATE TEMP TABLE IF NOT EXISTS sync_metadata (
-            block_hash BLOB NOT NULL UNIQUE,
-            parent_hash BLOB NOT NULL,
-            block_number INTEGER NOT NULL PRIMARY KEY,
-            version INTEGER DEFAULT 0,
-            peer BLOB DEFAULT NULL,
-            rawdata BLOB NOT NULL
-        );
-        CREATE INDEX IF NOT EXISTS idx_sync_metadata ON sync_metadata(block_number) WHERE peer IS NOT NULL;",
-        )?;
-
         Ok(())
     }
 
@@ -361,161 +347,6 @@ impl Db {
             return Ok(None);
         };
         Ok(Some(base_path.join("checkpoints").into_boxed_path()))
-    }
-
-    /// Returns the lowest block number of stored sync segments
-    pub fn last_sync_block_number(&self) -> Result<u64> {
-        Ok(self
-            .db
-            .lock()
-            .unwrap()
-            .prepare_cached("SELECT MIN(block_number) FROM sync_metadata")?
-            .query_row([], |row| row.get(0))
-            .unwrap_or_default())
-    }
-
-    /// Returns the number of stored sync segments
-    pub fn count_sync_segments(&self) -> Result<usize> {
-        Ok(self
-            .db
-            .lock()
-            .unwrap()
-            .prepare_cached("SELECT COUNT(block_number) FROM sync_metadata WHERE peer IS NOT NULL")?
-            .query_row([], |row| row.get(0))
-            .optional()?
-            .unwrap_or_default())
-    }
-
-    /// Checks if the stored metadata exists
-    pub fn contains_sync_metadata(&self, block_hash: &Hash) -> Result<bool> {
-        Ok(self
-            .db
-            .lock()
-            .unwrap()
-            .prepare_cached("SELECT parent_hash FROM sync_metadata WHERE block_hash = ?1")?
-            .query_row([block_hash], |row| row.get::<_, Hash>(0))
-            .optional()?
-            .is_some())
-    }
-
-    /// Retrieves bulk metadata information from the given block_hash (inclusive)
-    pub fn get_sync_segment(&self, hash: Hash) -> Result<Vec<Hash>> {
-        let db = self.db.lock().unwrap();
-
-        let mut hashes = Vec::new();
-        let mut block_hash = hash;
-
-        while let Some(parent_hash) = db
-            .prepare_cached("SELECT parent_hash FROM sync_metadata WHERE block_hash = ?1")?
-            .query_row([block_hash], |row| row.get::<_, Hash>(0))
-            .optional()?
-        {
-            hashes.push(block_hash);
-            block_hash = parent_hash;
-        }
-        Ok(hashes)
-    }
-
-    /// Peeks into the top of the segment stack.
-    pub fn last_sync_segment(&self) -> Result<Option<(BlockHeader, PeerInfo)>> {
-        let db = self.db.lock().unwrap();
-        let r = db.prepare_cached("SELECT rawdata, version, peer FROM sync_metadata WHERE peer IS NOT NULL ORDER BY block_number ASC LIMIT 1")?
-        .query_row([], |row| Ok((
-            serde_json::from_slice(row.get::<_,Vec<u8>>(0)?.as_slice()).unwrap(),
-        PeerInfo {
-            last_used: Instant::now(),
-            score: u32::MAX,
-            version: row.get(1)?,
-            peer_id: PeerId::from_bytes(row.get::<_,Vec<u8>>(2)?.as_slice()).unwrap(),
-        }))).optional()?;
-        Ok(r)
-    }
-
-    /// Pushes a particular segment into the stack.
-    pub fn push_sync_segment(&self, peer: &PeerInfo, meta: &BlockHeader) -> Result<()> {
-        let db = self.db.lock().unwrap();
-        db.prepare_cached(
-                "INSERT OR REPLACE INTO sync_metadata (parent_hash, block_hash, block_number, version, peer, rawdata) VALUES (:parent_hash, :block_hash, :block_number, :version, :peer, :rawdata)")?
-                .execute(
-                named_params! {
-                    ":parent_hash": meta.qc.block_hash,
-                    ":block_hash": meta.hash,
-                    ":block_number": meta.number,
-                    ":peer": peer.peer_id.to_bytes(),
-                    ":version": peer.version,
-                    ":rawdata": serde_json::to_vec(&meta).unwrap(),
-                },
-            )?;
-        Ok(())
-    }
-
-    /// Bulk inserts a bunch of metadata.
-    pub fn insert_sync_metadata(&self, metas: &Vec<BlockHeader>) -> Result<()> {
-        let mut db = self.db.lock().unwrap();
-        let tx = db.transaction()?;
-
-        for meta in metas {
-            tx.prepare_cached(
-                "INSERT OR REPLACE INTO sync_metadata (parent_hash, block_hash, block_number, rawdata) VALUES (:parent_hash, :block_hash, :block_number, :rawdata)")?
-                .execute(
-                named_params! {
-                    ":parent_hash": meta.qc.block_hash,
-                    ":block_hash": meta.hash,
-                    ":block_number": meta.number,
-                    ":rawdata": serde_json::to_vec(meta).unwrap(),
-            })?;
-        }
-        tx.commit()?;
-        Ok(())
-    }
-
-    /// Empty the metadata table.
-    pub fn empty_sync_metadata(&self) -> Result<()> {
-        self.db
-            .lock()
-            .unwrap()
-            .execute("DELETE FROM sync_metadata", [])?;
-        Ok(())
-    }
-
-    /// Pops a segment from the stack; and bulk removes all metadata associated with it.
-    pub fn pop_sync_segment(&self) -> Result<()> {
-        let mut db = self.db.lock().unwrap();
-        let c = db.transaction()?;
-
-        if let Some(block_hash) = c.prepare_cached("SELECT block_hash FROM sync_metadata WHERE peer IS NOT NULL ORDER BY block_number ASC LIMIT 1")?
-        .query_row([], |row| row.get::<_,Hash>(0)).optional()? {
-            if let Some(parent_hash) = c.prepare_cached("SELECT parent_hash FROM sync_metadata WHERE block_hash = ?1")?
-            .query_row([block_hash], |row| row.get(0)).optional()? {
-
-            // update marker
-            c.prepare_cached(
-                "UPDATE sync_metadata SET peer = NULL WHERE block_hash = ?1")?
-                .execute(
-                [block_hash]
-            )?;
-
-            // remove segment                
-            let mut hashes = Vec::new();
-            let mut block_hash = parent_hash;
-            while let Some(parent_hash) = c
-                    .prepare_cached("SELECT parent_hash FROM sync_metadata WHERE block_hash = ?1")?
-                    .query_row([block_hash], |row| row.get::<_, Hash>(0))
-                    .optional()?
-                {
-                    hashes.push(block_hash);
-                    block_hash = parent_hash;
-                }
-
-            for hash in hashes {
-                c.prepare_cached("DELETE FROM sync_metadata WHERE block_hash = ?1")?
-                .execute([hash])?;
-            }
-            }
-        }
-
-        c.commit()?;
-        Ok(())
     }
 
     /// Returns the lowest and highest block numbers of stored blocks

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -1356,9 +1356,7 @@ impl SyncSegments {
 
     /// Peeks into the top of the segment stack.
     fn last_sync_segment(&self) -> Option<(BlockHeader, PeerInfo)> {
-        let Some((hash, peer)) = self.segments.last() else {
-            return None;
-        };
+        let (hash, peer) = self.segments.last()?;
         let header = self.headers.get(hash).cloned()?;
         let peer = PeerInfo {
             last_used: Instant::now(),
@@ -1370,14 +1368,14 @@ impl SyncSegments {
 
     /// Pushes a particular segment into the stack.
     fn push_sync_segment(&mut self, peer: &PeerInfo, meta: &BlockHeader) {
-        self.headers.insert(meta.hash, meta.clone());
+        self.headers.insert(meta.hash, *meta);
         self.segments.push((meta.hash, peer.clone()));
     }
 
     /// Bulk inserts a bunch of metadata.
     fn insert_sync_metadata(&mut self, metas: &Vec<BlockHeader>) {
         for meta in metas {
-            self.headers.insert(meta.hash, meta.clone());
+            self.headers.insert(meta.hash, *meta);
         }
     }
 


### PR DESCRIPTION
This PR:
1. Moves the syncing metadata functionality from SQL/DB into in-memory structures; and
2. Minor change from Range to RangeInclusive that is semantically correct.