### PR TITLE
Always expose the finalized block in Zilliqa APIs

### DIFF
--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -540,11 +540,11 @@ impl Node {
         }
     }
 
-    pub fn get_latest_finalized_block(&self) -> Result<Option<Block>> {
+    pub fn get_finalized_block(&self) -> Result<Option<Block>> {
         self.resolve_block_number(BlockNumberOrTag::Finalized)
     }
 
-    pub fn get_latest_finalized_block_number(&self) -> Result<u64> {
+    pub fn get_finalized_block_number(&self) -> Result<u64> {
         match self.resolve_block_number(BlockNumberOrTag::Finalized)? {
             Some(block) => Ok(block.number()),
             None => Ok(0),

--- a/zilliqa/tests/it/zil.rs
+++ b/zilliqa/tests/it/zil.rs
@@ -46,12 +46,12 @@ pub async fn zilliqa_account_with_funds(
         .run_until_async(
             || async {
                 wallet
-                    .get_transaction_receipt(hash)
+                    .provider()
+                    .request::<[_; 1], Option<Value>>("GetTransaction", [hash])
                     .await
-                    .unwrap()
-                    .is_some()
+                    .is_ok()
             },
-            50,
+            200,
         )
         .await
         .unwrap();


### PR DESCRIPTION
This fixes the remaining few places where we would query data from the latest block instead of the finalized block.