### PR TITLE
increase gossipsub forward queue duration to 30s.

### DIFF
--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -139,7 +139,7 @@ impl P2pNode {
                             // Increase the queue duration to reduce the likelihood of dropped messages.
                             // https://github.com/Zilliqa/zq2/issues/2823
                             .publish_queue_duration(Duration::from_secs(50))
-                            .forward_queue_duration(Duration::from_secs(10)) // might be helpful too
+                            .forward_queue_duration(Duration::from_secs(30)) // might be helpful too
                             .build()
                             .map_err(|e| anyhow!(e))?,
                     )


### PR DESCRIPTION
Although there are no more dropped publish messages, there are still a small number of dropped forwards. So, it might be useful to increase this slightly.
https://cloudlogging.app.goo.gl/nPKHvb3eMpt2DkAX9