### PR TITLE
Flush any changes at the end of conversion

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -601,6 +601,8 @@ pub async fn convert_persistence(
     write.blocks()?.insert(&empty_high_qc_block)?;
     write.high_qc()?.set(&empty_high_qc_block.header.qc)?;
 
+    write.commit()?;
+
     println!(
         "Persistence conversion done up to block {}",
         zq2_db


### PR DESCRIPTION
All changes should be flushed before conversion completes (as the TxWrite doesn't call `commit` when it's dropped).