### PR TITLE
Reduce write locking of `Node`

### DIFF
--- a/zilliqa/src/api/admin.rs
+++ b/zilliqa/src/api/admin.rs
@@ -76,7 +76,7 @@ pub struct CheckpointResponse {
 fn checkpoint(params: Params, node: &Arc<RwLock<Node>>) -> Result<CheckpointResponse> {
     let mut params = params.sequence();
     let block_id: BlockId = params.next()?;
-    let mut node = node.write();
+    let node = node.read();
     let block = node
         .get_block(block_id)?
         .ok_or(anyhow!("Block {block_id} does not exist"))?;

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -204,7 +204,7 @@ fn call(params: Params, node: &Arc<RwLock<Node>>) -> Result<String> {
     let block_id: BlockId = params.optional_next()?.unwrap_or_default();
     expect_end_of_params(&mut params, 1, 2)?;
 
-    let mut node = node.write();
+    let node = node.read();
     let block = node.get_block(block_id)?;
     let block = build_errored_response_for_missing_block(block_id, block)?;
 
@@ -237,7 +237,7 @@ fn estimate_gas(params: Params, node: &Arc<RwLock<Node>>) -> Result<String> {
     let block_number: BlockNumberOrTag = params.optional_next()?.unwrap_or_default();
     expect_end_of_params(&mut params, 1, 2)?;
 
-    let return_value = node.write().estimate_gas(
+    let return_value = node.read().estimate_gas(
         block_number,
         call_params.from,
         call_params.to,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2247,7 +2247,7 @@ impl Consensus {
 
     /// Trigger a checkpoint, for debugging.
     /// Returns (file_name, block_hash). At some time after you call this function, hopefully a checkpoint will end up in the file
-    pub fn checkpoint_at(&mut self, block_number: u64) -> Result<(String, String)> {
+    pub fn checkpoint_at(&self, block_number: u64) -> Result<(String, String)> {
         let block = self
             .get_canonical_block_by_number(block_number)?
             .ok_or(anyhow!("No such block number {block_number}"))?;

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -856,7 +856,7 @@ impl Node {
     }
 
     pub fn call_contract(
-        &mut self,
+        &self,
         block: &Block,
         from_addr: Address,
         to_addr: Option<Address>,
@@ -905,7 +905,7 @@ impl Node {
 
     #[allow(clippy::too_many_arguments)]
     pub fn estimate_gas(
-        &mut self,
+        &self,
         block_number: BlockNumberOrTag,
         from_addr: Address,
         to_addr: Option<Address>,


### PR DESCRIPTION
Some easy wins where `&mut self` was already unnecessary.