### PR TITLE
Do not take `network_message_cache` on first access

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -556,7 +556,7 @@ impl Consensus {
                     % self.config.consensus.new_view_broadcast_interval.as_secs())
                     == 0
             {
-                match self.network_message_cache.take() {
+                match self.network_message_cache.clone() {
                     Some((_, ExternalMessage::NewView(new_view))) => {
                         // If new_view message is not for this view then it must be outdated
                         if new_view.view == self.get_view()? {


### PR DESCRIPTION
At some point the clone of `network_message_cache` was changed to a `take()`.

I may be suffering from Friday afternoon by not being able to find a clean way to borrow from `network_message_cache` to compare the view value before cloning. This works for now I'll come back to it on Monday to consider making it more elegant. 