### PR TITLE
Handle own new view broadcast

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -562,6 +562,7 @@ impl Consensus {
                         if new_view.view == self.get_view()? {
                             // When re-sending new view messages we broadcast them, rather than only sending them to the
                             // view leader. This speeds up network recovery when many nodes have different high QCs.
+                            self.new_view(self.peer_id(), *new_view.clone())?;
                             return Ok(Some((None, ExternalMessage::NewView(new_view))));
                         }
                     }


### PR DESCRIPTION
Missed from [this PR](https://github.com/Zilliqa/zq2/pull/2843) we do want to process our own `NewView` broadcast in case we are leader.