### PR TITLE
Reroute sync-requests to broadcast

### DIFF
--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -42,7 +42,7 @@ use crate::{
 pub struct NodeLauncher {
     pub node: Arc<RwLock<Node>>,
     pub config: NodeConfig,
-    pub broadcasts: UnboundedReceiverStream<(PeerId, String, ExternalMessage, ResponseChannel)>,
+    pub broadcasts: UnboundedReceiverStream<(PeerId, ExternalMessage, ResponseChannel)>,
     pub requests: UnboundedReceiverStream<(PeerId, String, ExternalMessage, ResponseChannel)>,
     pub request_failures: UnboundedReceiverStream<(PeerId, OutgoingMessageFailure)>,
     pub responses: UnboundedReceiverStream<(PeerId, ExternalMessage)>,
@@ -81,7 +81,7 @@ impl ResponseChannel {
 /// The collection of channels used to send messages to a [NodeLauncher].
 pub struct NodeInputChannels {
     /// Send broadcast messages (received via gossipsub) down this channel.
-    pub broadcasts: UnboundedSender<(PeerId, String, ExternalMessage, ResponseChannel)>,
+    pub broadcasts: UnboundedSender<(PeerId, ExternalMessage, ResponseChannel)>,
     /// Send direct requests down this channel. The `ResponseChannel` must be used by the receiver to respond to this
     /// request.
     pub requests: UnboundedSender<(PeerId, String, ExternalMessage, ResponseChannel)>,
@@ -208,7 +208,7 @@ impl NodeLauncher {
         loop {
             select! {
                 message = self.broadcasts.next() => {
-                    let (source, _id, message, response_channel) = message.expect("message stream should be infinite");
+                    let (source, message, response_channel) = message.expect("message stream should be infinite");
                     let mut attributes = vec![
                         KeyValue::new(MESSAGING_OPERATION_NAME, "handle"),
                         KeyValue::new(MESSAGING_SYSTEM, "tokio_channel"),

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -42,7 +42,7 @@ use crate::{
 pub struct NodeLauncher {
     pub node: Arc<RwLock<Node>>,
     pub config: NodeConfig,
-    pub broadcasts: UnboundedReceiverStream<(PeerId, ExternalMessage)>,
+    pub broadcasts: UnboundedReceiverStream<(PeerId, String, ExternalMessage, ResponseChannel)>,
     pub requests: UnboundedReceiverStream<(PeerId, String, ExternalMessage, ResponseChannel)>,
     pub request_failures: UnboundedReceiverStream<(PeerId, OutgoingMessageFailure)>,
     pub responses: UnboundedReceiverStream<(PeerId, ExternalMessage)>,
@@ -81,7 +81,7 @@ impl ResponseChannel {
 /// The collection of channels used to send messages to a [NodeLauncher].
 pub struct NodeInputChannels {
     /// Send broadcast messages (received via gossipsub) down this channel.
-    pub broadcasts: UnboundedSender<(PeerId, ExternalMessage)>,
+    pub broadcasts: UnboundedSender<(PeerId, String, ExternalMessage, ResponseChannel)>,
     /// Send direct requests down this channel. The `ResponseChannel` must be used by the receiver to respond to this
     /// request.
     pub requests: UnboundedSender<(PeerId, String, ExternalMessage, ResponseChannel)>,
@@ -208,7 +208,7 @@ impl NodeLauncher {
         loop {
             select! {
                 message = self.broadcasts.next() => {
-                    let (source, message) = message.expect("message stream should be infinite");
+                    let (source, _id, message, response_channel) = message.expect("message stream should be infinite");
                     let mut attributes = vec![
                         KeyValue::new(MESSAGING_OPERATION_NAME, "handle"),
                         KeyValue::new(MESSAGING_SYSTEM, "tokio_channel"),
@@ -229,7 +229,7 @@ impl NodeLauncher {
                         }
                         self.node.write().handle_broadcast_transactions(verified)?;
                     }
-                    else if let Err(e) = self.node.write().handle_broadcast(source, message) {
+                    else if let Err(e) = self.node.write().handle_broadcast(source, message, response_channel) {
                         attributes.push(KeyValue::new(ERROR_TYPE, "process-error"));
                         error!("Failed to process broadcast message: {e}");
                     }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -383,15 +383,13 @@ impl P2pNode {
                                     let _id = format!("{}", _request_id);
                                     cfg_if! {
                                         if #[cfg(not(feature = "fake_response_channel"))] {
-                                            if !matches!(_external_message,
-                                                    ExternalMessage::MultiBlockRequest(_)|
-                                                    ExternalMessage::PassiveSyncRequest(_)|
-                                                    ExternalMessage::MetaDataRequest(_)|
-                                                    ExternalMessage::BlockRequest(_)
-                                                ) {
-                                                self.send_to(&_topic.hash(), |c| c.requests.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?;
-                                            } else {
-                                                self.send_to(&_topic.hash(), |c| c.broadcasts.send((_source, _external_message, ResponseChannel::Remote(_channel))))?;
+                                            match _external_message {
+                                                ExternalMessage::MetaDataRequest(_)
+                                                | ExternalMessage::MultiBlockRequest(_)
+                                                | ExternalMessage::BlockRequest(_)
+                                                | ExternalMessage::PassiveSyncRequest(_) => self
+                                                    .send_to(&_topic.hash(), |c| c.broadcasts.send((_source, _external_message, ResponseChannel::Remote(_channel))))?,
+                                                _ => self.send_to(&_topic.hash(), |c| c.requests.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?,
                                             }
                                         } else {
                                             panic!("fake_response_channel is enabled and you are trying to use a real libp2p network");

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -369,7 +369,7 @@ impl P2pNode {
                                     self.send_to(&topic_hash, |c| c.requests.send((source, msg_id.to_string(), message, ResponseChannel::Local)))?;
                                 },
                                 _ => {
-                                    self.send_to(&topic_hash, |c| c.broadcasts.send((source, message)))?;
+                                    self.send_to(&topic_hash, |c| c.broadcasts.send((source, "faux_id".to_string(), message, ResponseChannel::Local)))?;
                                 }
                             }
                         }
@@ -383,7 +383,16 @@ impl P2pNode {
                                     let _id = format!("{}", _request_id);
                                     cfg_if! {
                                         if #[cfg(not(feature = "fake_response_channel"))] {
-                                            self.send_to(&_topic.hash(), |c| c.requests.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?;
+                                            if !matches!(_external_message,
+                                                    ExternalMessage::MultiBlockRequest(_)|
+                                                    ExternalMessage::PassiveSyncRequest(_)|
+                                                    ExternalMessage::MetaDataRequest(_)|
+                                                    ExternalMessage::BlockRequest(_)
+                                                ) {
+                                                self.send_to(&_topic.hash(), |c| c.requests.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?;
+                                            } else {
+                                                self.send_to(&_topic.hash(), |c| c.broadcasts.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?;
+                                            }
                                         } else {
                                             panic!("fake_response_channel is enabled and you are trying to use a real libp2p network");
                                         }
@@ -488,7 +497,7 @@ impl P2pNode {
                                             self.send_to(&topic.hash(), |c| c.requests.send((from, msg_id.to_string(), message, ResponseChannel::Local)))?;
                                         }
                                         _ => {
-                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message)))?;
+                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, msg_id.to_string(), message, ResponseChannel::Local)))?;
                                         }
                                     }
                                 },
@@ -496,10 +505,10 @@ impl P2pNode {
                                 Err(gossipsub::PublishError::InsufficientPeers) => {
                                     match message {
                                         ExternalMessage::Proposal(_) => {
-                                            self.send_to(&topic.hash(), |c| c.requests.send((from, "(faux-id)".to_string(), message, ResponseChannel::Local)))?;
+                                            self.send_to(&topic.hash(), |c| c.requests.send((from, "faux-id".to_string(), message, ResponseChannel::Local)))?;
                                         }
                                         _ => {
-                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message)))?;
+                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, "faux_id".to_string(), message, ResponseChannel::Local)))?;
                                         }
                                     }
                                 }

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -369,7 +369,7 @@ impl P2pNode {
                                     self.send_to(&topic_hash, |c| c.requests.send((source, msg_id.to_string(), message, ResponseChannel::Local)))?;
                                 },
                                 _ => {
-                                    self.send_to(&topic_hash, |c| c.broadcasts.send((source, "faux_id".to_string(), message, ResponseChannel::Local)))?;
+                                    self.send_to(&topic_hash, |c| c.broadcasts.send((source, message, ResponseChannel::Local)))?;
                                 }
                             }
                         }
@@ -391,7 +391,7 @@ impl P2pNode {
                                                 ) {
                                                 self.send_to(&_topic.hash(), |c| c.requests.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?;
                                             } else {
-                                                self.send_to(&_topic.hash(), |c| c.broadcasts.send((_source, _id, _external_message, ResponseChannel::Remote(_channel))))?;
+                                                self.send_to(&_topic.hash(), |c| c.broadcasts.send((_source, _external_message, ResponseChannel::Remote(_channel))))?;
                                             }
                                         } else {
                                             panic!("fake_response_channel is enabled and you are trying to use a real libp2p network");
@@ -497,7 +497,7 @@ impl P2pNode {
                                             self.send_to(&topic.hash(), |c| c.requests.send((from, msg_id.to_string(), message, ResponseChannel::Local)))?;
                                         }
                                         _ => {
-                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, msg_id.to_string(), message, ResponseChannel::Local)))?;
+                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message, ResponseChannel::Local)))?;
                                         }
                                     }
                                 },
@@ -508,7 +508,7 @@ impl P2pNode {
                                             self.send_to(&topic.hash(), |c| c.requests.send((from, "faux-id".to_string(), message, ResponseChannel::Local)))?;
                                         }
                                         _ => {
-                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, "faux_id".to_string(), message, ResponseChannel::Local)))?;
+                                            self.send_to(&topic.hash(), |c| c.broadcasts.send((from, message, ResponseChannel::Local)))?;
                                         }
                                     }
                                 }

--- a/zilliqa/tests/it/consensus.rs
+++ b/zilliqa/tests/it/consensus.rs
@@ -104,7 +104,6 @@ async fn block_production(mut network: Network) {
 
     info!("Adding networked node.");
     let index = network.add_node();
-
     network
         .run_until(
             |n| {


### PR DESCRIPTION
To avoid HOL-blocking issues on the request queue, reroute sync-related messages to broadcasts.