### PR TITLE
feat: DEVOPS-1908 excluding unused metrics in the prometheus exporters

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -502,7 +502,12 @@ start() {
     docker rm node-exporter-""" + VERSIONS.get('node_exporter') + """ &> /dev/null || echo 0
     docker run -td -p 9100:9100 --name node-exporter-""" + VERSIONS.get('node_exporter') + """ \
         --net=host --restart=unless-stopped --pull=always \
-        ${NODE_EXPORTER_IMAGE} &> /dev/null &
+        ${NODE_EXPORTER_IMAGE} \
+        --collector.disable-defaults \
+        --collector.cpu \
+        --collector.meminfo \
+        --collector.filesystem \
+        &> /dev/null &
 }
 
 stop() {
@@ -632,6 +637,10 @@ metrics:
             scrape_interval: 30s
             static_configs:
               - targets: ['localhost:9256']
+            metric_relabel_configs:
+              - source_labels: [__name__]
+                regex: 'namedprocess_namegroup_cpu_seconds_total'
+                action: keep
   service:
     log_level: info
     pipelines:


### PR DESCRIPTION
- For node-exporter metrics, removing all defaults and keeping cpu, meminfo and filesystem.
- For process-exporter metrics, publish only the used namedprocess_namegroup_cpu_seconds_total.
- Tested in devnet, will deploy in the next environments after merged.
- There is a possibility we could reduce as well eventually more node-exporter specific metrics.