### PR TITLE
feat: DEVOPS-2118 force http to https redirect in all endpoints

### DIFF
--- a/infra/tf/api.tf
+++ b/infra/tf/api.tf
@@ -104,6 +104,16 @@ resource "google_compute_backend_service" "health" {
   security_policy = module.health_security_policies.policy.self_link
 }
 
+resource "google_compute_url_map" "api_http_redirect" {
+  name = "${var.chain_name}-api-http-redirect"
+  
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
 resource "google_compute_url_map" "api" {
   name            = format("%s-api", var.chain_name)
   default_service = google_compute_backend_service.api.id
@@ -161,7 +171,7 @@ resource "google_compute_managed_ssl_certificate" "api" {
 
 resource "google_compute_target_http_proxy" "api" {
   name    = "${var.chain_name}-target-proxy"
-  url_map = google_compute_url_map.api.id
+  url_map = google_compute_url_map.api_http_redirect.id
 }
 
 resource "google_compute_target_https_proxy" "api" {

--- a/infra/tf/apps.tf
+++ b/infra/tf/apps.tf
@@ -149,6 +149,16 @@ resource "google_compute_backend_service" "stats" {
   }
 }
 
+resource "google_compute_url_map" "apps_http_redirect" {
+  name = "${var.chain_name}-apps-http-redirect"
+  
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
 resource "google_compute_url_map" "apps" {
   name            = "${var.chain_name}-apps"
   default_service = google_compute_backend_service.otterscan.id
@@ -207,7 +217,7 @@ resource "google_compute_managed_ssl_certificate" "apps" {
 
 resource "google_compute_target_http_proxy" "apps" {
   name    = "${var.chain_name}-apps-target-proxy"
-  url_map = google_compute_url_map.apps.id
+  url_map = google_compute_url_map.apps_http_redirect.id
 }
 
 resource "google_compute_target_https_proxy" "apps" {

--- a/infra/tf/checkpoints.tf
+++ b/infra/tf/checkpoints.tf
@@ -110,6 +110,16 @@ resource "google_compute_backend_bucket" "checkpoint" {
   project = var.project_id
 }
 
+resource "google_compute_url_map" "checkpoint_http_redirect" {
+  name = "${var.chain_name}-checkpoint-http-redirect"
+  
+  default_url_redirect {
+    https_redirect         = true
+    redirect_response_code = "MOVED_PERMANENTLY_DEFAULT"
+    strip_query            = false
+  }
+}
+
 resource "google_compute_url_map" "checkpoint" {
   name            = format("%s-checkpoint-cdn", var.chain_name)
   default_service = google_compute_backend_bucket.checkpoint.id
@@ -135,7 +145,7 @@ resource "google_compute_ssl_policy" "tls12_modern" {
 
 resource "google_compute_target_http_proxy" "checkpoint" {
   name    = format("%s-checkpoint-cdn", var.chain_name)
-  url_map = google_compute_url_map.checkpoint.id
+  url_map = google_compute_url_map.checkpoint_http_redirect.id
 }
 
 resource "google_compute_target_https_proxy" "checkpoint" {


### PR DESCRIPTION
Using the standard (and clean) approach provided by GCP. 
https://cloud.google.com/load-balancing/docs/https/setting-up-reg-http-https-redirect

Same logic as in GKE apps, having 2 url maps.

Applied and tested in and infratest and devnet. Once approved, will be promoted to testnet and mainnet.