### PR TITLE
fix: do not throw on attempted insert of existing item in receipts table

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -1145,7 +1145,7 @@ impl Db {
         sqlite_tx: &Connection,
         receipt: TransactionReceipt,
     ) -> Result<()> {
-        sqlite_tx.prepare_cached("INSERT INTO receipts
+        sqlite_tx.prepare_cached("INSERT OR IGNORE INTO receipts
                 (tx_hash, block_hash, tx_index, success, gas_used, cumulative_gas_used, contract_address, logs, transitions, accepted, errors, exceptions)
             VALUES (:tx_hash, :block_hash, :tx_index, :success, :gas_used, :cumulative_gas_used, :contract_address, :logs, :transitions, :accepted, :errors, :exceptions)",)?.execute(            
             named_params! {


### PR DESCRIPTION
[This PR](https://github.com/Zilliqa/zq2/pull/2588) stopped us from removing items from `receipts` table but did not remove the throw from the insert fn when an item already exists 