### PR TITLE
feat: DEVOPS-1946 memory metrics for processes monitoring

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -639,7 +639,7 @@ metrics:
               - targets: ['localhost:9256']
             metric_relabel_configs:
               - source_labels: [__name__]
-                regex: 'namedprocess_namegroup_cpu_seconds_total'
+                regex: 'namedprocess_namegroup_cpu_seconds_total|namedprocess_namegroup_memory_bytes'
                 action: keep
   service:
     log_level: info


### PR DESCRIPTION
Enable memory metrics by processes.

Tested in devnet.
https://monitoring.zilliqa.com/d/aee8cinu6kwlcc/zq2-uptime-status?orgId=1&from=now-1h&to=now&timezone=browser&var-project=prj-d-zq2-devnet-c83bkpsd&var-node=$__all