### PR TITLE
Yet another speeding up pending_transactions by reducing calls to get_account

### DIFF
--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -822,8 +822,6 @@ mod tests {
             "Benchmark completed: pending_transactions took {:?} to execute.",
             duration
         );
-
         Ok(())
     }
-
 }

--- a/zilliqa/src/pool.rs
+++ b/zilliqa/src/pool.rs
@@ -749,4 +749,71 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn benchmark_preview_content() -> Result<()> {
+        let mut pool = TransactionPool::default();
+        let from = "0x0000000000000000000000000000000000001234".parse()?;
+
+        let mut state = get_in_memory_state()?;
+        create_acc(&mut state, from, 1_000_000, 0)?;
+
+        // Insert 100 pending transactions
+        for nonce in 0u64..100u64 {
+            pool.insert_transaction(transaction(from, nonce as u8, 1), nonce, false);
+        }
+
+        // Insert 100 queued transactions
+        for nonce in 101u64..201u64 {
+            pool.insert_transaction(transaction(from, nonce as u8, 1), 0, false);
+        }
+
+        // Benchmark the preview_content method
+        let start = std::time::Instant::now();
+        let content = pool.preview_content(&state)?;
+        let duration = start.elapsed();
+
+        // Verify the results
+        assert_eq!(content.pending.len(), 100);
+        assert_eq!(content.queued.len(), 100);
+
+        println!(
+            "Benchmark completed: preview_content took {:?} to execute.",
+            duration
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn benchmark_pending_transactions() -> Result<()> {
+        let mut pool = TransactionPool::default();
+        let from = "0x0000000000000000000000000000000000001234".parse()?;
+
+        let mut state = get_in_memory_state()?;
+        create_acc(&mut state, from, 1_000_000, 0)?;
+
+        // Insert 100 pending transactions
+        for nonce in 0u64..100u64 {
+            pool.insert_transaction(transaction(from, nonce as u8, 1), nonce, false);
+        }
+
+        // Insert 100 queued transactions
+        for nonce in 101u64..201u64 {
+            pool.insert_transaction(transaction(from, nonce as u8, 1), 0, false);
+        }
+
+        // Benchmark the preview_content method
+        let start = std::time::Instant::now();
+        let _result = pool.pending_transactions(&state)?;
+        let duration = start.elapsed();
+
+        println!(
+            "Benchmark completed: pending_transactions took {:?} to execute.",
+            duration
+        );
+
+        Ok(())
+    }
+
 }


### PR DESCRIPTION
This does roughly the same thing as #2837 in terms of reducing calls to the slow `state.get_account()`, I'm happy to go with either implementation.

I've also added two benchmarks for measuring the speed up. The results are as follows:

Before caching (as of afeaf9):
Benchmark completed: pending_transactions took 4.095512ms to execute.
After caching (as of 245fae0):
Benchmark completed: pending_transactions took 387.258µs to execute.

Clearly the root problem is somewhere in state.get_account but this makes things a bit better until that's fixed