### PR TITLE
Alter TxZilliqa serializer to keep it < 230 bytes

### DIFF
--- a/z2/resources/chain-specs/zq2-mainnet.toml
+++ b/z2/resources/chain-specs/zq2-mainnet.toml
@@ -2,86 +2,91 @@ network = "zq2-mainnet"
 p2p_port = 3333
 
 bootstrap_address = [
-  "12D3KooWLQ9Uu31ZVn2wMwt5HgunwHYRh4V12cLuTa9qqyFKxkqS",
-  "/dns/bootstrap.zq2-mainnet.zilliqa.com/tcp/3333"
+    "12D3KooWLQ9Uu31ZVn2wMwt5HgunwHYRh4V12cLuTa9qqyFKxkqS",
+    "/dns/bootstrap.zq2-mainnet.zilliqa.com/tcp/3333",
 ]
 
 [[nodes]]
 eth_chain_id = 32769
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [ ["0xa50581ea4c4cec6b53262ca16b5b003d34c820be", "100_000_000_000_000_000_000" ] ]
+consensus.genesis_accounts = [
+    [
+        "0xa50581ea4c4cec6b53262ca16b5b003d34c820be",
+        "100_000_000_000_000_000_000",
+    ],
+]
 consensus.genesis_deposits = [
-  [
-    "833c9265b6443f2707e506081e2bc08c55d867c04dca6171f9203876fcf436335464703747b425458ce60b83036bfcba",
-    "12D3KooWNSC7ZnMRYu6f4CMAjfCc5KzUMhyd31UQXDfR2QFPPg9K",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "b8e9d87775aa2ad48f1e263434ff7f13c7c68c1c89c0e0031f791f35a3907ee1014ffc2d7b67fc534022da2fe5152d61",
-    "12D3KooWShbg7H3LSPZZrSYa6JyacX8eLFDiSSPha4gEWq5q1fd7",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "b4f5f2573109d4c33a95df26aed1727e5e388c5d37f446ede0576b98e23d1ea88fcc3cd1b981e45b2c584187a18f8fb6",
-    "12D3KooWLAHDwZMphR4akwzxzbpSWfqvzommPYftNu5cohNbtyUz",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "adcdcc405d4edaf804e6a96b912021ae2e5ef6000ff7cb9ce0012620b6525c80e1b015b18e172bb54cdf213af0ca070d",
-    "12D3KooWAZkrsNMmpje2ToBXAJMERbMg5HGC8aAzvTJwAR3VxQos",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "8afe2d8034b8cfd4282d638715086fb6ede67ac0fe7503e3c996064b645d461a518370ab12f228e5f2be5c3ff170a725",
-    "12D3KooWKY2gxqPsJ11gweKWvYGZd4F2Z1T8dYEaYRc49Bz2JGVN",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "b78794fd6708cec1b7ab0716fe48d9b72e0b89015a0c3d3c86c24310569f9cbff389910cfc147fd7f7d59b0b34cb7025",
-    "12D3KooWNUDP3wtdJXxEubzPtEuWqF142TP9fmJrGrQKRKdvJUvB",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "ae1b41871f821517561cd6430772d75e28e21f971dbe119f31025672ec49c696d7e70fae05af7cc9e0fe0ecbac97acca",
-    "12D3KooWLrZaV4NfuSZCm3f731Yf8AxM8csVTv498ikCTdYm6anc",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "800772dfa8a53fef9f075380a7ab835f2dd07c88a608400e8c02a96d031f69aa4a8f95b6e79a6a8787a86f0cb3409710",
-    "12D3KooWQUq7Y2KsCrMaFGnsNB6tC5f1W1uRXmLjBZYcsJewE5TL",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "afb35a4ca993d53647ade97788913fba1ffa658ab70bac01a661ed1d3fa7721c3979012c9ce5d6995d0726dd8fcc59a6",
-    "12D3KooWNZDZbdxGFEZY4XkP9ymzUVH65bWAxXPMUSta5Y1i6kxb",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "93c027c2d9b9611affec8f785add787bbc548f2efe5e2c911c45d814e87a2cc5c39463fdda7d2137b8e8280902366a25",
-    "12D3KooWBhH9yj4Qwq4Dm99p6QzWeuUBQBjFD9jhsoF7LoUSezNs",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ]
+    [
+        "833c9265b6443f2707e506081e2bc08c55d867c04dca6171f9203876fcf436335464703747b425458ce60b83036bfcba",
+        "12D3KooWNSC7ZnMRYu6f4CMAjfCc5KzUMhyd31UQXDfR2QFPPg9K",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "b8e9d87775aa2ad48f1e263434ff7f13c7c68c1c89c0e0031f791f35a3907ee1014ffc2d7b67fc534022da2fe5152d61",
+        "12D3KooWShbg7H3LSPZZrSYa6JyacX8eLFDiSSPha4gEWq5q1fd7",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "b4f5f2573109d4c33a95df26aed1727e5e388c5d37f446ede0576b98e23d1ea88fcc3cd1b981e45b2c584187a18f8fb6",
+        "12D3KooWLAHDwZMphR4akwzxzbpSWfqvzommPYftNu5cohNbtyUz",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "adcdcc405d4edaf804e6a96b912021ae2e5ef6000ff7cb9ce0012620b6525c80e1b015b18e172bb54cdf213af0ca070d",
+        "12D3KooWAZkrsNMmpje2ToBXAJMERbMg5HGC8aAzvTJwAR3VxQos",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "8afe2d8034b8cfd4282d638715086fb6ede67ac0fe7503e3c996064b645d461a518370ab12f228e5f2be5c3ff170a725",
+        "12D3KooWKY2gxqPsJ11gweKWvYGZd4F2Z1T8dYEaYRc49Bz2JGVN",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "b78794fd6708cec1b7ab0716fe48d9b72e0b89015a0c3d3c86c24310569f9cbff389910cfc147fd7f7d59b0b34cb7025",
+        "12D3KooWNUDP3wtdJXxEubzPtEuWqF142TP9fmJrGrQKRKdvJUvB",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "ae1b41871f821517561cd6430772d75e28e21f971dbe119f31025672ec49c696d7e70fae05af7cc9e0fe0ecbac97acca",
+        "12D3KooWLrZaV4NfuSZCm3f731Yf8AxM8csVTv498ikCTdYm6anc",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "800772dfa8a53fef9f075380a7ab835f2dd07c88a608400e8c02a96d031f69aa4a8f95b6e79a6a8787a86f0cb3409710",
+        "12D3KooWQUq7Y2KsCrMaFGnsNB6tC5f1W1uRXmLjBZYcsJewE5TL",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "afb35a4ca993d53647ade97788913fba1ffa658ab70bac01a661ed1d3fa7721c3979012c9ce5d6995d0726dd8fcc59a6",
+        "12D3KooWNZDZbdxGFEZY4XkP9ymzUVH65bWAxXPMUSta5Y1i6kxb",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "93c027c2d9b9611affec8f785add787bbc548f2efe5e2c911c45d814e87a2cc5c39463fdda7d2137b8e8280902366a25",
+        "12D3KooWBhH9yj4Qwq4Dm99p6QzWeuUBQBjFD9jhsoF7LoUSezNs",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
 ]
 
 # Reward parameters
@@ -95,12 +100,51 @@ consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params =
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 sync.ignore_passive = true
 
-api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
-consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [], scilla_delta_maps_are_applied_correctly = false, scilla_server_unlimited_response_size = false, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false }
+api_servers = [
+    { port = 4201, enabled_apis = [
+        { namespace = "eth", apis = [
+            "blockNumber",
+        ] },
+    ] },
+    { port = 4202, enabled_apis = [
+        "admin",
+        "debug",
+        "erigon",
+        "eth",
+        "net",
+        "ots",
+        "trace",
+        "txpool",
+        "web3",
+        "zilliqa",
+    ] },
+]
+consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [
+], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [
+], scilla_delta_maps_are_applied_correctly = false, scilla_server_unlimited_response_size = false, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false, smaller_cbor_encoding_for_txzilliqa = false }
 consensus.forks = [
     { at_height = 4770088, executable_blocks = true },
     { at_height = 4854500, scilla_delta_maps_are_applied_correctly = true },
-    { at_height = 4957200, scilla_call_gas_exempt_addrs = ["0x95347b860Bd49818AFAccCA8403C55C23e7BB9ED", "0xe64cA52EF34FdD7e20C0c7fb2E392cc9b4F6D049", "0x63B991C17010C21250a0eA58C6697F696a48cdf3", "0x241c677D9969419800402521ae87C411897A029f", "0x2274005778063684fbB1BfA96a2b725dC37D75f9", "0x598FbD8B68a8B7e75b8B7182c750164f348907Bc", "0x2938fF251Aecc1dfa768D7d0276eB6d073690317", "0x17D5af5658A24bd964984b36d28e879a8626adC3", "0xCcF3Ea256d42Aeef0EE0e39Bfc94bAa9Fa14b0Ba", "0xc6F3dede529Af9D98a11C5B32DbF03Bf34272ED5", "0x7D2fF48c6b59229d448473D267a714d29F078D3E", "0xE9D47623bb2B3C497668B34fcf61E101a7ea4058", "0x03A79429acc808e4261a68b0117aCD43Cb0FdBfa", "0x097C26F8A93009fd9d98561384b5014D64ae17C2", "0x01035e423c40a9ad4F6be2E6cC014EB5617c8Bd6", "0x9C3fE3f471d8380297e4fB222eFb313Ee94DFa0f", "0x20Dd5D5B5d4C72676514A0eA1052d0200003d69D", "0xbfDe2156aF75a29d36614bC1F8005DD816Bd9200"] },
+    { at_height = 4957200, scilla_call_gas_exempt_addrs = [
+        "0x95347b860Bd49818AFAccCA8403C55C23e7BB9ED",
+        "0xe64cA52EF34FdD7e20C0c7fb2E392cc9b4F6D049",
+        "0x63B991C17010C21250a0eA58C6697F696a48cdf3",
+        "0x241c677D9969419800402521ae87C411897A029f",
+        "0x2274005778063684fbB1BfA96a2b725dC37D75f9",
+        "0x598FbD8B68a8B7e75b8B7182c750164f348907Bc",
+        "0x2938fF251Aecc1dfa768D7d0276eB6d073690317",
+        "0x17D5af5658A24bd964984b36d28e879a8626adC3",
+        "0xCcF3Ea256d42Aeef0EE0e39Bfc94bAa9Fa14b0Ba",
+        "0xc6F3dede529Af9D98a11C5B32DbF03Bf34272ED5",
+        "0x7D2fF48c6b59229d448473D267a714d29F078D3E",
+        "0xE9D47623bb2B3C497668B34fcf61E101a7ea4058",
+        "0x03A79429acc808e4261a68b0117aCD43Cb0FdBfa",
+        "0x097C26F8A93009fd9d98561384b5014D64ae17C2",
+        "0x01035e423c40a9ad4F6be2E6cC014EB5617c8Bd6",
+        "0x9C3fE3f471d8380297e4fB222eFb313Ee94DFa0f",
+        "0x20Dd5D5B5d4C72676514A0eA1052d0200003d69D",
+        "0xbfDe2156aF75a29d36614bC1F8005DD816Bd9200",
+    ] },
     { at_height = 4986000, scilla_server_unlimited_response_size = true },
     { at_height = 5528557, scilla_failed_txn_correct_balance_deduction = true, scilla_transition_proper_order = true, evm_to_scilla_value_transfer_zero = true, restore_xsgd_contract = true },
 ]

