### PR TITLE
feat: DEVOPS-2116 alternative dns option for spout and otterscan services

### DIFF
--- a/infra/ansible/group_vars/network_zq2_devnet/all.yml
+++ b/infra/ansible/group_vars/network_zq2_devnet/all.yml
@@ -7,6 +7,7 @@ ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
 eth_chain_id: 33469
 chain_name: "zq2-devnet"
 dns_subdomain: "zq2-devnet.zilliqa.com"
+stats_endpoint: "stats.zq2-devnet.zilliqa.com"
 project_id: prj-d-zq2-devnet-c83bkpsd
 log_level: "zilliqa=info"
 enable_faucet: true

--- a/infra/ansible/group_vars/network_zq2_infratest/all.yml
+++ b/infra/ansible/group_vars/network_zq2_infratest/all.yml
@@ -7,6 +7,7 @@ ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
 eth_chain_id: 33469
 chain_name: "zq2-infratest"
 dns_subdomain: "zq2-infratest.zilstg.dev"
+stats_endpoint: "stats.zq2-infratest.zilliqa.com"
 project_id: prj-d-zq2-devnet-c83bkpsd
 log_level: "zilliqa=info"
 enable_faucet: true

--- a/infra/ansible/group_vars/network_zq2_mainnet/all.yml
+++ b/infra/ansible/group_vars/network_zq2_mainnet/all.yml
@@ -6,7 +6,8 @@ ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
 # Node Configuration
 eth_chain_id: 32769
 chain_name: "zq2-mainnet"
-dns_subdomain: "zq2-mainnet.zilliqa.com"
+dns_subdomain: "zilliqa.com"
+stats_endpoint: "stats.zq2-mainnet.zilliqa.com"
 project_id: prj-p-zq2-mainnet-sn5n8wfl
 log_level: "zilliqa=trace"
 enable_faucet: false

--- a/infra/ansible/group_vars/network_zq2_protomainnet/all.yml
+++ b/infra/ansible/group_vars/network_zq2_protomainnet/all.yml
@@ -7,6 +7,7 @@ ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
 eth_chain_id: 32770
 chain_name: "zq2-protomainnet"
 dns_subdomain: "zq2-protomainnet.zilliqa.com"
+stats_endpoint: "stats.zq2-protomainnet.zilliqa.com"
 project_id: prj-p-zq2-mainnet-sn5n8wfl
 log_level: "zilliqa=trace"
 enable_faucet: true

--- a/infra/ansible/group_vars/network_zq2_prototestnet/all.yml
+++ b/infra/ansible/group_vars/network_zq2_prototestnet/all.yml
@@ -7,6 +7,7 @@ ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
 eth_chain_id: 33103
 chain_name: "zq2-prototestnet"
 dns_subdomain: "zq2-prototestnet.zilliqa.com"
+stats_endpoint: "stats.zq2-prototestnet.zilliqa.com"
 project_id: prj-d-zq2-testnet-g13pnaa8
 log_level: "zilliqa=trace"
 enable_faucet: true

--- a/infra/ansible/group_vars/network_zq2_testnet/all.yml
+++ b/infra/ansible/group_vars/network_zq2_testnet/all.yml
@@ -6,7 +6,8 @@ ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet
 # Node Configuration
 eth_chain_id: 33101
 chain_name: "zq2-testnet"
-dns_subdomain: "zq2-testnet.zilliqa.com"
+dns_subdomain: "testnet.zilliqa.com"
+stats_endpoint: "stats.zq2-testnet.zilliqa.com"
 project_id: prj-d-zq2-testnet-g13pnaa8
 log_level: "zilliqa=trace"
 enable_faucet: true

--- a/infra/ansible/playbooks/templates/spout.sh.j2
+++ b/infra/ansible/playbooks/templates/spout.sh.j2
@@ -12,7 +12,7 @@ start() {
         -e NATIVE_TOKEN_SYMBOL="ZIL" \
         -e PRIVATE_KEY="${GENESIS_KEY}" \
         -e ETH_AMOUNT=100 \
-        -e EXPLORER_URL="https://explorer.{{ dns_subdomain }}" \
+        -e EXPLORER_URL="https://otterscan.{{ dns_subdomain }}" \
         -e MINIMUM_SECONDS_BETWEEN_REQUESTS=60 \
         -e BECH32_HRP="zil" \
         --restart=unless-stopped --pull=always \

--- a/infra/ansible/playbooks/templates/stats_agent.sh.j2
+++ b/infra/ansible/playbooks/templates/stats_agent.sh.j2
@@ -16,7 +16,7 @@ start() {
         -e LISTENING_PORT="3333" \
         -e INSTANCE_NAME={{ ansible_hostname }} \
         -e CONTACT_DETAILS="devops@zilliqa.com" \
-        -e WS_SERVER="ws://stats.{{ dns_subdomain }}" \
+        -e WS_SERVER="ws://{{ stats_endpoint }}" \
         -e WS_SECRET="${STATS_DASHBOARD_KEY}" \
         -e PEER_ID="{{ hostvars[inventory_hostname]['labels']['peer-id'] }}" \
         -e VERBOSITY="2" \


### PR DESCRIPTION
Possibility of alternative dns for spout and otterscan services. Already applied.

![image](https://github.com/user-attachments/assets/823ce245-ab09-40a3-94cc-a731c68a7447)
