### PR TITLE
feat: DEVOPS-1986 service accounts per node

### DIFF
--- a/infra/tf/checkpoints.tf
+++ b/infra/tf/checkpoints.tf
@@ -79,7 +79,10 @@ resource "google_storage_bucket" "checkpoint" {
 resource "google_storage_bucket_iam_binding" "checkpoint_bucket_admins" {
   bucket  = google_storage_bucket.checkpoint.name
   role    = "roles/storage.objectAdmin"
-  members = ["serviceAccount:${module.checkpoints.service_account.email}"]
+  members = [
+    for name, sa in module.checkpoints.service_account : 
+      "serviceAccount:${sa.email}"
+  ]
 }
 
 resource "google_storage_bucket_iam_binding" "checkpoint_bucket_viewers" {

--- a/infra/tf/modules/node/main.tf
+++ b/infra/tf/modules/node/main.tf
@@ -9,15 +9,28 @@ resource "random_id" "name_suffix" {
 }
 
 resource "google_service_account" "this" {
-  account_id = substr(local.resource_name, 0, 28)
+  for_each = { for k, v in local.instances_map : v.resource_name => v }
+
+  account_id   = "sa-${substr(md5(each.value.resource_name), 0, 27)}"
+  display_name = each.value.resource_name
+  description  = format("Service account for the node %s", each.value.resource_name)
 }
 
 resource "google_project_iam_member" "this" {
-  for_each = toset(var.service_account_iam)
+  for_each = {
+    for pair in flatten([
+      for sa_key, sa in google_service_account.this : [
+        for iam in var.service_account_iam : {
+          sa_key = sa_key
+          iam    = iam
+        }
+      ]
+    ]) : "${pair.sa_key}-${pair.iam}" => pair
+  }
 
-  project = split("=>", each.value)[1]
-  role    = split("=>", each.value)[0]
-  member  = "serviceAccount:${google_service_account.this.email}"
+  project = split("=>", each.value.iam)[1]
+  role    = split("=>", each.value.iam)[0]
+  member  = "serviceAccount:${google_service_account.this[each.value.sa_key].email}"
 }
 
 resource "google_compute_address" "external_regional" {
@@ -51,7 +64,7 @@ resource "google_compute_instance" "this" {
   labels = merge(local.labels, { "node-name" = each.value.resource_name })
 
   service_account {
-    email = google_service_account.this.email
+    email = google_service_account.this[each.value.resource_name].email
     scopes = [
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/devstorage.read_only",

--- a/infra/tf/modules/node/outputs.tf
+++ b/infra/tf/modules/node/outputs.tf
@@ -50,6 +50,11 @@ output "zones" {
 }
 
 output "service_account" {
-  description = "The GCP service account associated to the instances"
-  value       = google_service_account.this
+  description = "The GCP service accounts associated to the instances"
+  value = {
+    for service_account in google_service_account.this : service_account.name => {
+      account_id = service_account.account_id,
+      email = service_account.email,
+    }
+  }
 }


### PR DESCRIPTION
To provide fine-grained access to resources we need to create a service account per node.

Tested and applied in infratest.
