### PR TITLE
Make message routing, stricter - dropping unexpected messages, early.

### DIFF
--- a/zilliqa/src/message.rs
+++ b/zilliqa/src/message.rs
@@ -255,6 +255,7 @@ pub struct IntershardCall {
 
 /// A message intended to be sent over the network as part of p2p communication.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+/// Keep this in-sync with the routing in P2pNode::start()
 pub enum ExternalMessage {
     Proposal(Proposal),
     Vote(Box<Vote>),


### PR DESCRIPTION
To avoid cross-pollution e.g. Proposals sent as requests, being received and processed. The node will only receive and then process expected message flows.