### PR TITLE
Improve performance of eth_blocknumber by reducing db queries

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -193,7 +193,8 @@ fn accounts(params: Params, _: &Arc<Mutex<Node>>) -> Result<[(); 0]> {
 
 fn block_number(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {
     expect_end_of_params(&mut params.sequence(), 0, 0)?;
-    Ok(node.lock().unwrap().number().to_hex())
+    let node = node.lock().unwrap();
+    Ok(node.consensus.get_highest_canonical_block_number().to_hex())
 }
 
 fn call(params: Params, node: &Arc<Mutex<Node>>) -> Result<String> {

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -420,6 +420,13 @@ impl Consensus {
             .unwrap()
     }
 
+    pub fn get_highest_canonical_block_number(&self) -> u64 {
+        self.db
+            .get_highest_canonical_block_number()
+            .unwrap()
+            .unwrap()
+    }
+
     pub fn timeout(&mut self) -> Result<Option<NetworkMessage>> {
         let view = self.get_view()?;
         // We never want to timeout while on view 1


### PR DESCRIPTION
Previously we got the block number by first getting the number, then getting the block, then discarding everything but the number