### PR TITLE
Don't recreate transaction pool while handling forks

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2794,15 +2794,6 @@ impl Consensus {
             self.state
                 .set_to_root(parent_block.state_root_hash().into());
 
-            // Ensure the transaction pool is consistent by recreating it. This is moderately costly, but forks are
-            // rare.
-            let existing_txns = self.transaction_pool.drain();
-
-            for txn in existing_txns {
-                let account_nonce = self.state.get_account(txn.signer)?.nonce;
-                self.transaction_pool.insert_transaction(txn, account_nonce);
-            }
-
             // block transactions need to be removed from self.transactions and re-injected
             for tx_hash in &head_block.transactions {
                 let orig_tx = self.get_transaction_by_hash(*tx_hash)?.unwrap();

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -419,13 +419,6 @@ impl TransactionPool {
         }
     }
 
-    /// Clear the transaction pool, returning all remaining transactions in an unspecified order.
-    pub fn drain(&mut self) -> impl Iterator<Item = VerifiedTransaction> + use<> {
-        self.hash_to_index.clear();
-        self.gas_index.clear();
-        std::mem::take(&mut self.transactions).into_values()
-    }
-
     /// Check the ready transactions in arbitrary order, for one that is Ready
     pub fn has_txn_ready(&self) -> bool {
         !self.gas_index.is_empty()


### PR DESCRIPTION
It no longer makes sense to recreate transaction pool during forks because the proper order of gas and nonce indexes is already preserved (when we moved from binary heap to maps). This should help with dealing with forks in case the pool already contained many transactions.  