--- a/z2/resources/chain-specs/zq2-testnet.toml
+++ b/z2/resources/chain-specs/zq2-testnet.toml
@@ -2,65 +2,70 @@ network = "zq2-testnet"
 p2p_port = 3333
 
 bootstrap_address = [
-  "12D3KooWPFzgn8XUdrvRMuJmSPXRZPBBzv2ZmDmeKM8HGE8gKDJP",
-  "/dns/bootstrap.zq2-testnet.zilliqa.com/tcp/3333"
+    "12D3KooWPFzgn8XUdrvRMuJmSPXRZPBBzv2ZmDmeKM8HGE8gKDJP",
+    "/dns/bootstrap.zq2-testnet.zilliqa.com/tcp/3333",
 ]
 
 [[nodes]]
 eth_chain_id = 33101
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [ ["0x214695413d1ea6a4a4453cd24ffd151fbc95496a", "900_000_000_000_000_000_000_000_000" ] ]
+consensus.genesis_accounts = [
+    [
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+        "900_000_000_000_000_000_000_000_000",
+    ],
+]
 consensus.genesis_deposits = [
-  [
-    "94ce9650426f5c5b7eeb8499b94bc2cc6b82b423f3bb235889d3120aedc75a1d8236c2912dda45b75a3226731a776cbf",
-    "12D3KooWQPkr3EGzqiVdRcLTBo3sjBA5J2HRbBR6kcxY3QNCDF1M",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "b2ba01dbc1989399ffca35c1e9c73613bbe678c94740feb035538d7299c4bd8ba98b28292982857534f60289ca2b663c",
-    "12D3KooWRuSPXcoiFHaFkxgfy3P4UnhB5vKtgShkXTWL9xfdVZ1V",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "ae776c587e6869d41331529c6dd0f59c31d1ef4c47f8b5ecb1acc54fa7452d9b2ba6f56bdad08a606d25761c8522b367",
-    "12D3KooWJyH1r2UfcFPiHbEFBYB3xWufR1va8cRK3veMwfUunfRD",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "95de7dae002295bba9c4cffd1b0df70a7ccd0cc68e6b10da06b1b91f8a7e9b305e19431fc42b7413c65a8ab6959e41c6",
-    "12D3KooWM5L182sQtJuARf5Xfg517xVqZRaPM9583BsmLcv5Ma2o",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "ae96338209ec4f1ad446a131e687bde02506207b750465cbc43d1ea4f5b32daa51ff060e8451c903d6de7f1c89951b1d",
-    "12D3KooWQpAM4F19CwJAAhHFgeD7feyQLHDTxzKu2hsVH4BQceSQ",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "a3a2419fba7962021d730f4e1eb087b5bf0d66140ef7d4ba758348b13fb2ffa9a75afbdbef988c65ce625544360dea42",
-    "12D3KooWAWoMVZAXJDkuhyzyBJHGHn2gYFyTbbdZGhHs4BuEN5Fe",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "8093ea6fa4720ca0975559a5f9d3a2694c6ab8e63a8c54e986d11a28f9e958f006420e30a8d6f04d6b2df63fe6e0563d",
-    "12D3KooWNqZxaW4ZirvWUNj9KSRgTp55RsZHSFumDeRdCLZAjNNA",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ]
+    [
+        "94ce9650426f5c5b7eeb8499b94bc2cc6b82b423f3bb235889d3120aedc75a1d8236c2912dda45b75a3226731a776cbf",
+        "12D3KooWQPkr3EGzqiVdRcLTBo3sjBA5J2HRbBR6kcxY3QNCDF1M",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "b2ba01dbc1989399ffca35c1e9c73613bbe678c94740feb035538d7299c4bd8ba98b28292982857534f60289ca2b663c",
+        "12D3KooWRuSPXcoiFHaFkxgfy3P4UnhB5vKtgShkXTWL9xfdVZ1V",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "ae776c587e6869d41331529c6dd0f59c31d1ef4c47f8b5ecb1acc54fa7452d9b2ba6f56bdad08a606d25761c8522b367",
+        "12D3KooWJyH1r2UfcFPiHbEFBYB3xWufR1va8cRK3veMwfUunfRD",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "95de7dae002295bba9c4cffd1b0df70a7ccd0cc68e6b10da06b1b91f8a7e9b305e19431fc42b7413c65a8ab6959e41c6",
+        "12D3KooWM5L182sQtJuARf5Xfg517xVqZRaPM9583BsmLcv5Ma2o",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "ae96338209ec4f1ad446a131e687bde02506207b750465cbc43d1ea4f5b32daa51ff060e8451c903d6de7f1c89951b1d",
+        "12D3KooWQpAM4F19CwJAAhHFgeD7feyQLHDTxzKu2hsVH4BQceSQ",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "a3a2419fba7962021d730f4e1eb087b5bf0d66140ef7d4ba758348b13fb2ffa9a75afbdbef988c65ce625544360dea42",
+        "12D3KooWAWoMVZAXJDkuhyzyBJHGHn2gYFyTbbdZGhHs4BuEN5Fe",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "8093ea6fa4720ca0975559a5f9d3a2694c6ab8e63a8c54e986d11a28f9e958f006420e30a8d6f04d6b2df63fe6e0563d",
+        "12D3KooWNqZxaW4ZirvWUNj9KSRgTp55RsZHSFumDeRdCLZAjNNA",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
 ]
 
 # Reward parameters
@@ -74,10 +79,43 @@ consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params =
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 sync.ignore_passive = true
 
-api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
-consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [], scilla_delta_maps_are_applied_correctly = true, scilla_server_unlimited_response_size = true, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false }
+api_servers = [
+    { port = 4201, enabled_apis = [
+        { namespace = "eth", apis = [
+            "blockNumber",
+        ] },
+    ] },
+    { port = 4202, enabled_apis = [
+        "admin",
+        "debug",
+        "erigon",
+        "eth",
+        "net",
+        "ots",
+        "trace",
+        "txpool",
+        "web3",
+        "zilliqa",
+    ] },
+]
+consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [
+], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [
+], scilla_delta_maps_are_applied_correctly = true, scilla_server_unlimited_response_size = true, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false, smaller_cbor_encoding_for_txzilliqa = false }
 consensus.forks = [
     { at_height = 8099088, executable_blocks = true },
-    { at_height = 8377200, scilla_call_gas_exempt_addrs = ["0x60E6b5b1B8D3E373E1C04dC0b4f5624776bcBB60", "0x7013Da2653453299Efb867EfcCCcB1A6d5FE1384", "0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3", "0xE90Dd366D627aCc5feBEC126211191901A69f8a0", "0x5900Ac075A67742f5eA4204650FEad9E674c664F", "0x28e8d39fc68eaa27c88797eb7d324b4b97d5b844", "0x51b9f3ddb948bcc16b89b48d83b920bc01dbed55", "0x1fD09F6701a1852132A649fe9D07F2A3b991eCfA", "0x878c5008A348A60a5B239844436A7b483fAdb7F2", "0x8895Aa1bEaC254E559A3F91e579CF4a67B70ce02", "0x453b11386FBd54bC532892c0217BBc316fc7b918", "0xaD581eC62eA08831c8FE2Cd7A1113473fE40A057"] },
+    { at_height = 8377200, scilla_call_gas_exempt_addrs = [
+        "0x60E6b5b1B8D3E373E1C04dC0b4f5624776bcBB60",
+        "0x7013Da2653453299Efb867EfcCCcB1A6d5FE1384",
+        "0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3",
+        "0xE90Dd366D627aCc5feBEC126211191901A69f8a0",
+        "0x5900Ac075A67742f5eA4204650FEad9E674c664F",
+        "0x28e8d39fc68eaa27c88797eb7d324b4b97d5b844",
+        "0x51b9f3ddb948bcc16b89b48d83b920bc01dbed55",
+        "0x1fD09F6701a1852132A649fe9D07F2A3b991eCfA",
+        "0x878c5008A348A60a5B239844436A7b483fAdb7F2",
+        "0x8895Aa1bEaC254E559A3F91e579CF4a67B70ce02",
+        "0x453b11386FBd54bC532892c0217BBc316fc7b918",
+        "0xaD581eC62eA08831c8FE2Cd7A1113473fE40A057",
+    ] },
     { at_height = 9341630, scilla_failed_txn_correct_balance_deduction = true, scilla_transition_proper_order = true, evm_to_scilla_value_transfer_zero = true, restore_xsgd_contract = true },
 ]

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -191,6 +191,7 @@ impl Chain {
                 "scilla_transition_proper_order": false,
                 "evm_to_scilla_value_transfer_zero": false,
                 "restore_xsgd_contract": false,
+                "smaller_cbor_encoding_for_txzilliqa": false, // differs from default
             })),
             Chain::Zq2Mainnet => Some(json!({
                 "at_height": 0,
@@ -216,6 +217,7 @@ impl Chain {
                 "scilla_transition_proper_order": false,
                 "evm_to_scilla_value_transfer_zero": false,
                 "restore_xsgd_contract": false,
+                "smaller_cbor_encoding_for_txzilliqa": false, // differs from default
             })),
             _ => None,
         }

