### PR TITLE
Gracefully handle situations where our high QC is dangling

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -232,7 +232,7 @@ impl Consensus {
 
         let (start_view, finalized_view, high_qc) = {
             match db.get_high_qc()? {
-                Some(mut qc) => {
+                Some(qc) => {
                     let high_block = db
                         .get_block_by_hash(&qc.block_hash)?
                         .ok_or_else(|| anyhow!("missing block that high QC points to!"))?;
@@ -282,8 +282,8 @@ impl Consensus {
                             trace!("recovery: stored block {0} reverted", head_block.number());
                             db.remove_transactions_executed_in_block(&head_block.hash())?;
                             db.remove_block(&head_block)?;
-                            db.set_high_qc(head_block.header.qc)?;
-                            qc = head_block.header.qc;
+                            // Note that we don't update our `high_qc`, meaning it may be left pointing to a block
+                            // we've removed. Other bits of code are expected to handle this situation gracefully.
                         } else {
                             break;
                         }
@@ -421,10 +421,11 @@ impl Consensus {
     /// Build NewView message for this view
     fn build_new_view(&mut self) -> Result<NetworkMessage> {
         let view = self.get_view()?;
-        let block = self.get_block(&self.high_qc.block_hash)?.ok_or_else(|| {
-            anyhow!("missing block corresponding to our high qc - this should never happen")
-        })?;
-        let leader = self.leader_at_block(&block, view);
+        // If we don't have the block corresponding to our high QC, we broadcast the `NewView`, since we don't know who
+        // the view's leader is.
+        let leader = self
+            .get_block(&self.high_qc.block_hash)?
+            .and_then(|block| self.leader_at_block(&block, view));
         let new_view_message = (
             leader.map(|leader: Validator| leader.peer_id),
             ExternalMessage::NewView(Box::new(NewView::new(
@@ -566,26 +567,26 @@ impl Consensus {
             self.head_block().hash()
         );
 
-        let block = self.get_block(&self.high_qc.block_hash)?.ok_or_else(|| {
-            anyhow!("missing block corresponding to our high qc - this should never happen")
-        })?;
-
-        // Get the list of stakers for the next block.
-        let next_block_header = BlockHeader {
-            number: block.number() + 1,
-            ..block.header
-        };
-        let stakers = self
-            .state
-            .at_root(block.state_root_hash().into())
-            .get_stakers(next_block_header)?;
-        if !stakers.iter().any(|v| *v == self.public_key()) {
-            debug!(
-                "can't vote for new view, we aren't in the committee of length {:?}",
-                stakers.len()
-            );
-            return Ok(None);
+        if let Some(block) = self.get_block(&self.high_qc.block_hash)? {
+            // Get the list of stakers for the next block.
+            let next_block_header = BlockHeader {
+                number: block.number() + 1,
+                ..block.header
+            };
+            let stakers = self
+                .state
+                .at_root(block.state_root_hash().into())
+                .get_stakers(next_block_header)?;
+            if !stakers.iter().any(|v| *v == self.public_key()) {
+                debug!(
+                    "can't vote for new view, we aren't in the committee of length {:?}",
+                    stakers.len()
+                );
+                return Ok(None);
+            }
         }
+        // If we don't have the block corresponding to our high QC, we still proceed with a view change and send a
+        // `NewView`.
 
         let next_view = view + 1;
         let next_exponential_backoff_timeout = self.exponential_backoff_timeout(next_view);


### PR DESCRIPTION
Previously, when deleting unfinalized blocks on startup, we would update our high QC to ensure it was always pointing to a block we had stored. However, this causes restarted nodes to get far out-of-sync with the network with no easy way of recovering.

Instead, we let the high QC be dangling and handle the situations where it does not point to a block more gracefully:

* If we are building a `NewView`, we cannot work out the leader of the view so we unconditionally broadcast the `NewView` message.
* If we reach the next exponential timeout period, we cannot tell if we are in the current consnesus committee, so we unconditionally assume we are and send a `NewView`.