### PR TITLE
Speedup pending_transactions()

### DIFF
--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -198,8 +198,7 @@ impl TransactionPool {
         let mut pending_txns = Vec::with_capacity(4000);
 
         // Find a set of transactions that are pending for inclusion in the next block
-        let now = Instant::now();
-        while !ready.is_empty() && now.elapsed().as_millis() < 100 && pending_txns.len() < 4000 {
+        while !ready.is_empty() {
             // It's safe to unwrap since ready must have at least one non-empty same-gas-price set
             let tx_index = *ready.iter().next_back().unwrap().1.iter().next().unwrap();
 
@@ -218,12 +217,11 @@ impl TransactionPool {
 
             let tx_cost = txn.tx.maximum_validation_cost()?;
 
-            // Save it no matter what
-            tracked_balances.insert(txn.signer, balance.saturating_sub(tx_cost));
-            // While there may be a queued txn that may well fit, this is a good enough approximation
             if tx_cost > balance {
+                tracked_balances.insert(txn.signer, balance);
                 continue;
             }
+            tracked_balances.insert(txn.signer, balance.saturating_sub(tx_cost));
 
             pending_txns.push(txn);
 

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -739,11 +739,11 @@ mod tests {
         create_acc(&mut state, from, 100, 0)?;
 
         pool.insert_transaction(intershard_transaction(0, 0, 100), 0, false);
-        pool.insert_transaction(transaction(from, 0, 1), 0, false);
-        pool.insert_transaction(transaction(from, 1, 1), 1, false);
-        pool.insert_transaction(transaction(from, 2, 1), 2, false);
-        pool.insert_transaction(transaction(from, 3, 200), 3, false);
-        pool.insert_transaction(transaction(from, 10, 1), 3, false);
+        pool.insert_transaction(transaction(from, 0, 30), 0, false);
+        pool.insert_transaction(transaction(from, 1, 30), 1, false);
+        pool.insert_transaction(transaction(from, 2, 30), 2, false);
+        pool.insert_transaction(transaction(from, 3, 30), 3, false);
+        pool.insert_transaction(transaction(from, 10, 30), 3, false);
 
         let content = pool.preview_content(&state)?;
 

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -198,8 +198,7 @@ impl TransactionPool {
         let mut pending_txns = Vec::with_capacity(4000);
 
         // Find a set of transactions that are pending for inclusion in the next block
-        let now = Instant::now();
-        while !ready.is_empty() && now.elapsed().as_millis() < 100 && pending_txns.len() < 4000 {
+        while !ready.is_empty() {
             // It's safe to unwrap since ready must have at least one non-empty same-gas-price set
             let tx_index = *ready.iter().next_back().unwrap().1.iter().next().unwrap();
 

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -733,11 +733,11 @@ mod tests {
         create_acc(&mut state, from, 100, 0)?;
 
         pool.insert_transaction(intershard_transaction(0, 0, 100), 0, false);
-        pool.insert_transaction(transaction(from, 0, 30), 0, false);
-        pool.insert_transaction(transaction(from, 1, 30), 1, false);
-        pool.insert_transaction(transaction(from, 2, 30), 2, false);
-        pool.insert_transaction(transaction(from, 3, 30), 3, false);
-        pool.insert_transaction(transaction(from, 10, 30), 3, false);
+        pool.insert_transaction(transaction(from, 0, 1), 0, false);
+        pool.insert_transaction(transaction(from, 1, 1), 1, false);
+        pool.insert_transaction(transaction(from, 2, 1), 2, false);
+        pool.insert_transaction(transaction(from, 3, 200), 3, false);
+        pool.insert_transaction(transaction(from, 10, 1), 3, false);
 
         let content = pool.preview_content(&state)?;
 

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -194,10 +194,11 @@ impl TransactionPool {
 
         let mut ready = self.gas_index.clone();
 
-        let mut pending_txns = Vec::new();
+        let mut pending_txns = Vec::with_capacity(4000);
 
-        // Find all transactions that are pending for inclusion in the next block
-        while !ready.is_empty() {
+        // Find a set of transactions that are pending for inclusion in the next block
+        let now = Instant::now();
+        while !ready.is_empty() && now.elapsed().as_millis() < 100 && pending_txns.len() < 4000 {
             // It's safe to unwrap since ready must have at least one non-empty same-gas-price set
             let tx_index = *ready.iter().next_back().unwrap().1.iter().next().unwrap();
 

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -222,10 +222,11 @@ impl TransactionPool {
 
             let tx_cost = txn.tx.maximum_validation_cost()?;
 
+            // Save it no matter what
+            tracked_balances.insert(txn.signer, balance.saturating_sub(tx_cost));
+            // While there may be a queued txn that may well fit, this is a good enough approximation
             if tx_cost > balance {
                 continue;
-            } else {
-                tracked_balances.insert(txn.signer, balance.saturating_sub(tx_cost));
             }
 
             pending_txns.push(txn);

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -5,12 +5,11 @@ use std::{
 
 use alloy::primitives::Address;
 use anyhow::{Result, anyhow};
-use tokio::time::Instant;
 use tracing::debug;
 
 use crate::{
     crypto::Hash,
-    state::{Account, State},
+    state::State,
     transaction::{SignedTransaction, ValidationOutcome, VerifiedTransaction},
 };
 
@@ -195,7 +194,7 @@ impl TransactionPool {
 
         let mut ready = self.gas_index.clone();
 
-        let mut pending_txns = Vec::with_capacity(4000);
+        let mut pending_txns = Vec::new();
 
         // Find a set of transactions that are pending for inclusion in the next block
         while !ready.is_empty() {


### PR DESCRIPTION
Refer to issue for details. These small changes result in the following speedup:
```
time cast rpc --rpc-url http://localhost:44201 txpool_status
{"pending":4000,"queued":1000}

real    0m0.029s
user    0m0.003s
sys     0m0.011s

```