### PR TITLE
Performance enhancement to log filters

### DIFF
--- a/zilliqa/src/api/types/filters.rs
+++ b/zilliqa/src/api/types/filters.rs
@@ -1,7 +1,4 @@
-use std::{
-    collections::{HashMap, HashSet},
-    time::Duration,
-};
+use std::{collections::HashMap, time::Duration};
 
 use anyhow::anyhow;
 
@@ -101,7 +98,6 @@ impl PendingTxFilter {
 pub struct LogFilter {
     pub criteria: Box<alloy::rpc::types::Filter>,
     pub last_block_number: Option<u64>,
-    pub seen_logs: HashSet<super::eth::Log>,
 }
 
 impl Filter {

--- a/zilliqa/tests/it/eth.rs
+++ b/zilliqa/tests/it/eth.rs
@@ -1544,7 +1544,7 @@ async fn get_block_receipts(mut network: Network) {
     assert!(receipts.contains(&individual1));
 }
 
-#[allow(dead_code)]
+#[zilliqa_macros::test]
 async fn test_block_filter(mut network: Network) {
     println!("Starting block filter test");
     let wallet = network.random_wallet().await;
@@ -1605,7 +1605,7 @@ async fn test_block_filter(mut network: Network) {
     assert!(filter_removed_successfully);
 }
 
-#[allow(dead_code)]
+#[zilliqa_macros::test]
 async fn test_pending_transaction_filter(mut network: Network) {
     let wallet = network.genesis_wallet().await;
     let provider = wallet.provider();
@@ -1647,7 +1647,7 @@ async fn test_pending_transaction_filter(mut network: Network) {
     assert!(changes.is_empty());
 }
 
-#[allow(dead_code)]
+#[zilliqa_macros::test]
 async fn test_log_filter(mut network: Network) {
     let wallet = network.genesis_wallet().await;
     let provider = wallet.provider();
@@ -1724,7 +1724,7 @@ async fn test_log_filter(mut network: Network) {
     assert!(filter_removed_successfully);
 }
 
-#[allow(dead_code)]
+#[zilliqa_macros::test]
 async fn test_invalid_filter_id(mut network: Network) {
     println!("Starting invalid filter ID test");
     let wallet = network.random_wallet().await;
@@ -1738,7 +1738,7 @@ async fn test_invalid_filter_id(mut network: Network) {
     assert!(result.is_err());
 }
 
-#[allow(dead_code)]
+#[zilliqa_macros::test]
 async fn test_uninstall_filter(mut network: Network) {
     println!("Starting uninstall filter test");
     let wallet = network.random_wallet().await;


### PR DESCRIPTION
@JamesHinshelwood hopefully this is what you were looking for?
This reintroduces the filters, with the log filter now adjusted to only gather logs for blocks that match both the filter criteria and haven't yet been returned, rather than gathering everything that matches the criteria then throwing away everything that's already been returned.

It also fixes what I believe was a bug in the previous implementation where the filter wasn't getting updated with the last block retrieved, which definitely wouldn't have been helping the performance.

I haven't added any benchmarking or performance testing, if there's something you'd like to see in that respect, let me know

Fixes #2794