--- a/zilliqa/benches/it.rs
+++ b/zilliqa/benches/it.rs
@@ -295,7 +295,7 @@ fn full_blocks_zil_transfers(c: &mut Criterion) {
         address,
         iter::empty(),
         txns,
-        2300,
+        4000,
     );
 }
 

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -587,6 +587,9 @@ impl Forks {
                 ForkName::ScillaTransitionsProperOrder => fork.scilla_transition_proper_order,
                 ForkName::EvmToScillaValueTransferZero => fork.evm_to_scilla_value_transfer_zero,
                 ForkName::RestoreXsgdContract => fork.restore_xsgd_contract,
+                ForkName::SmallerCborEncodingForTxZilliqa => {
+                    fork.smaller_cbor_encoding_for_txzilliqa
+                }
             } {
                 return Some(fork.at_height);
             }
@@ -620,6 +623,7 @@ pub struct Fork {
     pub scilla_transition_proper_order: bool,
     pub evm_to_scilla_value_transfer_zero: bool,
     pub restore_xsgd_contract: bool,
+    pub smaller_cbor_encoding_for_txzilliqa: bool,
 }
 
 pub enum ForkName {
@@ -639,6 +643,7 @@ pub enum ForkName {
     ScillaTransitionsProperOrder,
     EvmToScillaValueTransferZero,
     RestoreXsgdContract,
+    SmallerCborEncodingForTxZilliqa,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -728,6 +733,8 @@ pub struct ForkDelta {
     pub evm_to_scilla_value_transfer_zero: Option<bool>,
     /// If true, re-write XSGD contract to address 0x173CA6770aA56eb00511Dac8e6E13B3D7f16A5a5's code
     pub restore_xsgd_contract: Option<bool>,
+    /// If true, use smaller CBOR encoding for TxZilliqa
+    pub smaller_cbor_encoding_for_txzilliqa: Option<bool>,
 }
 
 impl Fork {
@@ -801,6 +808,9 @@ impl Fork {
             restore_xsgd_contract: delta
                 .restore_xsgd_contract
                 .unwrap_or(self.restore_xsgd_contract),
+            smaller_cbor_encoding_for_txzilliqa: delta
+                .restore_xsgd_contract
+                .unwrap_or(self.smaller_cbor_encoding_for_txzilliqa),
         }
     }
 }
@@ -895,6 +905,7 @@ pub fn genesis_fork_default() -> Fork {
         scilla_transition_proper_order: true,
         evm_to_scilla_value_transfer_zero: true,
         restore_xsgd_contract: true,
+        smaller_cbor_encoding_for_txzilliqa: true,
     }
 }
 
