### PR TITLE
Add locks around receipts cache and early proposal

### DIFF
--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -758,7 +758,7 @@ fn send_raw_transaction(params: Params, node: &Arc<RwLock<Node>>) -> Result<Stri
 
     let transaction = transaction.verify()?;
 
-    let (hash, result) = node.write().create_transaction(transaction)?;
+    let (hash, result) = node.read().create_transaction(transaction)?;
     match result {
         TxAddResult::AddedToMempool
         | TxAddResult::Duplicate(_)

--- a/zilliqa/src/api/zilliqa.rs
+++ b/zilliqa/src/api/zilliqa.rs
@@ -228,7 +228,7 @@ fn create_transaction(
 ) -> Result<CreateTransactionResponse> {
     let transaction: TransactionParams = params.one()?;
 
-    let mut node = node.write();
+    let node = node.read();
 
     let version = transaction.version & 0xffff;
     let chain_id = transaction.version >> 16;

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -472,13 +472,11 @@ impl Node {
         Ok(false)
     }
 
-    pub fn create_transaction(&mut self, txn: VerifiedTransaction) -> Result<(Hash, TxAddResult)> {
+    pub fn create_transaction(&self, txn: VerifiedTransaction) -> Result<(Hash, TxAddResult)> {
         let hash = txn.hash;
 
         let from_broadcast = false;
-        let result = self
-            .consensus
-            .handle_new_transaction(txn.clone(), from_broadcast)?;
+        let result = self.consensus.handle_new_transaction(txn, from_broadcast)?;
         if !result.was_added() {
             debug!(?result, "Transaction cannot be added to mempool");
         }


### PR DESCRIPTION
This means we can make `handle_new_transaction` (and a few others) take a `&self`. Therefore, `eth_sendRawTransaction` can now be called concurrently.