### PR TITLE
Extend admin_getPeers() RPC

### DIFF
--- a/zilliqa/src/api/admin.rs
+++ b/zilliqa/src/api/admin.rs
@@ -98,7 +98,17 @@ fn force_view(params: Params, node: &Arc<Mutex<Node>>) -> Result<bool> {
     Ok(true)
 }
 
-fn get_peers(_params: Params, node: &Arc<Mutex<Node>>) -> Result<Vec<PeerId>> {
+#[derive(Clone, Debug, Serialize)]
+struct PeerInfo {
+    pub swarm_peers: Vec<PeerId>,
+    pub sync_peers: Vec<PeerId>,
+}
+
+fn get_peers(_params: Params, node: &Arc<Mutex<Node>>) -> Result<PeerInfo> {
     let node = node.lock().unwrap();
-    Ok(node.consensus.sync.peer_ids())
+    let (swarm_peers, sync_peers) = node.get_peer_ids()?;
+    Ok(PeerInfo {
+        swarm_peers,
+        sync_peers,
+    })
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1,6 +1,9 @@
 use std::{
     fmt::Debug,
-    sync::{Arc, atomic::AtomicUsize},
+    sync::{
+        Arc,
+        atomic::{AtomicPtr, AtomicUsize},
+    },
     time::Duration,
 };
 
@@ -165,6 +168,7 @@ pub struct Node {
     pub consensus: Consensus,
     peer_num: Arc<AtomicUsize>,
     pub chain_id: ChainId,
+    swarm_peers: Arc<AtomicPtr<Vec<PeerId>>>,
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -191,7 +195,8 @@ impl Node {
         request_responses: UnboundedSender<(ResponseChannel, ExternalMessage)>,
         reset_timeout: UnboundedSender<Duration>,
         peer_num: Arc<AtomicUsize>,
-        peers: Arc<SyncPeers>,
+        sync_peers: Arc<SyncPeers>,
+        swarm_peers: Arc<AtomicPtr<Vec<PeerId>>>,
     ) -> Result<Node> {
         config.validate()?;
         let peer_id = secret_key.to_libp2p_keypair().public().to_peer_id();
@@ -226,9 +231,10 @@ impl Node {
                 message_sender,
                 reset_timeout,
                 db,
-                peers,
+                sync_peers,
             )?,
             peer_num,
+            swarm_peers,
         };
         Ok(node)
     }
@@ -1023,5 +1029,15 @@ impl Node {
                 .broadcast_proposal(ExternalMessage::Proposal(proposal))?;
         }
         Ok(())
+    }
+
+    pub fn get_peer_ids(&self) -> Result<(Vec<PeerId>, Vec<PeerId>)> {
+        let sync_peers = self.consensus.sync.peer_ids();
+        let swarm_peers: Vec<PeerId>;
+        unsafe {
+            let swarm_ptr = self.swarm_peers.load(std::sync::atomic::Ordering::SeqCst);
+            swarm_peers = (*swarm_ptr).clone();
+        }
+        Ok((swarm_peers, sync_peers))
     }
 }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1035,7 +1035,7 @@ impl Node {
         let sync_peers = self.consensus.sync.peer_ids();
         let swarm_peers: Vec<PeerId>;
         unsafe {
-            let swarm_ptr = self.swarm_peers.load(std::sync::atomic::Ordering::SeqCst);
+            let swarm_ptr = self.swarm_peers.load(std::sync::atomic::Ordering::Relaxed);
             swarm_peers = (*swarm_ptr).clone();
         }
         Ok((swarm_peers, sync_peers))

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -3,12 +3,16 @@
 use std::{
     collections::HashMap,
     iter,
-    sync::{Arc, atomic::AtomicUsize},
+    sync::{
+        Arc,
+        atomic::{AtomicPtr, AtomicUsize},
+    },
     time::Duration,
 };
 
 use anyhow::{Result, anyhow};
 use cfg_if::cfg_if;
+use itertools::Itertools;
 use libp2p::{
     PeerId, StreamProtocol, Swarm, autonat,
     futures::StreamExt,
@@ -83,6 +87,7 @@ pub struct P2pNode {
     pending_requests: HashMap<request_response::OutboundRequestId, (u64, RequestId)>,
     // Count of current peers for API
     peer_num: Arc<AtomicUsize>,
+    swarm_peers: Arc<AtomicPtr<Vec<PeerId>>>,
 }
 
 impl P2pNode {
@@ -162,6 +167,7 @@ impl P2pNode {
             request_responses_receiver,
             pending_requests: HashMap::new(),
             peer_num: Arc::new(AtomicUsize::new(0)),
+            swarm_peers: Arc::new(AtomicPtr::new(Box::into_raw(Box::new(vec![])))),
         })
     }
 
@@ -201,6 +207,7 @@ impl P2pNode {
             self.local_message_sender.clone(),
             self.request_responses_sender.clone(),
             self.peer_num.clone(),
+            self.swarm_peers.clone(),
         )
         .await?;
         self.shard_peers.insert(topic.hash(), peers);
@@ -249,6 +256,15 @@ impl P2pNode {
                     let event = event.expect("swarm stream should be infinite");
                     debug!(?event, "swarm event");
                     match event {
+                        SwarmEvent::ConnectionClosed{..} |
+                        SwarmEvent::ConnectionEstablished{..} => {
+                            // update peers when new peer connects/disconnects
+                            let new_peers = Box::into_raw(Box::new(self.swarm.connected_peers().cloned().collect_vec()));
+                            let old_ptr = self.swarm_peers.swap(new_peers, std::sync::atomic::Ordering::SeqCst);
+                            unsafe {
+                                        let _old_vec = Box::from_raw(old_ptr); // Old vec will be dropped here
+                            }
+                        }
                         // only dial after we have a listen address, to reuse port
                         SwarmEvent::NewListenAddr { address, .. } => {
                             info!(%address, "P2P swarm listening on");
@@ -450,10 +466,16 @@ impl P2pNode {
                 }
                 _ = terminate.recv() => {
                     self.shard_threads.shutdown().await;
+                    unsafe {
+                            let _ = Box::from_raw(self.swarm_peers.load(std::sync::atomic::Ordering::SeqCst));
+                    }
                     break;
                 },
                 _ = signal::ctrl_c() => {
                     self.shard_threads.shutdown().await;
+                    unsafe {
+                            let _ = Box::from_raw(self.swarm_peers.load(std::sync::atomic::Ordering::SeqCst));
+                    }
                     break;
                 },
             }


### PR DESCRIPTION
Extends the `admin_getPeers()` RPC to return the totality of peers `swarm_peers`, not just the peers used for syncing `sync_peers`. The peers used for syncing is a subset as it only contains peers that are part of the topic, and are still good. So, it won't match the numbers in `net_peerCount` which will match `swarm_peers` returned in this PR.

If combined with #2730 the sync peers are the known peers in the topic. So, there will be no need to return a separate `topic_peers`.