@@ -1037,6 +1048,7 @@ mod tests {
                 scilla_transition_proper_order: None,
                 evm_to_scilla_value_transfer_zero: None,
                 restore_xsgd_contract: None,
+                smaller_cbor_encoding_for_txzilliqa: None,
             }],
             ..Default::default()
         };
@@ -1082,6 +1094,7 @@ mod tests {
                     scilla_transition_proper_order: None,
                     evm_to_scilla_value_transfer_zero: None,
                     restore_xsgd_contract: None,
+                    smaller_cbor_encoding_for_txzilliqa: None,
                 },
                 ForkDelta {
                     at_height: 20,
@@ -1107,6 +1120,7 @@ mod tests {
                     scilla_transition_proper_order: None,
                     evm_to_scilla_value_transfer_zero: None,
                     restore_xsgd_contract: None,
+                    smaller_cbor_encoding_for_txzilliqa: None,
                 },
             ],
             ..Default::default()
@@ -1166,6 +1180,7 @@ mod tests {
                     scilla_transition_proper_order: None,
                     evm_to_scilla_value_transfer_zero: None,
                     restore_xsgd_contract: None,
+                    smaller_cbor_encoding_for_txzilliqa: None,
                 },
                 ForkDelta {
                     at_height: 10,
@@ -1191,6 +1206,7 @@ mod tests {
                     scilla_transition_proper_order: None,
                     evm_to_scilla_value_transfer_zero: None,
                     restore_xsgd_contract: None,
+                    smaller_cbor_encoding_for_txzilliqa: None,
                 },
             ],
             ..Default::default()
