### PR TITLE
logging: Remove duplicate API call logging and remove Scilla state update logging

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -197,7 +197,6 @@ fn block_number(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 }
 
 fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    trace!("call: params: {:?}", params);
     let mut params = params.sequence();
     let call_params: CallParams = params.next()?;
     let block_id: BlockId = params.optional_next()?.unwrap_or_default();
@@ -231,7 +230,6 @@ fn chain_id(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 }
 
 fn estimate_gas(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    trace!("estimate_gas: params: {:?}", params);
     let mut params = params.sequence();
     let call_params: CallParams = params.next()?;
     let block_number: BlockNumberOrTag = params.optional_next()?.unwrap_or_default();
@@ -418,7 +416,6 @@ fn get_code(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 }
 
 fn get_storage_at(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    trace!("get_storage_at: params: {:?}", params);
     let mut params = params.sequence();
     let address: Address = params.next()?;
     let position: U256 = params.next()?;
@@ -438,7 +435,6 @@ fn get_storage_at(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
 }
 
 fn get_transaction_count(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    trace!("get_transaction_count: params: {:?}", params);
     let mut params = params.sequence();
     let address: Address = params.next()?;
     let block_id: BlockId = params.next()?;
@@ -709,7 +705,6 @@ fn get_transaction_by_hash(
     params: Params,
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<eth::Transaction>> {
-    trace!("get_transaction_by_hash: params: {:?}", params);
     let hash: B256 = params.one()?;
     let hash: Hash = Hash(hash.0);
     let node = node.lock().unwrap();
@@ -741,7 +736,6 @@ fn get_transaction_receipt(
     params: Params,
     node: &Arc<Mutex<Node>>,
 ) -> Result<Option<eth::TransactionReceipt>> {
-    trace!("get_transaction_receipt: params: {:?}", params);
     let hash: B256 = params.one()?;
     let hash: Hash = hash.into();
     let node = node.lock().unwrap();
@@ -753,7 +747,6 @@ fn get_transaction_receipt(
 }
 
 fn send_raw_transaction(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
-    trace!("send_raw_transaction: params: {:?}", params);
     let transaction: String = params.one()?;
     let transaction = transaction
         .strip_prefix("0x")

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -94,7 +94,7 @@ macro_rules! declare_module {
                 .build();
             module
                 .register_method($name, move |params, context, _| {
-                    tracing::trace!("{}: params: {:?}", $name, params);
+                    tracing::debug!("{}: params: {:?}", $name, params);
                     if !enabled {
                         return Err(jsonrpsee::types::ErrorObject::owned(
                             jsonrpsee::types::error::ErrorCode::InvalidRequest.code(),

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -909,11 +909,9 @@ impl ActiveCall {
         name: String,
         indices: Vec<Vec<u8>>,
     ) -> Result<Option<ProtoScillaVal>> {
-        trace!(sender = %self.sender, name, indices_len = indices.len(), "fetch state value");
         let result = self
             .fetch_value_inner(self.sender, name, indices)?
             .map(|(v, _)| v);
-        trace!(result_is_some = result.is_some(), "value fetched");
         Ok(result)
     }
 
@@ -923,7 +921,6 @@ impl ActiveCall {
         name: String,
         indices: Vec<Vec<u8>>,
     ) -> Result<Option<(ProtoScillaVal, String)>> {
-        trace!(sender = %self.sender, %addr, name, indices_len = indices.len(), "fetch external state value");
         fn scilla_val(b: Vec<u8>) -> ProtoScillaVal {
             ProtoScillaVal {
                 val_type: Some(ValType::Bval(b)),
@@ -962,7 +959,6 @@ impl ActiveCall {
             }
             _ => self.fetch_value_inner(addr, name.clone(), indices.clone()),
         }?;
-        trace!(result_is_some = result.is_some(), "value fetched");
 
         Ok(result)
     }
@@ -974,7 +970,6 @@ impl ActiveCall {
         ignore_value: bool,
         value: ProtoScillaVal,
     ) -> Result<()> {
-        trace!(sender = %self.sender, name, indices_len = indices.len(), ignore_value, "update state value");
         let (_, depth) = self.state.load_var_info(self.sender, &name)?;
         let depth = depth as usize;
 
@@ -1031,13 +1026,10 @@ impl ActiveCall {
         }
         self.state.touch(self.sender);
 
-        trace!("value updated");
-
         Ok(())
     }
 
     fn fetch_blockchain_info(&self, name: String, args: String) -> Result<(bool, String)> {
-        trace!(sender = %self.sender, name, args, "fetch blockchain value");
         let (exists, value) = match name.as_str() {
             "CHAINID" => Ok((true, self.state.zil_chain_id().to_string())),
             "BLOCKNUMBER" => {
@@ -1092,7 +1084,6 @@ impl ActiveCall {
                 "fetch_blockchain_info: `{name}` not implemented yet."
             )),
         }?;
-        trace!(exists, value, "info fetched");
         Ok((exists, value))
     }
 }


### PR DESCRIPTION
@JamesHinshelwood I believe we have more sophisticated techniques for inspecting Scilla now. Let me know if these are still useful and I'll bring them back.