### PR TITLE
feat: DEVOPS-2060 remove deployer unused api command

### DIFF
--- a/z2/docs/deployer.md
+++ b/z2/docs/deployer.md
@@ -28,7 +28,6 @@ Commands:
   reset                  Reset a network stopping all the nodes and cleaning the /data folder
   restart                Restart a network stopping all the nodes and starting the service again
   monitor                Monitor the network nodes specified metrics
-  api                    Perform operation over the network API nodes
   help                   Print this message or the help of the given subcommand(s)
 
 Options:
@@ -625,51 +624,6 @@ Configuration file: zq2-prototestnet.yaml
 
 ```bash
 z2 deployer restart zq2-prototestnet.yaml
-```
-
-## Perform operations over the API nodes
-
-```bash
-z2 deployer api --help
-```
-
-```bash
-Perform operation over the network API nodes
-
-Usage: z2 deployer api [OPTIONS] --operation <OPERATION> [CONFIG_FILE]
-
-Arguments:
-  [CONFIG_FILE]  The network deployer config file
-
-Options:
-  -o, --operation <OPERATION>  The operation to perform over the API nodes [possible values: attach, detach]
-  -v, --verbose...             Increase logging verbosity
-  -q, --quiet...               Decrease logging verbosity
-  -h, --help                   Print help
-```
-
-### Usage example
-
-#### Scenario detach an API node from the load balancer
-
-```yaml
-Network name: zq2-prototestnet
-Configuration file: zq2-prototestnet.yaml
-```
-
-```bash
-z2 deployer api -o detach zq2-prototestnet.yaml
-```
-
-#### Scenario attach an API node to the load balancer
-
-```yaml
-Network name: zq2-prototestnet
-Configuration file: zq2-prototestnet.yaml
-```
-
-```bash
-z2 deployer api -o attach zq2-prototestnet.yaml
 ```
 
 ## Monitor the network nodes specified metrics

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -12,7 +12,7 @@ use libp2p::PeerId;
 use z2lib::{
     chain::{self, node::NodePort},
     components::Component,
-    deployer::{ApiOperation, Metrics},
+    deployer::Metrics,
     node_spec::{Composition, NodeSpec},
     plumbing, utils, validators,
 };
@@ -114,8 +114,6 @@ enum DeployerCommands {
     Restart(DeployerActionsArgs),
     /// Monitor the network nodes specified metrics
     Monitor(DeployerMonitorArgs),
-    /// Perform operation over the network API nodes
-    Api(DeployerApiArgs),
 }
 
 #[derive(Args, Debug)]
@@ -273,15 +271,6 @@ pub struct DeployerGenerateActionsArgs {
     /// Generate and replace the existing key
     #[clap(long)]
     force: bool,
-}
-
-#[derive(Args, Debug)]
-pub struct DeployerApiArgs {
-    /// The operation to perform over the API nodes
-    #[clap(long, short)]
-    operation: ApiOperation,
-    /// The network deployer config file
-    config_file: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -1048,17 +1037,6 @@ async fn main() -> Result<()> {
                 .map_err(|err| {
                     anyhow::anyhow!("Failed to run deployer monitor command: {}", err)
                 })?;
-                Ok(())
-            }
-            DeployerCommands::Api(arg) => {
-                let config_file = arg.config_file.clone().ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Provide a configuration file. [--config-file] mandatory argument"
-                    )
-                })?;
-                plumbing::run_deployer_api_operation(&config_file, arg.operation.clone())
-                    .await
-                    .map_err(|err| anyhow::anyhow!("Failed to run API operation: {}", err))?;
                 Ok(())
             }
         },

--- a/z2/src/chain/config.rs
+++ b/z2/src/chain/config.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+
 use super::node::NodeRole;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -1217,30 +1217,4 @@ impl ChainNode {
 
         Ok(())
     }
-
-    pub async fn api_attach(&self, multi_progress: &MultiProgress) -> Result<()> {
-        let machine = &self.machine;
-        let progress_bar = multi_progress.add(cliclack::progress_bar(1));
-
-        progress_bar.start(format!("{}: Starting the service", self.name()));
-        machine.run("sudo systemctl start healthcheck.service", false)?;
-        progress_bar.inc(1);
-
-        progress_bar.stop(format!("{} {}: Attach completed", "✔".green(), self.name()));
-
-        Ok(())
-    }
-
-    pub async fn api_detach(&self, multi_progress: &MultiProgress) -> Result<()> {
-        let machine = &self.machine;
-        let progress_bar = multi_progress.add(cliclack::progress_bar(1));
-
-        progress_bar.start(format!("{}: Stopping the service", self.name()));
-        machine.run("sudo systemctl stop healthcheck.service", false)?;
-        progress_bar.inc(1);
-
-        progress_bar.stop(format!("{} {}: Detach completed", "✔".green(), self.name()));
-
-        Ok(())
-    }
 }

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -16,7 +16,7 @@ use crate::{
         self,
         node::{NodePort, NodeRole},
     },
-    deployer::{ApiOperation, Metrics},
+    deployer::Metrics,
     kpi,
     node_spec::{Composition, NodeSpec},
     utils,
@@ -317,12 +317,6 @@ pub async fn run_deployer_monitor(
 ) -> Result<()> {
     println!("🦆 Running monitor for {config_file} .. ");
     deployer::run_monitor(config_file, metric, node_selection, follow).await?;
-    Ok(())
-}
-
-pub async fn run_deployer_api_operation(config_file: &str, operation: ApiOperation) -> Result<()> {
-    println!("🦆 Running API operation '{operation}' for {config_file} .. ");
-    deployer::run_api_operation(config_file, operation).await?;
     Ok(())
 }
 


### PR DESCRIPTION
Removed references and commands.

```
z2 deployer --help
Recompiling z2, please wait …
Group of subcommands to deploy and configure a Zilliqa 2 network

Usage: z2 deployer [OPTIONS] <COMMAND>

Commands:
  install               Install the network defined in the deployer config file
  upgrade               Update the network defined in the deployer config file
  get-config-file       Generate in output the validator config file to join the network
  get-deposit-commands  Generate in output the commands to deposit stake amount to all the validators
  deposit               Deposit stake amounts to the internal validators
  deposit-top-up        Top up stake to the internal validators
  unstake               Unstake funds of the internal validators
  withdraw              Withdraw unstaked funds to the internal validators
  stakers               Show network stake information
  rpc                   Run RPC calls over the internal network nodes
  ssh                   Run command over SSH in the internal network nodes
  backup                Backup a node data dir in the persistence bucket
  restore               Restore a node data dir from a backup in the persistence bucket
  reset                 Reset a network stopping all the nodes and cleaning the /data folder
  restart               Restart a network stopping all the nodes and starting the service again
  monitor               Monitor the network nodes specified metrics
  api                   Perform operation over the network API nodes
  help                  Print this message or the help of the given subcommand(s)

Options:
  -v, --verbose...  Increase logging verbosity
  -q, --quiet...    Decrease logging verbosity
  -h, --help        Print help
```