### PR TITLE
feat: DEVOPS-2093 no-restart option to avoid starting the service after zq2 restore

### DIFF
--- a/z2/docs/deployer.md
+++ b/z2/docs/deployer.md
@@ -539,6 +539,7 @@ Arguments:
 Options:
   -n, --name <NAME>                  The name of the backup folder. If zip is specified, it represents the name of the zip file
       --zip                          If specified, restore the persistence from a zip file
+      --no-restart                   If specified, the service will not be restarted after the restore
       --max-parallel <MAX_PARALLEL>  Define the number of nodes to process in parallel. Default: 50
   -v, --verbose...                   Increase logging verbosity
   -q, --quiet...                     Decrease logging verbosity

--- a/z2/src/bin/z2.rs
+++ b/z2/src/bin/z2.rs
@@ -254,6 +254,9 @@ pub struct DeployerRestoreArgs {
     /// If specified, restore the persistence from a zip file
     #[clap(long)]
     zip: bool,
+    /// If specified, the service will not be restarted after the restore
+    #[clap(long)]
+    no_restart: bool,
     /// Define the number of nodes to process in parallel. Default: 50
     #[clap(long)]
     max_parallel: Option<usize>,
@@ -988,6 +991,7 @@ async fn main() -> Result<()> {
                     arg.max_parallel,
                     arg.name.clone(),
                     arg.zip,
+                    arg.no_restart,
                 )
                 .await
                 .map_err(|err| {

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -973,9 +973,7 @@ impl ChainNode {
 
         let bar_length = if zip {
             if no_restart { 5 } else { 6 }
-        } else {
-            if no_restart { 3 } else { 4 }
-        };
+        } else if no_restart { 3 } else { 4 };
         let progress_bar = multi_progress.add(cliclack::progress_bar(bar_length));
 
         // stop the service

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -973,7 +973,11 @@ impl ChainNode {
 
         let bar_length = if zip {
             if no_restart { 5 } else { 6 }
-        } else if no_restart { 3 } else { 4 };
+        } else if no_restart {
+            3
+        } else {
+            4
+        };
         let progress_bar = multi_progress.add(cliclack::progress_bar(bar_length));
 
         // stop the service

--- a/z2/src/deployer.rs
+++ b/z2/src/deployer.rs
@@ -856,6 +856,7 @@ pub async fn run_restore(
     max_parallel: usize,
     name: Option<String>,
     zip: bool,
+    no_restart: bool,
 ) -> Result<()> {
     let config = NetworkConfig::from_file(config_file).await?;
     let chain = ChainInstance::new(config).await?;
@@ -889,7 +890,7 @@ pub async fn run_restore(
         let permit = semaphore.clone().acquire_owned().await?;
         let mp = multi_progress.to_owned();
         let future = task::spawn(async move {
-            let result = node.restore_from(name, zip, &mp).await;
+            let result = node.restore_from(name, zip, no_restart, &mp).await;
             drop(permit); // Release the permit when the task is done
             (node, result)
         });

--- a/z2/src/plumbing.rs
+++ b/z2/src/plumbing.rs
@@ -291,9 +291,17 @@ pub async fn run_deployer_restore(
     max_parallel: Option<usize>,
     name: Option<String>,
     zip: bool,
+    no_restart: bool,
 ) -> Result<()> {
     println!("🦆 Restoring process for {config_file} .. ");
-    deployer::run_restore(config_file, max_parallel.unwrap_or(50), name, zip).await?;
+    deployer::run_restore(
+        config_file,
+        max_parallel.unwrap_or(50),
+        name,
+        zip,
+        no_restart,
+    )
+    .await?;
     Ok(())
 }
 


### PR DESCRIPTION
`--no-restart` parameter in zq2 deployer restore
If specified, the service will not be restarted after the restore.

Tests:
`z2 deployer restore --no-restart zq2-infratest.yaml`
```
🦆 Restoring process for zq2-infratest.yaml ..
Using the project ID prj-d-zq2-devnet-c83bkpsd
Create the instance list for zq2-infratest
◇  Select target nodes
│  zq2-infratest-api-ase1-2
│
◇  Restoring the nodes data dir
│  ✔ zq2-infratest-api-ase1-2: Restore completed (service not restarted)
```