### PR TITLE
feat: DEVOPS-1929 stats-agents promote to v0.0.3

### DIFF
--- a/zq2-devnet.yaml
+++ b/zq2-devnet.yaml
@@ -9,8 +9,8 @@ roles:
 - persistence
 - private-api
 versions:
-  zq2: v0.6.0
+  zq2: v0.7.7
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3

--- a/zq2-infratest.yaml
+++ b/zq2-infratest.yaml
@@ -13,5 +13,5 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3
   zq2_metrics: v0.0.1

--- a/zq2-mainnet.yaml
+++ b/zq2-mainnet.yaml
@@ -13,5 +13,5 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3
   zq2_metrics: v0.0.1

--- a/zq2-perftest.yaml
+++ b/zq2-perftest.yaml
@@ -13,4 +13,4 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3

--- a/zq2-persistence.yaml
+++ b/zq2-persistence.yaml
@@ -13,4 +13,4 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3

--- a/zq2-protomainnet.yaml
+++ b/zq2-protomainnet.yaml
@@ -13,5 +13,5 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3
   zq2_metrics: v0.0.1

--- a/zq2-prototestnet.yaml
+++ b/zq2-prototestnet.yaml
@@ -13,5 +13,5 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3
   zq2_metrics: v0.0.1

--- a/zq2-richard.yaml
+++ b/zq2-richard.yaml
@@ -13,4 +13,4 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3

--- a/zq2-testnet.yaml
+++ b/zq2-testnet.yaml
@@ -13,5 +13,5 @@ versions:
   otterscan: develop
   spout: main
   stats_dashboard: v0.0.4
-  stats_agent: v0.0.2
+  stats_agent: v0.0.3
   zq2_metrics: v0.0.1


### PR DESCRIPTION
Stats-agents promote to v0.0.3, which includes single line logs for stats-agent.

Tested OK:

2025-04-16 06:52 +00:00: [eth] =i= { id: 'zq2DevnetApiAse12B549', stats: { active: true, syncing: false, mining: false, peers: 9, gasPrice: '4761904800000', uptime: 100 } }
2025-04-16 06:52 +00:00: [eth] =i= { id: 'zq2DevnetApiAse12B549', stats: { active: true, syncing: false, mining: false, peers: 9, gasPrice: '4761904800000', uptime: 100 } }
2025-04-16 06:52 +00:00: [eth] =i= { id: 'zq2DevnetApiAse12B549', stats: { active: true, syncing: false, mining: false, peers: 9, gasPrice: '4761904800000', uptime: 100 } }
2025-04-16 06:52 +00:00: [eth] =i= { id: 'zq2DevnetApiAse12B549', stats: { active: true, syncing: false, mining: false, peers: 9, gasPrice: '4761904800000', uptime: 100 } }

Previous with multi-line:

2025-03-23 07:02 +00:00: [eth] =i= {
2025-03-23 07:02 +00:00:   id: 'zq2ProtomainnetValidatorAse12B9Fd',
2025-03-23 07:02 +00:00:   stats: {
2025-03-23 07:02 +00:00:     active: true,
2025-03-23 07:02 +00:00:     syncing: false,
2025-03-23 07:02 +00:00:     mining: false,
2025-03-23 07:02 +00:00:     peers: 44,
2025-03-23 07:02 +00:00:     gasPrice: '4761904800000',
2025-03-23 07:02 +00:00:     uptime: 10