### PR TITLE
Added credits-based RPC rate-limiter

### DIFF
--- a/config-single-node.toml
+++ b/config-single-node.toml
@@ -3,7 +3,7 @@ network = "Localnet"
 
 [[nodes]]
 api_servers = [
-    { port = 4201, enabled_apis = [ "admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa" ] }
+    { rate_credit = 0, port = 4201, enabled_apis = [ "admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa" ] }
 ]
 eth_chain_id = 0x8001
 consensus.scilla_address = "http://localhost:3000"

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -681,7 +681,7 @@ impl ChainNode {
             json!({"port": 4201, "enabled_apis": [ { "namespace": "eth", "apis": ["blockNumber"] } ] })
         };
         // 4202 is not exposed, so enable everything for local debugging.
-        let private_api = json!({ "port": 4202, "enabled_apis": ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] });
+        let private_api = json!({ "rate_credit": 0, "port": 4202, "enabled_apis": ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] });
         let api_servers = json!([public_api, private_api]);
 
         // Enable Otterscan indices on API nodes.

--- a/z2/src/setup.rs
+++ b/z2/src/setup.rs
@@ -518,6 +518,8 @@ impl Setup {
                 api_servers: vec![ApiServer {
                     port,
                     enabled_apis: api::all_enabled(),
+                    rate_credit: 0,
+                    rate_seconds: 0,
                 }],
                 allowed_timestamp_skew: allowed_timestamp_skew_default(),
                 data_dir: None,

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -117,9 +117,9 @@ pub struct ApiServer {
     pub rate_seconds: u16,
 }
 
-// default config allows 2 calls/period
+// default config allows 1 call/period.
 fn default_rate_credit() -> u16 {
-    crate::ratelimit::DEFAULT_CREDIT * 2
+    crate::ratelimit::DEFAULT_CREDIT * default_rate_period()
 }
 
 fn default_rate_period() -> u16 {

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -110,6 +110,11 @@ pub struct ApiServer {
     pub port: u16,
     /// RPC APIs to enable.
     pub enabled_apis: Vec<EnabledApi>,
+    /// Rate limit configuration at N credit/seconds, 0 to disable.
+    #[serde(default)]
+    pub rate_credit: u64,
+    #[serde(default)]
+    pub rate_seconds: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -113,16 +113,17 @@ pub struct ApiServer {
     /// Rate limit configuration at N credit/seconds, 0 to disable.
     #[serde(default = "default_rate_credit")]
     pub rate_credit: u16,
-    #[serde(default = "default_rate_seconds")]
+    #[serde(default = "default_rate_period")]
     pub rate_seconds: u16,
 }
 
+// default config allows 2 calls/period
 fn default_rate_credit() -> u16 {
-    crate::ratelimit::DEFAULT_CREDIT
+    crate::ratelimit::DEFAULT_CREDIT * 2
 }
 
-fn default_rate_seconds() -> u16 {
-    1
+fn default_rate_period() -> u16 {
+    2
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -111,10 +111,18 @@ pub struct ApiServer {
     /// RPC APIs to enable.
     pub enabled_apis: Vec<EnabledApi>,
     /// Rate limit configuration at N credit/seconds, 0 to disable.
-    #[serde(default)]
-    pub rate_credit: u64,
-    #[serde(default)]
-    pub rate_seconds: u64,
+    #[serde(default = "default_rate_credit")]
+    pub rate_credit: u16,
+    #[serde(default = "default_rate_seconds")]
+    pub rate_seconds: u16,
+}
+
+fn default_rate_credit() -> u16 {
+    crate::ratelimit::DEFAULT_CREDIT
+}
+
+fn default_rate_seconds() -> u16 {
+    1
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -17,6 +17,7 @@ pub mod p2p_node;
 mod pool;
 mod precompiles;
 pub mod range_map;
+pub mod ratelimit;
 pub mod schnorr;
 pub mod scilla;
 mod scilla_proto;

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -149,9 +149,7 @@ impl NodeLauncher {
 
             // RPC rate limit, because HTTP connection rate limits do not inspect for RPC calls e.g. batch calls
             let rpc_middleware = jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
-                .layer_fn(move |service| {
-                    RateLimit::new(service, rate_limit) // 2 TPS
-                });
+                .layer_fn(move |service| RateLimit::new(service, rate_limit));
 
             let server = jsonrpsee::server::ServerBuilder::new()
                 .max_response_body_size(config.max_rpc_response_size)

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -137,7 +137,7 @@ impl NodeLauncher {
         for api_server in &config.api_servers {
             let rate_limit = Rate::new(
                 api_server.rate_credit,
-                Duration::from_secs(api_server.rate_seconds),
+                Duration::from_secs(api_server.rate_seconds.into()),
             );
             let rpc_module = api::rpc_module(Arc::clone(&node), &api_server.enabled_apis);
             // Construct the JSON-RPC API server. We inject a [CorsLayer] to ensure web browsers can call our API directly.

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -143,9 +143,10 @@ impl NodeLauncher {
                 .allow_headers([header::CONTENT_TYPE]);
             let http_middleware = tower::ServiceBuilder::new().layer(HealthLayer).layer(cors);
 
+            // RPC rate limit, because HTTP connection rate limits do not inspect for RPC calls e.g. batch calls
             let rpc_middleware = jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new()
-                .layer_fn(move |service| {
-                    RateLimit::new(service, Rate::new(42, Duration::from_secs(60))) // 42 RPM
+                .layer_fn(|service| {
+                    RateLimit::new(service, Rate::new(2, Duration::from_secs(1))) // 2 TPS
                 });
 
             let server = jsonrpsee::server::ServerBuilder::new()

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -298,5 +298,5 @@ static RPC_CREDITS: LazyLock<HashMap<&'static str, u16>> = LazyLock::new(|| {
     map
 });
 
-// the default allows 1 call/period
+// the default allows 2 call/period
 pub static DEFAULT_CREDIT: u16 = 500;

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -1,8 +1,13 @@
-use jsonrpsee::MethodResponse;
-use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceT};
-use jsonrpsee::types::{ErrorObject, Request};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use jsonrpsee::{
+    MethodResponse,
+    server::middleware::rpc::{ResponseFuture, RpcServiceT},
+    types::{ErrorObject, Request},
+};
 
 /// Derived from
 /// https://github.com/paritytech/jsonrpsee/blob/master/examples/examples/rpc_middleware_rate_limiting.rs
@@ -29,9 +34,6 @@ enum State {
 /// it's possible to select whether the rate limit
 /// is be applied per connection or shared by
 /// all connections.
-///
-/// Have a look at `async fn run_server` below which
-/// shows how do it.
 #[derive(Clone)]
 pub struct RateLimit<S> {
     service: S,

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -14,12 +14,12 @@ use jsonrpsee::{
 
 #[derive(Debug, Copy, Clone)]
 pub struct Rate {
-    num: u64,
+    num: u16,
     period: Duration,
 }
 
 impl Rate {
-    pub fn new(num: u64, period: Duration) -> Self {
+    pub fn new(num: u16, period: Duration) -> Self {
         Self { num, period }
     }
 }
@@ -27,7 +27,7 @@ impl Rate {
 #[derive(Debug, Copy, Clone)]
 enum State {
     Deny { until: Instant },
-    Allow { until: Instant, rem: u64 },
+    Allow { until: Instant, rem: u16 },
 }
 
 #[derive(Clone)]
@@ -47,7 +47,7 @@ impl<S> RateLimit<S> {
             rate,
             state: Arc::new(Mutex::new(State::Allow {
                 until: Instant::now() + period,
-                rem: num + 1,
+                rem: num,
             })),
         }
     }
@@ -79,7 +79,7 @@ where
                     if now > until {
                         State::Allow {
                             until: now + self.rate.period,
-                            rem: self.rate.num - 1,
+                            rem: self.rate.num,
                         }
                     } else {
                         State::Deny { until }
@@ -89,17 +89,21 @@ where
                     if now > until {
                         State::Allow {
                             until: now + self.rate.period,
-                            rem: self.rate.num - 1,
+                            rem: self.rate.num,
                         }
                     } else {
-                        let n = rem - 1;
-                        if n > 0 {
+                        // look up method pricing
+                        let price = *RPC_CREDITS
+                            .get(req.method_name())
+                            .unwrap_or(&DEFAULT_CREDIT);
+
+                        if price > rem {
+                            State::Deny { until }
+                        } else {
                             State::Allow {
                                 until: now + self.rate.period,
-                                rem: n,
+                                rem: rem - price,
                             }
-                        } else {
-                            State::Deny { until }
                         }
                     }
                 }
@@ -119,3 +123,80 @@ where
         }
     }
 }
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+// Pricing should be derived based on the typical/average timing of the RPC calls.
+// The conversion rate should be around 1ms:1credit such that a 5ms call costs 5 credits.
+// Unless otherwise listed below, the default pricing allows for 1 call/second.
+
+// Initial pricing derived from https://docs.metamask.io/services/get-started/pricing/credit-cost/
+static RPC_CREDITS: LazyLock<HashMap<&'static str, u16>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    map.insert("eth_accounts", 80);
+    map.insert("eth_blobBaseFee", 300);
+    map.insert("eth_blockNumber", 80);
+    map.insert("eth_call", 80);
+    map.insert("eth_chainId", 80);
+    map.insert("eth_estimateGas", 300);
+    map.insert("eth_feeHistory", 80);
+    map.insert("eth_gasPrice", 80);
+    map.insert("eth_getBalance", 80);
+    map.insert("eth_getBlockByHash", 80);
+    map.insert("eth_getBlockByNumber", 80);
+    map.insert("eth_getBlockReceipts", 1000);
+    map.insert("eth_getBlockTransactionCountByHash", 150);
+    map.insert("eth_getBlockTransactionCountByNumber", 150);
+    map.insert("eth_getCode", 80);
+    map.insert("eth_getLogs", 255);
+    map.insert("eth_getProof", 150);
+    map.insert("eth_getStorageAt", 80);
+    map.insert("eth_getTransactionByBlockHashAndIndex", 150);
+    map.insert("eth_getTransactionByBlockNumberAndIndex", 150);
+    map.insert("eth_getTransactionByHash", 150);
+    map.insert("eth_getTransactionCount", 150);
+    map.insert("eth_getTransactionReceipt", 150);
+    map.insert("eth_hashrate", 5);
+    map.insert("eth_maxPriorityFeePerGas", 80);
+    map.insert("eth_mining", 5);
+    map.insert("eth_protocolVersion", 5);
+    map.insert("eth_sendRawTransaction", 80);
+    map.insert("eth_simulateV1", 300);
+    map.insert("eth_submitWork", 80);
+    map.insert("eth_syncing", 5);
+    map.insert("eth_getFilterChanges", 140);
+    map.insert("eth_getFilterLogs", 255);
+    map.insert("eth_newBlockFilter", 80);
+    map.insert("eth_newFilter", 80);
+    map.insert("eth_uninstallFilter", 80);
+
+    map.insert("net_version", 5);
+    map.insert("net_peerCount", 5);
+    map.insert("net_listening", 5);
+
+    map.insert("web3_clientVersion", 5);
+
+    map.insert("trace_block", 300);
+    map.insert("trace_call", 300);
+    map.insert("trace_callMany", 300);
+    map.insert("trace_filter", 300);
+    map.insert("trace_rawTransaction", 300);
+    map.insert("trace_replayBlockTransactions", 300);
+    map.insert("trace_replayTransaction", 300);
+    map.insert("trace_transaction", 300);
+
+    map.insert("debug_getBadBlocks", 1000);
+    map.insert("debug_getTrieFlushInterval", 1000);
+    map.insert("debug_storageRangeAt", 1000);
+    map.insert("debug_traceBlock", 1000);
+    map.insert("debug_traceBlockByHash", 1000);
+    map.insert("debug_traceBlockByNumber", 1000);
+    map.insert("debug_traceCall", 1000);
+    map.insert("debug_traceTransaction", 1000);
+
+    map
+});
+
+// the default allows 1 call/second
+pub static DEFAULT_CREDIT: u16 = 500;

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -298,5 +298,5 @@ static RPC_CREDITS: LazyLock<HashMap<&'static str, u16>> = LazyLock::new(|| {
     map
 });
 
-// the default allows 2 call/period
+// default config allows 1 call/period.
 pub static DEFAULT_CREDIT: u16 = 500;

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -132,8 +132,7 @@ where
     }
 }
 
-use std::collections::HashMap;
-use std::sync::LazyLock;
+use std::{collections::HashMap, sync::LazyLock};
 
 // Pricing should be derived based on the typical/average timing of the RPC calls.
 // The conversion rate should be around 1ms:1credit such that a 5ms call costs 5 credits.

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -1,0 +1,116 @@
+use jsonrpsee::MethodResponse;
+use jsonrpsee::server::middleware::rpc::{ResponseFuture, RpcServiceT};
+use jsonrpsee::types::{ErrorObject, Request};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Derived from
+/// https://github.com/paritytech/jsonrpsee/blob/master/examples/examples/rpc_middleware_rate_limiting.rs
+
+#[derive(Debug, Copy, Clone)]
+pub struct Rate {
+    num: u64,
+    period: Duration,
+}
+
+impl Rate {
+    pub fn new(num: u64, period: Duration) -> Self {
+        Self { num, period }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+enum State {
+    Deny { until: Instant },
+    Allow { until: Instant, rem: u64 },
+}
+
+/// Depending on how the rate limit is instantiated
+/// it's possible to select whether the rate limit
+/// is be applied per connection or shared by
+/// all connections.
+///
+/// Have a look at `async fn run_server` below which
+/// shows how do it.
+#[derive(Clone)]
+pub struct RateLimit<S> {
+    service: S,
+    state: Arc<Mutex<State>>,
+    rate: Rate,
+}
+
+impl<S> RateLimit<S> {
+    pub fn new(service: S, rate: Rate) -> Self {
+        let period = rate.period;
+        let num = rate.num;
+
+        Self {
+            service,
+            rate,
+            state: Arc::new(Mutex::new(State::Allow {
+                until: Instant::now() + period,
+                rem: num + 1,
+            })),
+        }
+    }
+}
+
+impl<'a, S> RpcServiceT<'a> for RateLimit<S>
+where
+    S: Send + RpcServiceT<'a>,
+{
+    // Instead of `Boxing` the future in this example
+    // we are using a jsonrpsee's ResponseFuture future
+    // type to avoid those extra allocations.
+    type Future = ResponseFuture<S::Future>;
+
+    fn call(&self, req: Request<'a>) -> Self::Future {
+        let now = Instant::now();
+
+        let is_denied = {
+            let mut lock = self.state.lock().unwrap();
+            let next_state = match *lock {
+                State::Deny { until } => {
+                    if now > until {
+                        State::Allow {
+                            until: now + self.rate.period,
+                            rem: self.rate.num - 1,
+                        }
+                    } else {
+                        State::Deny { until }
+                    }
+                }
+                State::Allow { until, rem } => {
+                    if now > until {
+                        State::Allow {
+                            until: now + self.rate.period,
+                            rem: self.rate.num - 1,
+                        }
+                    } else {
+                        let n = rem - 1;
+                        if n > 0 {
+                            State::Allow {
+                                until: now + self.rate.period,
+                                rem: n,
+                            }
+                        } else {
+                            State::Deny { until }
+                        }
+                    }
+                }
+            };
+
+            *lock = next_state;
+            matches!(next_state, State::Deny { .. })
+        };
+
+        if is_denied {
+            ResponseFuture::ready(MethodResponse::error(
+                req.id,
+                ErrorObject::borrowed(-32000, "RPC_RATE_LIMIT", None),
+            ))
+        } else {
+            ResponseFuture::future(self.service.call(req))
+        }
+    }
+}

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -65,6 +65,11 @@ where
     // https://docs.metamask.io/services/get-started/pricing/credit-cost/
 
     fn call(&self, req: Request<'a>) -> Self::Future {
+        // disable rate limiting if rate is 0
+        if self.rate.num == 0 {
+            return ResponseFuture::future(self.service.call(req));
+        }
+
         let now = Instant::now();
 
         let is_denied = {

--- a/zilliqa/src/ratelimit.rs
+++ b/zilliqa/src/ratelimit.rs
@@ -138,68 +138,162 @@ use std::{collections::HashMap, sync::LazyLock};
 // The conversion rate should be around 1ms:1credit such that a 5ms call costs 5 credits.
 // Unless otherwise listed below, the default pricing allows for 1 call/period
 static RPC_CREDITS: LazyLock<HashMap<&'static str, u16>> = LazyLock::new(|| {
-    // Initial pricing derived from https://docs.metamask.io/services/get-started/pricing/credit-cost/
-    let mut map = HashMap::new();
-    map.insert("eth_accounts", 80);
-    map.insert("eth_blobBaseFee", 300);
-    map.insert("eth_blockNumber", 80);
-    map.insert("eth_call", 80);
-    map.insert("eth_chainId", 80);
-    map.insert("eth_estimateGas", 300);
-    map.insert("eth_feeHistory", 80);
-    map.insert("eth_gasPrice", 80);
-    map.insert("eth_getBalance", 80);
-    map.insert("eth_getBlockByHash", 80);
-    map.insert("eth_getBlockByNumber", 80);
-    map.insert("eth_getBlockReceipts", 1000);
-    map.insert("eth_getBlockTransactionCountByHash", 150);
-    map.insert("eth_getBlockTransactionCountByNumber", 150);
-    map.insert("eth_getCode", 80);
-    map.insert("eth_getLogs", 255);
-    map.insert("eth_getProof", 150);
-    map.insert("eth_getStorageAt", 80);
-    map.insert("eth_getTransactionByBlockHashAndIndex", 150);
-    map.insert("eth_getTransactionByBlockNumberAndIndex", 150);
-    map.insert("eth_getTransactionByHash", 150);
-    map.insert("eth_getTransactionCount", 150);
-    map.insert("eth_getTransactionReceipt", 150);
-    map.insert("eth_hashrate", 5);
-    map.insert("eth_maxPriorityFeePerGas", 80);
-    map.insert("eth_mining", 5);
-    map.insert("eth_protocolVersion", 5);
-    map.insert("eth_sendRawTransaction", 80);
-    map.insert("eth_simulateV1", 300);
-    map.insert("eth_submitWork", 80);
-    map.insert("eth_syncing", 5);
-    map.insert("eth_getFilterChanges", 140);
-    map.insert("eth_getFilterLogs", 255);
-    map.insert("eth_newBlockFilter", 80);
-    map.insert("eth_newFilter", 80);
-    map.insert("eth_uninstallFilter", 80);
-
-    map.insert("net_version", 5);
-    map.insert("net_peerCount", 5);
-    map.insert("net_listening", 5);
-
-    map.insert("web3_clientVersion", 5);
-
-    map.insert("trace_block", 300);
-    map.insert("trace_call", 300);
-    map.insert("trace_callMany", 300);
-    map.insert("trace_filter", 300);
-    map.insert("trace_rawTransaction", 300);
-    map.insert("trace_replayBlockTransactions", 300);
-    map.insert("trace_replayTransaction", 300);
-    map.insert("trace_transaction", 300);
-
-    map.insert("debug_getBadBlocks", 1000);
-    map.insert("debug_getTrieFlushInterval", 1000);
-    map.insert("debug_storageRangeAt", 1000);
-    map.insert("debug_traceBlock", 1000);
-    map.insert("debug_traceBlockByHash", 1000);
-    map.insert("debug_traceBlockByNumber", 1000);
-    map.insert("debug_traceCall", 1000);
-    map.insert("debug_traceTransaction", 1000);
+    // let mut map = HashMap::new();
+    let map: HashMap<&'static str, u16> = [
+        // Empirical estimates
+        ("CreateTransaction", 80),
+        ("GetContractAddressFromTransactionID", 250),
+        ("GetBlockchainInfo", 500),
+        ("GetNumTxBlocks", 250),
+        ("GetSmartContractState", 1000),
+        ("GetSmartContractCode", 50),
+        ("GetSmartContractInit", 250),
+        ("GetTransaction", 150),
+        ("GetBalance", 250),
+        ("GetCurrentMiniEpoch", 250),
+        ("GetLatestTxBlock", 250),
+        ("GetMinimumGasPrice", 250),
+        ("GetNetworkId", 5),
+        ("GetVersion", 5),
+        ("GetTransactionsForTxBlock", 300),
+        ("GetTxBlock", 250),
+        ("GetTxBlockVerbose", 300),
+        ("GetSmartContracts", 300),
+        // ("GetDSBlock", 500u16),
+        // ("GetDSBlockVerbose", 500u16),
+        ("GetLatestDSBlock", 250),
+        // ("GetCurrentDSComm", 500u16),
+        ("GetCurrentDSEpoch", 250),
+        ("DSBlockListing", 80),
+        ("GetDSBlockRate", 80),
+        ("GetTxBlockRate", 80),
+        ("TxBlockListing", 50),
+        ("GetNumPeers", 80),
+        // ("GetTransactionRate", 500u16),
+        // ("GetTransactionsForTxBlockEx", 500u16),
+        ("GetTxnBodiesForTxBlock", 250),
+        ("GetTxnBodiesForTxBlockEx", 80),
+        // ("GetNumDSBlocks", 500u16),
+        ("GetRecentTransactions", 500),
+        // ("GetNumTransactions", 500u16),
+        // ("GetNumTxnsTXEpoch", 500u16),
+        // ("GetNumTxnsDSEpoch", 500u16),
+        ("GetTotalCoinSupply", 5),
+        ("GetTotalCoinSupplyAsInt", 5),
+        ("GetMinerInfo", 5),
+        // ("GetNodeType", 500u16),
+        ("GetPrevDifficulty", 5),
+        ("GetPrevDSDifficulty", 5),
+        // ("GetShardingStructure", 500u16),
+        ("GetSmartContractSubState", 80),
+        // ("GetSoftConfirmedTransaction", 500u16),
+        // ("GetStateProof", 500u16),
+        ("GetTransactionStatus", 250),
+        // RPC rate-limit can be disabled for the admin port, to enable all these calls
+        ("admin_consensusInfo", 10000),
+        ("admin_generateCheckpoint", 10000),
+        ("admin_blockRange", 80),
+        ("admin_forceView", 10000),
+        ("admin_getPeers", 80),
+        ("admin_votesReceived", 10000),
+        ("admin_clearMempool", 10000),
+        ("admin_getLeaders", 10000),
+        // RPC rate-limit can be disabled for the admin port, to enable all these calls
+        ("debug_getBadBlocks", 10000),
+        ("debug_getTrieFlushInterval", 10000),
+        ("debug_storageRangeAt", 10000),
+        ("debug_traceBlock", 10000),
+        ("debug_traceBlockByHash", 10000),
+        ("debug_traceBlockByNumber", 10000),
+        ("debug_traceCall", 10000),
+        ("debug_traceTransaction", 10000),
+        // Estimated from similar eth_* calls
+        ("erigon_blockNumber", 80),
+        ("erigon_forks", 80),
+        ("erigon_getBlockByTimestamp", 150),
+        ("erigon_getBlockReceiptsByBlockHash", 1000),
+        ("erigon_getHeaderByHash", 80),
+        ("erigon_getHeaderByNumber", 80),
+        ("erigon_getLatestLogs", 250),
+        ("erigon_getLogsByHash", 250),
+        // Derived from https://docs.metamask.io/services/get-started/pricing/credit-cost/
+        ("net_version", 5),
+        ("net_peerCount", 80),
+        ("net_listening", 5),
+        ("web3_clientVersion", 80),
+        // Empirical estimate
+        ("ots_getApiLevel", 5),
+        ("ots_getBlockDetails", 80),
+        ("ots_getBlockDetailsByHash", 80),
+        ("ots_getBlockTransactions", 250),
+        ("ots_getContractCreator", 500),
+        ("ots_getInternalOperations", 80),
+        ("ots_getTransactionBySenderAndNonce", 50),
+        ("ots_getTransactionError", 50),
+        ("ots_hasCode", 5),
+        ("ots_searchTransactionsAfter", 500),
+        ("ots_searchTransactionsBefore", 500),
+        ("ots_traceTransaction", 80),
+        // Derived from https://docs.metamask.io/services/get-started/pricing/credit-cost/
+        ("trace_block", 300),
+        ("trace_call", 300),
+        ("trace_callMany", 300),
+        ("trace_filter", 300),
+        ("trace_rawTransaction", 300),
+        ("trace_replayBlockTransactions", 300),
+        ("trace_replayTransaction", 300),
+        ("trace_transaction", 300),
+        // Empirical estimate
+        ("txpool_content", 300),
+        ("txpool_contentFrom", 300),
+        ("txpool_inspect", 300),
+        ("txpool_status", 300),
+        // Derived from https://docs.metamask.io/services/get-started/pricing/credit-cost/
+        ("eth_accounts", 80),
+        ("eth_blobBaseFee", 300),
+        ("eth_blockNumber", 80),
+        ("eth_call", 80),
+        ("eth_chainId", 80),
+        ("eth_estimateGas", 300),
+        ("eth_feeHistory", 80),
+        ("eth_gasPrice", 80),
+        ("eth_getAccount", 80),
+        ("eth_getBalance", 80),
+        ("eth_getBlockByHash", 80),
+        ("eth_getBlockByNumber", 80),
+        ("eth_getBlockReceipts", 1000),
+        ("eth_getBlockTransactionCountByHash", 150),
+        ("eth_getBlockTransactionCountByNumber", 150),
+        ("eth_getCode", 80),
+        ("eth_getFilterChanges", 140),
+        ("eth_getFilterLogs", 250),
+        ("eth_getLogs", 250),
+        ("eth_getProof", 150),
+        ("eth_getStorageAt", 80),
+        ("eth_getTransactionByBlockHashAndIndex", 150),
+        ("eth_getTransactionByBlockNumberAndIndex", 150),
+        ("eth_getTransactionByHash", 150),
+        ("eth_getTransactionCount", 150),
+        ("eth_getTransactionReceipt", 150),
+        ("eth_getUncleByBlockHashAndIndex", 150),
+        ("eth_getUncleByBlockNumberAndIndex", 150),
+        ("eth_getUncleCountByBlockHash", 150),
+        ("eth_getUncleCountByBlockNumber", 150),
+        ("eth_hashrate", 5),
+        ("eth_maxPriorityFeePerGas", 80),
+        ("eth_mining", 5),
+        ("eth_newBlockFilter", 80),
+        ("eth_newFilter", 80),
+        ("eth_uninstallFilter", 80),
+        ("eth_protocolVersion", 5),
+        ("eth_sendRawTransaction", 80),
+        ("eth_signTransaction", 80),
+        ("eth_simulateV1", 300),
+        ("eth_submitWork", 80),
+        ("eth_syncing", 5),
+    ]
+    .into_iter()
+    .collect();
 
     map
 });

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -396,6 +396,8 @@ impl Network {
             api_servers: vec![ApiServer {
                 port: 4201,
                 enabled_apis: api::all_enabled(),
+                rate_credit: 0,
+                rate_seconds: 0,
             }],
             allowed_timestamp_skew: allowed_timestamp_skew_default(),
             data_dir: None,
@@ -517,6 +519,8 @@ impl Network {
             api_servers: vec![ApiServer {
                 port: 4201,
                 enabled_apis: api::all_enabled(),
+                rate_credit: 0,
+                rate_seconds: 0,
             }],
             allowed_timestamp_skew: allowed_timestamp_skew_default(),
             data_dir: None,


### PR DESCRIPTION
The global rate-limits would have to be managed using a hybrid GCP+APP level management. It is not feasible, otherwise.

IP-based connection limits are best managed at the GCP level, which has a global view on connectivity. However, GCP does not inspect the payload to count RPC call rate.

This PR attempts to bridge this gap, with a simple RPC per connection rate limit. So, for each connection that GCP lets through, it imposes a limit on how many RPC calls it makes. This also includes RPC batch calls as seen in the log output below.

This PR uses a credits-based mechanism. Each connection is allocated 500 (configurable) credits/second. Each RPC method is priced e.g. eth_blockNumber is priced at 80 credits. So, a single connection can make six eth_blockNumber calls/sec before hitting the rate limit (as seen in the log below).

Some calls are cheap e.g. net_version is priced at 5 credits, which allows 100 calls/sec and debug* calls are priced at 1000, meaning that they always hit the limit. Unknown (to me) calls are priced at the default value (e.g. 500) to allow for exactly 1 call/sec. It is expected that the price of all implemented calls will eventually be listed on the pricing table in `ratelimit.rs`

So, the global rate limit would be a combination of GCP + APP level limits e.g. 200 connections/minute/IP should result in around twenty (20) eth_blockNumber calls/sec on average, if it uses multiple RPC calls/connection. Otherwise, about three (3) eth_blockNumber calls/sec on average, per IP address.

```
POST / HTTP/1.0
Host: localhost:34201
Accept: */*
Accept-Encoding: gzip, deflate
User-Agent: Mozilla/5.0 (pc-x86_64-linux-gnu) Siege/4.0.7
Connection: keep-alive
Content-Type: application/json
Content-Length: 470

[{"jsonrpc":"2.0","id":"1","method":"eth_blockNumber","params": []},
{"jsonrpc":"2.0","id":"2","method":"eth_blockNumber","params": []},
{"jsonrpc":"2.0","id":"3","method":"eth_blockNumber","params": []},
{"jsonrpc":"2.0","id":"4","method":"eth_blockNumber","params": []},
{"jsonrpc":"2.0","id":"5","method":"eth_blockNumber","params": []},
{"jsonrpc":"2.0","id":"6","method":"eth_blockNumber","params": []},
{"jsonrpc":"2.0","id":"7","method":"eth_blockNumber","params": []}]

[{"jsonrpc":"2.0","id":"1","result":"0x31db"},
{"jsonrpc":"2.0","id":"2","result":"0x31db"},
{"jsonrpc":"2.0","id":"3","result":"0x31db"},
{"jsonrpc":"2.0","id":"4","result":"0x31db"},
{"jsonrpc":"2.0","id":"5","result":"0x31db"},
{"jsonrpc":"2.0","id":"6","result":"0x31db"},
{"jsonrpc":"2.0","id":"7","error":{"code":-32005,"message":"Limit exceeded"}}]
```

Currently deployed on `testnet` API nodes. Feel free to test it out.