### PR TITLE
Prevent equivocation by storing `voted_in_view` flag

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -236,11 +236,6 @@ impl Consensus {
                     let finalized_view = db
                         .get_finalized_view()?
                         .ok_or_else(|| anyhow!("missing latest finalized view!"))?;
-                    let finalized_block = db
-                        .get_block_by_view(finalized_view)?
-                        .ok_or_else(|| anyhow!("missing finalized block!"))?;
-
-                    state.set_to_root(finalized_block.header.state_root_hash.into());
 
                     // If latest view was written to disk then always start from there. Otherwise start from finalised view + 1
                     let start_view = db


### PR DESCRIPTION
If this flag is set in the database, we know we may have already voted for a proposal in our current view and thus can't send a `NewView` in the same view.