### PR TITLE
admin_getPeers() should return the full list of sync-peers

### DIFF
--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -1542,7 +1542,11 @@ impl Sync {
     }
 
     pub fn peer_ids(&self) -> Vec<PeerId> {
-        self.peers.peer_ids()
+        self.peers
+            .peer_ids()
+            .into_iter()
+            .chain(self.in_flight.iter().map(|(p, _)| p.peer_id))
+            .collect()
     }
 }
 


### PR DESCRIPTION
The current `admin_getPeers()` RPC only returns the list of unused sync-peers; missing out the ones that are in-flight.