### PR TITLE
feat: set new view broadcast interval via config

### DIFF
--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -2,6 +2,7 @@ use std::{
     collections::HashMap,
     path::{Path, PathBuf},
     str::FromStr,
+    time::Duration,
 };
 
 use alloy::{
@@ -545,6 +546,7 @@ impl Setup {
                     contract_upgrades: ContractUpgrades::default(),
                     forks: vec![],
                     genesis_fork: genesis_fork_default(),
+                    new_view_broadcast_interval: Duration::default(),
                 },
                 block_request_limit: block_request_limit_default(),
                 sync: SyncConfig {

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -457,6 +457,10 @@ pub struct ConsensusConfig {
     /// difference applies.
     #[serde(default)]
     pub forks: Vec<ForkDelta>,
+    /// Interval at which NewView messages are broadcast when node is in timeout
+    /// Defaut of 0 means never broadcast
+    #[serde(default)]
+    pub new_view_broadcast_interval: Duration,
 }
 
 impl ConsensusConfig {
@@ -508,6 +512,7 @@ impl Default for ConsensusConfig {
             contract_upgrades: ContractUpgrades::default(),
             forks: vec![],
             genesis_fork: genesis_fork_default(),
+            new_view_broadcast_interval: Duration::default(),
         }
     }
 }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -502,8 +502,9 @@ impl Consensus {
             // Resend NewView message for this view if timeout period is a multiple of consensus_timeout
             if (milliseconds_since_last_view_change
                 > self.config.consensus.consensus_timeout.as_millis() as u64)
+                && !self.config.consensus.new_view_broadcast_interval.is_zero()
                 && (Duration::from_millis(milliseconds_since_last_view_change).as_secs()
-                    % self.config.consensus.consensus_timeout.as_secs())
+                    % self.config.consensus.new_view_broadcast_interval.as_secs())
                     == 0
             {
                 if let Some((_, ExternalMessage::NewView(new_view))) =

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -121,7 +121,7 @@ impl P2pNode {
                             .max_transmit_size(1024 * 1024)
                             // Increase the duplicate cache time to reduce the likelihood of delayed messages being
                             // mistakenly re-propagated and flooding the network.
-                            .duplicate_cache_time(Duration::from_secs(300))
+                            .duplicate_cache_time(Duration::from_secs(3600))
                             .build()
                             .map_err(|e| anyhow!(e))?,
                     )

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -380,6 +380,7 @@ impl Network {
                     ],
                     ..genesis_fork_default()
                 },
+                new_view_broadcast_interval: Duration::default(),
             },
             api_servers: vec![ApiServer {
                 port: 4201,
@@ -540,6 +541,7 @@ impl Network {
                     ],
                     ..genesis_fork_default()
                 },
+                new_view_broadcast_interval: Duration::default(),
             },
             block_request_limit: block_request_limit_default(),
             sync: SyncConfig {


### PR DESCRIPTION
Configurable new view broadcast interval. Also sets Gossipsub's duplicate cache time to 1 hour to avoid re-broadcast loops between nodes which take >5 mins to process their message queues. 