### PR TITLE
feat: DEVOPS-1968 container id in log receiver

### DIFF
--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -607,6 +607,7 @@ logging:
       include_paths:
         - /var/lib/docker/containers/*/*.log
         - /zilliqa.log
+      record_log_file_path: true
   processors:
     parse_log:
         type: parse_json


### PR DESCRIPTION
We need a way to associate a log and a container. This is a quick win option.

- record_log_file_path: Optional. If set to true, then the path to the specific file from which the log record was obtained appears in the output log entry as the value of the agent.googleapis.com/log_file_path label. When using a wildcard, only the path of the file from which the record was obtained is recorded.