### PR TITLE
feat: DEVOPS-1991 not deploy faucet in mainnet

### DIFF
--- a/infra/tf/variables.tf
+++ b/infra/tf/variables.tf
@@ -22,6 +22,7 @@ variable "apps" {
     provisioning_model         = optional(string, "STANDARD")
     generate_external_ip       = optional(bool, false)
     detach_load_balancer       = optional(bool, false)
+    enable_faucet              = optional(bool, true)
     faucet_max_hourly_requests = optional(number, 1000000)
     nodes = optional(list(object({
       count  = number

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -117,7 +117,7 @@ pub enum Chain {
             subdomain = "zq2-mainnet.zilliqa.com",
             project_id = "prj-p-zq2-mainnet-sn5n8wfl",
             log_level = "zilliqa=trace",
-            enable_faucet = "true"
+            enable_faucet = "false"
         )
     )]
     Zq2Mainnet,

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -19,7 +19,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-richard.zilstg.dev",
             project_id = "prj-d-zq2-devnet-c83bkpsd",
-            log_level = "zilliqa=info"
+            log_level = "zilliqa=info",
+            enable_faucet = "true"
         )
     )]
     Zq2Richard,
@@ -29,7 +30,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-persistence.zilstg.dev",
             project_id = "prj-d-zq2-devnet-c83bkpsd",
-            log_level = "zilliqa=info"
+            log_level = "zilliqa=info",
+            enable_faucet = "true"
         )
     )]
     Zq2Persistence,
@@ -39,7 +41,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-infratest.zilstg.dev",
             project_id = "prj-d-zq2-devnet-c83bkpsd",
-            log_level = "zilliqa=info"
+            log_level = "zilliqa=info",
+            enable_faucet = "true"
         )
     )]
     Zq2InfraTest,
@@ -49,7 +52,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-perftest.zilstg.dev",
             project_id = "prj-d-zq2-devnet-c83bkpsd",
-            log_level = "zilliqa=info"
+            log_level = "zilliqa=info",
+            enable_faucet = "true"
         )
     )]
     Zq2PerfTest,
@@ -59,7 +63,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-devnet.zilliqa.com",
             project_id = "prj-d-zq2-devnet-c83bkpsd",
-            log_level = "zilliqa=trace"
+            log_level = "zilliqa=trace",
+            enable_faucet = "true"
         )
     )]
     Zq2Devnet,
@@ -69,7 +74,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-prototestnet.zilliqa.com",
             project_id = "prj-d-zq2-testnet-g13pnaa8",
-            log_level = "zilliqa=trace"
+            log_level = "zilliqa=trace",
+            enable_faucet = "true"
         )
     )]
     Zq2ProtoTestnet,
@@ -79,7 +85,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-protomainnet.zilliqa.com",
             project_id = "prj-p-zq2-mainnet-sn5n8wfl",
-            log_level = "zilliqa=trace"
+            log_level = "zilliqa=trace",
+            enable_faucet = "true"
         )
     )]
     Zq2ProtoMainnet,
@@ -89,7 +96,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-testnet.zilliqa.com",
             project_id = "prj-d-zq2-testnet-g13pnaa8",
-            log_level = "zilliqa=trace"
+            log_level = "zilliqa=trace",
+            enable_faucet = "true"
         )
     )]
     Zq2Testnet,
@@ -99,7 +107,8 @@ pub enum Chain {
         props(
             subdomain = "zq2-mainnet.zilliqa.com",
             project_id = "prj-p-zq2-mainnet-sn5n8wfl",
-            log_level = "zilliqa=trace"
+            log_level = "zilliqa=trace",
+            enable_faucet = "true"
         )
     )]
     Zq2Mainnet,
@@ -293,5 +302,11 @@ impl Chain {
         let log_level = self.get_str("log_level");
 
         Ok(log_level.unwrap_or("zilliqa=trace"))
+    }
+
+    pub fn get_enable_faucet(&self) -> Result<&'static str> {
+        let enable_faucet = self.get_str("enable_faucet");
+
+        Ok(enable_faucet.unwrap_or("true"))
     }
 }

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -987,6 +987,7 @@ impl ChainNode {
         let role_name = &self.role.to_string();
         let z2_image = &docker_image("zq2", &self.chain.get_version("zq2"))?;
         let otterscan_image = &docker_image("otterscan", &self.chain.get_version("otterscan"))?;
+        let enable_faucet = self.chain()?.get_enable_faucet()?;
         let spout_image = &docker_image("spout", &self.chain.get_version("spout"))?;
         let stats_dashboard_image = &docker_image(
             "stats_dashboard",
@@ -1017,6 +1018,7 @@ impl ChainNode {
         var_map.insert("role", role_name);
         var_map.insert("docker_image", z2_image);
         var_map.insert("otterscan_image", otterscan_image);
+        var_map.insert("enable_faucet", enable_faucet);
         var_map.insert("spout_image", spout_image);
         var_map.insert("stats_dashboard_image", stats_dashboard_image);
         var_map.insert("stats_dashboard_key", stats_dashboard_key);


### PR DESCRIPTION
- Adding a enable_faucet variable in the chain definitions.
- Conditional deployment of faucet/spout resources.
- Separating the start/stop logic of the faucet from the apps.
- Tested with `z2 deployer install --select zq2-infratest.yaml`.