### PR TITLE
Update Scilla version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
   e2e_test:
     services:
       scilla:
-        image: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:a5a81f72
+        image: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:e762f387
         options: --init --add-host host.docker.internal:host-gateway --entrypoint "/scilla/0/bin/scilla-server-http"
         ports:
           - 3000:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ RUN apt update -y && \
 
 COPY --chmod=777 ./infra/run.sh /run.sh
 COPY --from=builder /zilliqa/build/zilliqa /zilliqa
-COPY --from=asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:a5a81f72 /scilla/0 /scilla/0
+COPY --from=asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:e762f387 /scilla/0 /scilla/0
 
 ENTRYPOINT [ "/run.sh" ]

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -264,7 +264,7 @@ fn run_scilla_docker() -> Result<Child> {
         .arg("--rm")
         .arg("-v")
         .arg("/tmp:/scilla_ext_libs")
-        .arg("asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:a5a81f72")
+        .arg("asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:e762f387")
         .arg("/scilla/0/bin/scilla-server-http")
         .spawn()?;
 

--- a/zilliqa-macros/src/test.rs
+++ b/zilliqa-macros/src/test.rs
@@ -169,7 +169,7 @@ pub(crate) fn test_macro(args: TokenStream, item: TokenStream) -> TokenStream {
                 .arg("--rm")
                 .arg("-v")
                 .arg("/tmp:/scilla_ext_libs")
-                .arg("asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:a5a81f72")
+                .arg("asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public/scilla:e762f387")
                 .arg("/scilla/0/bin/scilla-server-http")
                 .spawn()
                 .unwrap();


### PR DESCRIPTION
Includes 2 new commits:
https://github.com/Zilliqa/scilla/compare/a5a81f72...a886a135

The impactful one is https://github.com/Zilliqa/scilla/commit/a886a135f4ed570c4014ab10257a9506d1079ec6 which adds caching to the curl client and speeds up Scilla transactions significantly.
