### PR TITLE
refactor: Consistently return NetworkMessage back from consensus layer

### DIFF
--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -457,7 +457,7 @@ fn a_big_process_vote(big: &mut Consensus, vote: Vote, txns_per_block: usize) ->
     let proposal = big
         .vote(black_box(vote))
         .unwrap()
-        .map(|(b, t)| Proposal::from_parts(b, t));
+        .map(|(_, t)| t.into_proposal().unwrap());
     // The first vote should immediately result in a proposal. Subsequent views require a timeout before
     // the proposal is produced. Therefore, we trigger a timeout if there was not a proposal from the vote.
     let proposal = proposal.unwrap_or_else(|| {

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -474,15 +474,11 @@ impl Consensus {
             // Check if enough time elapsed to propose block
             if milliseconds_remaining_of_block_time == 0 {
                 match self.propose_new_block() {
-                    Ok(Some((block, transactions))) => {
+                    Ok(network_message) => {
                         self.create_next_block_on_timeout = false;
-                        return Ok(Some((
-                            None,
-                            ExternalMessage::Proposal(Proposal::from_parts(block, transactions)),
-                        )));
+                        return Ok(network_message);
                     }
                     Err(e) => error!("Failed to finalise proposal: {e}"),
-                    _ => {}
                 };
             } else {
                 self.reset_timeout
@@ -728,15 +724,12 @@ impl Consensus {
                 let count = buffered_votes.len();
                 for (i, vote) in buffered_votes.into_iter().enumerate() {
                     trace!("applying buffered vote {} of {count}", i + 1);
-                    if let Some((block, transactions)) = self.vote(vote)? {
+                    if let Some(network_message) = self.vote(vote)? {
                         // If we reached the supermajority while processing this vote, send the next block proposal.
                         // Further votes are ignored (including our own).
                         // TODO(#720): We should prioritise our own vote.
                         trace!("supermajority reached, sending next proposal");
-                        return Ok(Some((
-                            None,
-                            ExternalMessage::Proposal(Proposal::from_parts(block, transactions)),
-                        )));
+                        return Ok(Some(network_message));
                     }
                     // A bit hacky: processing of our buffered votes may have resulted in an early_proposal be created and awaiting empty block timeout for broadcast. In this case we must return now
                     if self.create_next_block_on_timeout
@@ -980,7 +973,7 @@ impl Consensus {
         Ok(())
     }
 
-    pub fn vote(&mut self, vote: Vote) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
+    pub fn vote(&mut self, vote: Vote) -> Result<Option<NetworkMessage>> {
         let block_hash = vote.block_hash;
         let block_view = vote.view;
         let current_view = self.get_view()?;
@@ -1460,7 +1453,7 @@ impl Consensus {
 
     /// Called when consensus will accept our early_block.
     /// Either propose now or set timeout to allow for txs to come in.
-    fn ready_for_block_proposal(&mut self) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
+    fn ready_for_block_proposal(&mut self) -> Result<Option<NetworkMessage>> {
         // Check if there's enough time to wait on a timeout and then propagate an empty block in the network before other participants trigger NewView
         let (milliseconds_since_last_view_change, milliseconds_remaining_of_block_time, _) =
             self.get_consensus_timeout_params()?;
@@ -1605,7 +1598,7 @@ impl Consensus {
 
     /// Produces the Proposal block.
     /// It must return a final Proposal with correct QC, regardless of whether it is empty or not.
-    fn propose_new_block(&mut self) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
+    fn propose_new_block(&mut self) -> Result<Option<NetworkMessage>> {
         // We expect early_proposal to exist already but try create incase it doesn't
         self.early_proposal_assemble_at(None)?;
         let (pending_block, applied_txs, _, _, cumulative_gas_fee) =
@@ -1638,7 +1631,10 @@ impl Consensus {
 
         info!(proposal_hash = ?final_block.hash(), ?final_block.header.view, ?final_block.header.number, txns = final_block.transactions.len(), "######### proposing block");
 
-        Ok(Some((final_block, broadcasted_transactions)))
+        Ok(Some((
+            None,
+            ExternalMessage::Proposal(Proposal::from_parts(final_block, broadcasted_transactions)),
+        )))
     }
 
     /// Insert transaction and add to early_proposal if possible.
@@ -1716,10 +1712,7 @@ impl Consensus {
         Ok(committee)
     }
 
-    pub fn new_view(
-        &mut self,
-        new_view: NewView,
-    ) -> Result<Option<(Block, Vec<VerifiedTransaction>)>> {
+    pub fn new_view(&mut self, new_view: NewView) -> Result<Option<NetworkMessage>> {
         trace!("Received new view for view: {:?}", new_view.view);
 
         let mut current_view = self.get_view()?;

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -240,8 +240,8 @@ impl Node {
             }
             // Repeated `NewView`s might get broadcast.
             ExternalMessage::NewView(m) => {
-                if let Some((block, transactions)) = self.consensus.new_view(*m)? {
-                    self.broadcast_and_execute_proposal(Proposal::from_parts(block, transactions))?;
+                if let Some(network_message) = self.consensus.new_view(*m)? {
+                    self.handle_network_message_response(network_message)?;
                 }
             }
             // `Proposals` are re-routed to `handle_request()`
@@ -267,8 +267,8 @@ impl Node {
                 self.request_responses
                     .send((response_channel, ExternalMessage::Acknowledgement))?;
 
-                if let Some((block, transactions)) = self.consensus.vote(*m)? {
-                    self.broadcast_and_execute_proposal(Proposal::from_parts(block, transactions))?;
+                if let Some(network_message) = self.consensus.vote(*m)? {
+                    self.handle_network_message_response(network_message)?;
                 }
             }
             ExternalMessage::NewView(m) => {
@@ -276,8 +276,8 @@ impl Node {
                 self.request_responses
                     .send((response_channel, ExternalMessage::Acknowledgement))?;
 
-                if let Some((block, transactions)) = self.consensus.new_view(*m)? {
-                    self.broadcast_and_execute_proposal(Proposal::from_parts(block, transactions))?;
+                if let Some(network_message) = self.consensus.new_view(*m)? {
+                    self.handle_network_message_response(network_message)?;
                 }
             }
             // RFC-161 sync algorithm, phase 2.


### PR DESCRIPTION
A small bit of cleanup between return types from consensus layer

This is currently running in `zq2-devnet-validator-ase1-0-a6d2`.