### PR TITLE
Return null instead of {} for GetSmartContractSubState

### DIFF
--- a/zilliqa/src/api/zilliqa.rs
+++ b/zilliqa/src/api/zilliqa.rs
@@ -1521,7 +1521,11 @@ fn get_smart_contract_sub_state(params: Params, node: &Arc<RwLock<Node>>) -> Res
             }
         }
     }
-    Ok(result.into())
+    if result.is_empty() {
+        Ok(Value::Null)
+    } else {
+        Ok(result.into())
+    }
 }
 
 // GetSoftConfirmedTransaction


### PR DESCRIPTION
Fixes API inconsistency between ZQ1 and ZQ2 where GetSmartContractSubState would return an empty object `{}` instead of `null` when querying for:
- Non-existent variable names
- Non-existent map indices

ZQ1 behavior (expected): returns `null`
ZQ2 behavior (before fix): returns `{}`
ZQ2 behavior (after fix): returns `null` (matches ZQ1)

Changes:
- Modified get_smart_contract_sub_state() to check if result map is empty
- Return Value::Null when no matching state is found
- Added test case to verify the fix and prevent regression

This ensures API compatibility between ZQ1 and ZQ2 implementations.