### PR TITLE
feat: DEVOPS-1989 retrieve genesis and stats key from inside the node

### DIFF
--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -997,20 +997,14 @@ impl ChainNode {
         )?;
         let stats_agent_image =
             &docker_image("stats_agent", &self.chain.get_version("stats_agent"))?;
-        let genesis_key = if *role_name == NodeRole::Apps.to_string() {
-            &self.chain.genesis_private_key().await?
-        } else {
-            ""
-        };
         let zq2_metrics_image =
             &docker_image("zq2_metrics", &self.chain.get_version("zq2_metrics"))?;
-
-        let stats_dashboard_key = &self.chain.stats_dashboard_key().await?;
 
         let persistence_url = self.chain.persistence_url().unwrap_or_default();
         let checkpoint_url = self.chain.checkpoint_url().unwrap_or_default();
         let log_level = self.chain()?.get_log_level()?;
         let project_id = &self.machine.project_id;
+        let chain_name = &self.chain.name();
         let node_name = &self.machine.name;
 
         let mut var_map = BTreeMap::<&str, &str>::new();
@@ -1020,14 +1014,13 @@ impl ChainNode {
         var_map.insert("enable_faucet", enable_faucet);
         var_map.insert("spout_image", spout_image);
         var_map.insert("stats_dashboard_image", stats_dashboard_image);
-        var_map.insert("stats_dashboard_key", stats_dashboard_key);
         var_map.insert("stats_agent_image", stats_agent_image);
-        var_map.insert("genesis_key", genesis_key);
         var_map.insert("persistence_url", &persistence_url);
         var_map.insert("checkpoint_url", &checkpoint_url);
         var_map.insert("zq2_metrics_image", zq2_metrics_image);
         var_map.insert("log_level", log_level);
         var_map.insert("project_id", project_id);
+        var_map.insert("chain_name", chain_name);
         var_map.insert("node_name", node_name);
 
         let ctx = Context::from_serialize(var_map)?;


### PR DESCRIPTION
- Retrieve genesis key with gcloud from the node provisioner for spout app.
- Retrieve stats key with gcloud from the node provisioner for stats app.

Tested in infratest, commands used to compare the values:
cat /usr/local/bin/spout.sh
cat /usr/local/bin/stats_dashboard.sh
cat /usr/local/bin/stats_agents.sh
docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}'

Stats showing on https://stats.zq2-infratest.zilstg.dev/