@@ -1241,6 +1257,7 @@ mod tests {
                 scilla_transition_proper_order: true,
                 evm_to_scilla_value_transfer_zero: true,
                 restore_xsgd_contract: true,
+                smaller_cbor_encoding_for_txzilliqa: true,
             },
             forks: vec![],
             ..Default::default()
@@ -1279,6 +1296,7 @@ mod tests {
                     scilla_transition_proper_order: None,
                     evm_to_scilla_value_transfer_zero: None,
                     restore_xsgd_contract: None,
+                    smaller_cbor_encoding_for_txzilliqa: None,
                 },
                 ForkDelta {
                     at_height: 20,
@@ -1304,6 +1322,7 @@ mod tests {
                     scilla_transition_proper_order: None,
                     evm_to_scilla_value_transfer_zero: None,
                     restore_xsgd_contract: None,
+                    smaller_cbor_encoding_for_txzilliqa: None,
                 },
             ],
             ..Default::default()

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -3307,6 +3307,10 @@ impl Consensus {
             state.contract_upgrade_apply_state_change(&self.config.consensus, block.header)?;
         }
 
+        // TODO: Remove this check after the hardfork, and make it permanent.
+        crate::transaction::ser_pubkey::new_format(fork.smaller_cbor_encoding_for_txzilliqa);
+        crate::transaction::ser_signature::new_format(fork.smaller_cbor_encoding_for_txzilliqa);
+
         Ok(())
     }
 

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -1491,18 +1491,26 @@ fn test_encode_zilliqa_transaction() {
     let encoded = cbor4ii::serde::to_vec(Vec::with_capacity(1024 * 1024), &data).unwrap();
     let e_data = cbor4ii::serde::from_slice::<SignedTransaction>(&encoded).unwrap();
 
+    let new_bin = bincode::serialize(&data).unwrap();
+
     ser_signature::new_format(false);
     let partial = cbor4ii::serde::to_vec(Vec::with_capacity(1024 * 1024), &data).unwrap();
+    let p_data = cbor4ii::serde::from_slice::<SignedTransaction>(&partial).unwrap();
 
     ser_pubkey::new_format(false);
     let original = cbor4ii::serde::to_vec(Vec::with_capacity(1024 * 1024), &data).unwrap();
     let o_data = cbor4ii::serde::from_slice::<SignedTransaction>(&original).unwrap();
 
+    let old_bin = bincode::serialize(&data).unwrap();
+
     // check for difference
+    assert_eq!(o_data, data);
+    assert_eq!(p_data, data);
+    assert_eq!(e_data, data);
+    assert_eq!(new_bin, old_bin); // bincode data should be unchanged
+    // check for size
     assert!(original.len() > 300);
     assert!(partial.len() < 300);
     assert!(partial.len() > 230);
     assert!(encoded.len() < 230); // 4000 txns fit inside 90% of 1MB
-    assert_eq!(o_data, data);
-    assert_eq!(e_data, data);
 }

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -175,8 +175,9 @@ pub enum SignedTransaction {
 // Custom serialization to avoid double-byte encodings.
 // https://github.com/Zilliqa/zq2/issues/2922
 mod ser_signature {
-    use super::schnorr::Signature;
     use serde::{Deserializer, Serializer};
+
+    use super::schnorr::Signature;
 
     pub fn serialize<S>(signature: &Signature, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -219,9 +220,10 @@ mod ser_signature {
 }
 
 mod ser_pubkey {
-    use super::schnorr::PublicKey;
     use k256::elliptic_curve::sec1::ToEncodedPoint;
     use serde::{Deserializer, Serializer};
+
+    use super::schnorr::PublicKey;
 
     pub fn serialize<S>(public_key: &PublicKey, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -157,6 +157,7 @@ pub enum SignedTransaction {
         sig: PrimitiveSignature,
     },
     Zilliqa {
+        #[serde(with = "ser_rlp")]
         tx: TxZilliqa,
         key: schnorr::PublicKey,
         sig: schnorr::Signature,
@@ -827,7 +828,9 @@ impl TxIntershard {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TxZilliqa {
+    #[serde(with = "alloy::serde::quantity")]
     pub chain_id: u16,
+    #[serde(with = "alloy::serde::quantity")]
     pub nonce: u64,
     pub gas_price: ZilAmount,
     pub gas_limit: ScillaGas,
@@ -870,6 +873,45 @@ impl TxZilliqa {
         }
         let hashed = hasher.finalize();
         Ok(Address::from_slice(&hashed[12..]))
+    }
+}
+
+impl alloy::rlp::Encodable for TxZilliqa {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.chain_id.encode(out);
+        self.nonce.encode(out);
+        self.gas_price.encode(out);
+        self.gas_limit.encode(out);
+        self.to_addr.encode(out);
+        self.amount.encode(out);
+        self.code.encode(out);
+        self.data.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.chain_id.length()
+            + self.nonce.length()
+            + self.gas_price.length()
+            + self.gas_limit.length()
+            + self.to_addr.length()
+            + self.amount.length()
+            + self.code.length()
+            + self.data.length()
+    }
+}
+
+impl alloy::rlp::Decodable for TxZilliqa {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        Ok(Self {
+            chain_id: alloy::rlp::Decodable::decode(buf)?,
+            nonce: alloy::rlp::Decodable::decode(buf)?,
+            gas_price: alloy::rlp::Decodable::decode(buf)?,
+            gas_limit: alloy::rlp::Decodable::decode(buf)?,
+            to_addr: alloy::rlp::Decodable::decode(buf)?,
+            amount: alloy::rlp::Decodable::decode(buf)?,
+            code: alloy::rlp::Decodable::decode(buf)?,
+            data: alloy::rlp::Decodable::decode(buf)?,
+        })
     }
 }
 
@@ -924,6 +966,22 @@ impl ZilAmount {
     }
 }
 
+impl alloy::rlp::Decodable for ZilAmount {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        Ok(ZilAmount(<u128 as alloy::rlp::Decodable>::decode(buf)?))
+    }
+}
+
+impl alloy::rlp::Encodable for ZilAmount {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.0.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.0.length()
+    }
+}
+
 impl Add for ZilAmount {
     type Output = ZilAmount;
 
@@ -973,6 +1031,22 @@ pub struct ScillaGas(pub u64);
 impl ScillaGas {
     pub fn checked_sub(self, rhs: ScillaGas) -> Option<ScillaGas> {
         Some(ScillaGas(self.0.checked_sub(rhs.0)?))
+    }
+}
+
+impl alloy::rlp::Decodable for ScillaGas {
+    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
+        Ok(ScillaGas(<u64 as alloy::rlp::Decodable>::decode(buf)?))
+    }
+}
+
+impl alloy::rlp::Encodable for ScillaGas {
+    fn encode(&self, out: &mut dyn BufMut) {
+        self.0.encode(out);
+    }
+
+    fn length(&self) -> usize {
+        self.0.length()
     }
 }
 

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -175,24 +175,24 @@ pub enum SignedTransaction {
 // Custom serialization to avoid double-byte encodings.
 // https://github.com/Zilliqa/zq2/issues/2922
 mod ser_signature {
-    pub fn serialize<S>(
-        signature: &k256::ecdsa::Signature,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
+    use super::schnorr::Signature;
+    use serde::{Deserializer, Serializer};
+
+    pub fn serialize<S>(signature: &Signature, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         let bytes = signature.to_bytes();
         serializer.serialize_bytes(bytes.as_slice())
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<k256::ecdsa::Signature, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Signature, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct SignatureVisitor;
-        impl<'de> serde::de::Visitor<'de> for SignatureVisitor {
-            type Value = k256::ecdsa::Signature;
+        impl serde::de::Visitor<'_> for SignatureVisitor {
+            type Value = Signature;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a byte array representing a signature")
@@ -219,24 +219,26 @@ mod ser_signature {
 }
 
 mod ser_pubkey {
+    use super::schnorr::PublicKey;
     use k256::elliptic_curve::sec1::ToEncodedPoint;
+    use serde::{Deserializer, Serializer};
 
-    pub fn serialize<S>(public_key: &k256::PublicKey, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(public_key: &PublicKey, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: serde::Serializer,
+        S: Serializer,
     {
         let bytes = public_key.to_encoded_point(false);
         serializer.serialize_bytes(bytes.as_bytes())
     }
 
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<k256::PublicKey, D::Error>
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<PublicKey, D::Error>
     where
-        D: serde::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct PublicKeyVisitor;
 
-        impl<'de> serde::de::Visitor<'de> for PublicKeyVisitor {
-            type Value = k256::PublicKey;
+        impl serde::de::Visitor<'_> for PublicKeyVisitor {
+            type Value = PublicKey;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("a byte array representing a public key")

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -174,7 +174,7 @@ pub enum SignedTransaction {
 // Custom serialization to avoid double-byte encodings.
 // https://github.com/Zilliqa/zq2/issues/2922
 //
-mod ser_signature {
+pub mod ser_signature {
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::sync::atomic::AtomicBool;
 
@@ -243,7 +243,7 @@ mod ser_signature {
     }
 }
 
-mod ser_pubkey {
+pub mod ser_pubkey {
     use super::schnorr::PublicKey;
     use k256::{elliptic_curve::sec1::ToEncodedPoint, pkcs8::DecodePublicKey};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -175,8 +175,9 @@ pub enum SignedTransaction {
 // https://github.com/Zilliqa/zq2/issues/2922
 //
 pub mod ser_signature {
-    use serde::{Deserialize, Deserializer, Serialize, Serializer};
     use std::sync::atomic::AtomicBool;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
     use super::schnorr::Signature;
 
@@ -244,10 +245,12 @@ pub mod ser_signature {
 }
 
 pub mod ser_pubkey {
-    use super::schnorr::PublicKey;
+    use std::sync::atomic::AtomicBool;
+
     use k256::{elliptic_curve::sec1::ToEncodedPoint, pkcs8::DecodePublicKey};
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
-    use std::sync::atomic::AtomicBool;
+
+    use super::schnorr::PublicKey;
 
     static NEW_FORMAT: AtomicBool = AtomicBool::new(true);
 

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -157,7 +157,6 @@ pub enum SignedTransaction {
         sig: PrimitiveSignature,
     },
     Zilliqa {
-        // #[serde(with = "ser_rlp")]
         tx: TxZilliqa,
         #[serde(with = "ser_pubkey")]
         key: schnorr::PublicKey,
@@ -971,9 +970,7 @@ impl TxIntershard {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TxZilliqa {
-    #[serde(with = "alloy::serde::quantity")]
     pub chain_id: u16,
-    #[serde(with = "alloy::serde::quantity")]
     pub nonce: u64,
     pub gas_price: ZilAmount,
     pub gas_limit: ScillaGas,
@@ -1016,45 +1013,6 @@ impl TxZilliqa {
         }
         let hashed = hasher.finalize();
         Ok(Address::from_slice(&hashed[12..]))
-    }
-}
-
-impl alloy::rlp::Encodable for TxZilliqa {
-    fn encode(&self, out: &mut dyn BufMut) {
-        self.chain_id.encode(out);
-        self.nonce.encode(out);
-        self.gas_price.encode(out);
-        self.gas_limit.encode(out);
-        self.to_addr.encode(out);
-        self.amount.encode(out);
-        self.code.encode(out);
-        self.data.encode(out);
-    }
-
-    fn length(&self) -> usize {
-        self.chain_id.length()
-            + self.nonce.length()
-            + self.gas_price.length()
-            + self.gas_limit.length()
-            + self.to_addr.length()
-            + self.amount.length()
-            + self.code.length()
-            + self.data.length()
-    }
-}
-
-impl alloy::rlp::Decodable for TxZilliqa {
-    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
-        Ok(Self {
-            chain_id: alloy::rlp::Decodable::decode(buf)?,
-            nonce: alloy::rlp::Decodable::decode(buf)?,
-            gas_price: alloy::rlp::Decodable::decode(buf)?,
-            gas_limit: alloy::rlp::Decodable::decode(buf)?,
-            to_addr: alloy::rlp::Decodable::decode(buf)?,
-            amount: alloy::rlp::Decodable::decode(buf)?,
-            code: alloy::rlp::Decodable::decode(buf)?,
-            data: alloy::rlp::Decodable::decode(buf)?,
-        })
     }
 }
 
@@ -1109,22 +1067,6 @@ impl ZilAmount {
     }
 }
 
-impl alloy::rlp::Decodable for ZilAmount {
-    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
-        Ok(ZilAmount(<u128 as alloy::rlp::Decodable>::decode(buf)?))
-    }
-}
-
-impl alloy::rlp::Encodable for ZilAmount {
-    fn encode(&self, out: &mut dyn BufMut) {
-        self.0.encode(out);
-    }
-
-    fn length(&self) -> usize {
-        self.0.length()
-    }
-}
-
 impl Add for ZilAmount {
     type Output = ZilAmount;
 
@@ -1174,22 +1116,6 @@ pub struct ScillaGas(pub u64);
 impl ScillaGas {
     pub fn checked_sub(self, rhs: ScillaGas) -> Option<ScillaGas> {
         Some(ScillaGas(self.0.checked_sub(rhs.0)?))
-    }
-}
-
-impl alloy::rlp::Decodable for ScillaGas {
-    fn decode(buf: &mut &[u8]) -> alloy::rlp::Result<Self> {
-        Ok(ScillaGas(<u64 as alloy::rlp::Decodable>::decode(buf)?))
-    }
-}
-
-impl alloy::rlp::Encodable for ScillaGas {
-    fn encode(&self, out: &mut dyn BufMut) {
-        self.0.encode(out);
-    }
-
-    fn length(&self) -> usize {
-        self.0.length()
     }
 }
 


### PR DESCRIPTION
By keeping ZIL transfers < 230 bytes, we can squeeze 4000 of them into a single Proposal. It was previously taking too much space due to double-byte encoding.

I'll still need to make this a compatible change.
1. ~~compatible with cbor~~
2. ~~compatible with bincode~~
3. ~~cut-over height~~

Just need to pick a height to deploy this.