### PR TITLE
#2578 improved pruning config

### DIFF
--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -552,7 +552,7 @@ impl Setup {
                 failed_request_sleep_duration: failed_request_sleep_duration_default(),
                 enable_ots_indices: false,
                 max_rpc_response_size: max_rpc_response_size_default(),
-                prune_interval: cfg::u64_max(),
+                prune_interval: None,
             };
             println!("🧩  Node {node_index} has RPC port {port}");
 

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -160,8 +160,7 @@ pub struct NodeConfig {
     #[serde(default = "max_rpc_response_size_default")]
     pub max_rpc_response_size: u32,
     /// The N number of historical blocks to be kept in the DB during pruning. N > 30.
-    #[serde(default = "u64_max")]
-    pub prune_interval: u64,
+    pub prune_interval: Option<u64>,
 }
 
 impl Default for NodeConfig {
@@ -182,7 +181,7 @@ impl Default for NodeConfig {
             failed_request_sleep_duration: failed_request_sleep_duration_default(),
             enable_ots_indices: false,
             max_rpc_response_size: max_rpc_response_size_default(),
-            prune_interval: u64_max(),
+            prune_interval: None,
         }
     }
 }
@@ -205,7 +204,7 @@ impl NodeConfig {
         }
 
         // when set, >> 15 to avoid pruning forks; > 256 to be EVM-safe; arbitrarily picked.
-        if self.prune_interval < 300 {
+        if self.prune_interval.is_some_and(|x| x < 300) {
             return Err(anyhow!("prune_interval must be at least 300",));
         }
         Ok(())

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -396,7 +396,7 @@ impl Network {
             failed_request_sleep_duration: failed_request_sleep_duration_default(),
             enable_ots_indices: true,
             max_rpc_response_size: max_rpc_response_size_default(),
-            prune_interval: u64_max(),
+            prune_interval: None,
         };
 
         let (nodes, external_receivers, local_receivers, request_response_receivers): (
@@ -544,7 +544,7 @@ impl Network {
             failed_request_sleep_duration: failed_request_sleep_duration_default(),
             enable_ots_indices: true,
             max_rpc_response_size: max_rpc_response_size_default(),
-            prune_interval: options.prune_interval.unwrap_or(u64_max()),
+            prune_interval: Some(options.prune_interval.unwrap_or(u64_max())),
         };
 
         let secret_key = options.secret_key_or_random(self.rng.clone());


### PR DESCRIPTION
Fixes #2578 

(I believe that `consensus::network_can_die_restart` fails independent of this patch - eg. for seed 6601524667959767463 at 14ed53aedbce24ca087d62164d91c461f165194d  - and so does `persistence::checkpoints_test`)