### PR TITLE
feat: DEVOPS-2101 alternative domains option for api and apps ssl

### DIFF
--- a/infra/tf/api.tf
+++ b/infra/tf/api.tf
@@ -109,12 +109,12 @@ resource "google_compute_url_map" "api" {
   default_service = google_compute_backend_service.api.id
 
   host_rule {
-    hosts        = ["api.${var.subdomain}"]
+    hosts        = concat(["api.${var.subdomain}"], var.api.alternative_ssl_domains.api)
     path_matcher = "api"
   }
 
   host_rule {
-    hosts        = ["health.${var.subdomain}"]
+    hosts        = concat(["health.${var.subdomain}"], var.api.alternative_ssl_domains.health)
     path_matcher = "health"
   }
 
@@ -151,7 +151,11 @@ resource "google_compute_managed_ssl_certificate" "api" {
   name = "${var.chain_name}-api"
 
   managed {
-    domains = ["api.${var.subdomain}", "health.${var.subdomain}"]
+    domains = concat(
+      ["api.${var.subdomain}", "health.${var.subdomain}"],
+      var.api.alternative_ssl_domains.api,
+      var.api.alternative_ssl_domains.health
+    )
   }
 }
 

--- a/infra/tf/apps.tf
+++ b/infra/tf/apps.tf
@@ -154,20 +154,20 @@ resource "google_compute_url_map" "apps" {
   default_service = google_compute_backend_service.otterscan.id
 
   host_rule {
-    hosts        = ["otterscan.${var.subdomain}"]
+    hosts        = concat(["otterscan.${var.subdomain}"], var.apps.alternative_ssl_domains.otterscan)
     path_matcher = "otterscan"
   }
 
   dynamic "host_rule" {
     for_each = var.apps.enable_faucet ? [1] : []
     content {
-      hosts        = ["faucet.${var.subdomain}"]
+      hosts        = concat(["faucet.${var.subdomain}"], var.apps.alternative_ssl_domains.faucet)
       path_matcher = "faucet"
     }
   }
 
   host_rule {
-    hosts        = ["stats.${var.subdomain}"]
+    hosts        = concat(["stats.${var.subdomain}"], var.apps.alternative_ssl_domains.stats)
     path_matcher = "stats"
   }
 
@@ -197,7 +197,10 @@ resource "google_compute_managed_ssl_certificate" "apps" {
     domains = concat(
       ["otterscan.${var.subdomain}"],
       var.apps.enable_faucet ? ["faucet.${var.subdomain}"] : [],
-      ["stats.${var.subdomain}"]
+      ["stats.${var.subdomain}"],
+      var.apps.alternative_ssl_domains.otterscan,
+      var.apps.enable_faucet ? var.apps.alternative_ssl_domains.faucet : [],
+      var.apps.alternative_ssl_domains.stats
     )
   }
 }

--- a/infra/tf/variables.tf
+++ b/infra/tf/variables.tf
@@ -24,6 +24,11 @@ variable "apps" {
     detach_load_balancer       = optional(bool, false)
     enable_faucet              = optional(bool, true)
     faucet_max_hourly_requests = optional(number, 1000000)
+    alternative_ssl_domains    = optional(object({
+      otterscan = optional(list(string), [])
+      faucet    = optional(list(string), [])
+      stats     = optional(list(string), [])
+    }), {})
     nodes = optional(list(object({
       count  = number
       region = optional(string)
@@ -56,12 +61,16 @@ variable "apps" {
 variable "api" {
   description = "(Optional) The configuration of the api nodes"
   type = object({
-    disk_size            = optional(number, 256)
-    instance_type        = optional(string, "e2-standard-2")
-    provisioning_model   = optional(string, "STANDARD")
-    generate_external_ip = optional(bool, false)
-    detach_load_balancer = optional(bool, false)
-    rate_limit           = optional(number, 1000000)
+    disk_size               = optional(number, 256)
+    instance_type           = optional(string, "e2-standard-2")
+    provisioning_model      = optional(string, "STANDARD")
+    generate_external_ip    = optional(bool, false)
+    detach_load_balancer    = optional(bool, false)
+    rate_limit              = optional(number, 1000000)
+    alternative_ssl_domains    = optional(object({
+      api    = optional(list(string), [])
+      health = optional(list(string), [])
+    }), {})
     nodes = optional(list(object({
       count  = number
       region = optional(string)


### PR DESCRIPTION
Optional alternative domains for ssl for apps and api.

Configurable in Terraform like this:
```
      apps:
        disk_size: 256
        instance_type: n2-standard-2
        provisioning_model: STANDARD
        generate_external_ip: true
        detach_load_balancer: false
        faucet_max_hourly_requests: 12
        alternative_ssl_domains: ["otterscan.testnet.zilliqa.com", "dev-wallet.zilliqa.com"]
        nodes:
        - count: 1
          zone: asia-southeast1-a
      api:
        disk_size: 1200
        instance_type: e2-highcpu-8
        provisioning_model: STANDARD
        generate_external_ip: true
        detach_load_balancer: false
        alternative_ssl_domains: ["dev-api.zilliqa.com"]
        nodes:
        - count: 3
          region: asia-southeast1
```