### PR TITLE
Fix for lockup during get_pending_or_queued

### DIFF
--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -676,7 +676,7 @@ pub struct TransactionReceiptResponse {
 }
 
 // From https://github.com/Zilliqa/Zilliqa/blob/master/src/common/TxnStatus.h#L23
-#[derive(Serialize_repr, Deserialize_repr, Clone)]
+#[derive(Serialize_repr, Debug, Deserialize_repr, Clone)]
 #[repr(u8)] // Because otherwise it's weird that 255 is a special case
 pub enum TxnStatusCode {
     Dispatched = 1,
@@ -685,7 +685,7 @@ pub enum TxnStatusCode {
     Error = 255, // MiscError
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Debug, Deserialize, Clone)]
 pub struct TransactionStatusResponse {
     #[serde(rename = "ID")]
     pub id: String,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1020,7 +1020,7 @@ impl Consensus {
     ) -> Result<Option<PendingOrQueued>> {
         let mut pool = self.transaction_pool.write();
         pool.update_with_state(&self.state);
-        self.transaction_pool.write().get_pending_or_queued(txn)
+        pool.get_pending_or_queued(txn)
     }
 
     /// This is total transactions for the account, including both executed and pending


### PR DESCRIPTION
- Problem was accidentally trying to acquire write lock twice
- Plus two tests for getting status of pending and queued transactions