### PR TITLE
feat: DEVOPS-1944 zilliqa container hard memory limit to 6g

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -236,7 +236,7 @@ start() {
     docker container prune -f
     docker run -td -p 3333:3333/udp -p 4201:4201 -p 4202:4202 --net=host --name zilliqa-""" + VERSIONS.get('zilliqa') + """ \
         -v /config.toml:/config.toml -v /zilliqa.log:/zilliqa.log -v /data:/data \
-        --log-driver json-file --log-opt max-size=1g --log-opt max-file=30 \
+        --log-driver json-file --log-opt max-size=1g --log-opt max-file=30 --memory=6g \
         -e RUST_LOG='""" + LOG_LEVEL + """' -e RUST_BACKTRACE=1 \
         --restart=unless-stopped \
     """ + mount_checkpoint_file() + """ ${ZQ2_IMAGE} """ + SCILLA_SERVER_PORT + """ ${1} --log-json


### PR DESCRIPTION
We are getting OOM in the VMs and this it is affecting to the SSH, Logs and Metrics collection services, necessary to debug the issues that cause the high memory usage, among others. 

More details on the usage in the ticket: https://zilliqa-jira.atlassian.net/browse/DEVOPS-1944

We propose to set a memory limit in the container in order to avoid the other services in the VM to be affected. With this configuration, the Zilliqa process will still get out of memory but at least the common services in the VM will keep working.

The value is also a fixed one, as all the instance types currently have 8GB (n2-standard-2 and e2-standard-2).

We can eventually also explore other possible options as swap memory or oom-kill-disabled https://docs.docker.com/engine/containers/resource_constraints/