### PR TITLE
Keep info level for relevant consensus parts

### DIFF
--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -681,7 +681,7 @@ fn full_transaction_benchmark(
 
 fn a_big_process_vote(big: &mut Consensus, vote: Vote, txns_per_block: usize) -> Proposal {
     let proposal = big
-        .vote(black_box(vote))
+        .vote(PeerId::random(), black_box(vote))
         .unwrap()
         .map(|(_, t)| t.into_proposal().unwrap());
     // The first vote should immediately result in a proposal. Subsequent views require a timeout before

--- a/zilliqa/src/api/types/admin.rs
+++ b/zilliqa/src/api/types/admin.rs
@@ -1,8 +1,9 @@
+use libp2p::PeerId;
 use serde::Serialize;
 
 #[derive(Clone, Debug, Serialize)]
 pub struct VotesReceivedReturnee {
     pub votes: Vec<(crate::crypto::Hash, crate::consensus::BlockVotes)>,
-    pub buffered_votes: Vec<(crate::crypto::Hash, Vec<crate::message::Vote>)>,
+    pub buffered_votes: Vec<(crate::crypto::Hash, Vec<(PeerId, crate::message::Vote)>)>,
     pub new_views: Vec<(u64, crate::consensus::NewViewVote)>,
 }

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -706,11 +706,12 @@ impl State {
     ) -> Result<TransactionApplyResult> {
         let hash = txn.hash;
         let from_addr = txn.signer;
-        info!(?txn, "executing txn");
+        let txn = txn.tx.into_transaction();
+
+        info!(?hash, from = ?from_addr, to = ?txn.to_addr(), ?txn, "executing txn");
 
         let blessed = BLESSED_TRANSACTIONS.iter().any(|elem| elem.hash == hash);
 
-        let txn = txn.tx.into_transaction();
         if let Transaction::Zilliqa(txn) = txn {
             let (result, state) =
                 self.apply_transaction_scilla(from_addr, txn, current_block, inspector)?;
@@ -985,7 +986,7 @@ impl State {
         )?;
         let committee = ensure_success(result)?;
         let committee = contracts::deposit::COMMITTEE.decode_output(&committee)?;
-        info!("committee: {committee:?}");
+        debug!("committee: {committee:?}");
 
         Ok(())
     }
@@ -1773,7 +1774,7 @@ fn scilla_create(
             }
         };
 
-    info!(?check_output);
+    debug!(?check_output);
 
     let gas = gas.min(check_output.gas_remaining);
 
@@ -1854,7 +1855,7 @@ fn scilla_create(
         }
     };
 
-    info!(?create_output);
+    debug!(?create_output);
 
     let gas = gas.min(create_output.gas_remaining);
 
@@ -2022,7 +2023,7 @@ pub fn scilla_call(
                 }
             };
 
-            info!(?output);
+            debug!(?output);
 
             gas = gas.min(output.gas_remaining);
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -253,7 +253,7 @@ impl Node {
             }
             // Repeated `NewView`s might get broadcast.
             ExternalMessage::NewView(m) => {
-                if let Some(network_message) = self.consensus.new_view(*m)? {
+                if let Some(network_message) = self.consensus.new_view(from, *m)? {
                     self.handle_network_message_response(network_message)?;
                 }
             }
@@ -280,7 +280,7 @@ impl Node {
                 self.request_responses
                     .send((response_channel, ExternalMessage::Acknowledgement))?;
 
-                if let Some(network_message) = self.consensus.vote(*m)? {
+                if let Some(network_message) = self.consensus.vote(from, *m)? {
                     self.handle_network_message_response(network_message)?;
                 }
             }
@@ -289,7 +289,7 @@ impl Node {
                 self.request_responses
                     .send((response_channel, ExternalMessage::Acknowledgement))?;
 
-                if let Some(network_message) = self.consensus.new_view(*m)? {
+                if let Some(network_message) = self.consensus.new_view(from, *m)? {
                     self.handle_network_message_response(network_message)?;
                 }
             }
@@ -467,8 +467,6 @@ impl Node {
 
     pub fn create_transaction(&mut self, txn: SignedTransaction) -> Result<(Hash, TxAddResult)> {
         let hash = txn.calculate_hash();
-
-        info!(?hash, "seen new txn {:?}", txn);
 
         let result = self.consensus.handle_new_transaction(txn.clone())?;
         if result.was_added() {

--- a/zilliqa/src/scilla.rs
+++ b/zilliqa/src/scilla.rs
@@ -356,7 +356,6 @@ impl Scilla {
         fork: &Fork,
         current_block: u64,
     ) -> Result<(Result<CreateOutput, ErrorResponse>, PendingState)> {
-        trace!("scilla addr : {}", self.state_server_addr());
         let request = ScillaServerRequestBuilder::new(ScillaServerRequestType::Run)
             .ipc_address(self.state_server_addr())
             .init(init.to_string())


### PR DESCRIPTION
Little improvements to logging - info! is now used only in consensus relevant parts: new view, proposal, vote etc.