### PR TITLE
Allow passive sync to sync ZQ1 blocks.

### DIFF
--- a/z2/resources/chain-specs/zq2-mainnet.toml
+++ b/z2/resources/chain-specs/zq2-mainnet.toml
@@ -2,86 +2,91 @@ network = "zq2-mainnet"
 p2p_port = 3333
 
 bootstrap_address = [
-  "12D3KooWLQ9Uu31ZVn2wMwt5HgunwHYRh4V12cLuTa9qqyFKxkqS",
-  "/dns/bootstrap.zq2-mainnet.zilliqa.com/tcp/3333"
+    "12D3KooWLQ9Uu31ZVn2wMwt5HgunwHYRh4V12cLuTa9qqyFKxkqS",
+    "/dns/bootstrap.zq2-mainnet.zilliqa.com/tcp/3333",
 ]
 
 [[nodes]]
 eth_chain_id = 32769
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [ ["0xa50581ea4c4cec6b53262ca16b5b003d34c820be", "100_000_000_000_000_000_000" ] ]
+consensus.genesis_accounts = [
+    [
+        "0xa50581ea4c4cec6b53262ca16b5b003d34c820be",
+        "100_000_000_000_000_000_000",
+    ],
+]
 consensus.genesis_deposits = [
-  [
-    "833c9265b6443f2707e506081e2bc08c55d867c04dca6171f9203876fcf436335464703747b425458ce60b83036bfcba",
-    "12D3KooWNSC7ZnMRYu6f4CMAjfCc5KzUMhyd31UQXDfR2QFPPg9K",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "b8e9d87775aa2ad48f1e263434ff7f13c7c68c1c89c0e0031f791f35a3907ee1014ffc2d7b67fc534022da2fe5152d61",
-    "12D3KooWShbg7H3LSPZZrSYa6JyacX8eLFDiSSPha4gEWq5q1fd7",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "b4f5f2573109d4c33a95df26aed1727e5e388c5d37f446ede0576b98e23d1ea88fcc3cd1b981e45b2c584187a18f8fb6",
-    "12D3KooWLAHDwZMphR4akwzxzbpSWfqvzommPYftNu5cohNbtyUz",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "adcdcc405d4edaf804e6a96b912021ae2e5ef6000ff7cb9ce0012620b6525c80e1b015b18e172bb54cdf213af0ca070d",
-    "12D3KooWAZkrsNMmpje2ToBXAJMERbMg5HGC8aAzvTJwAR3VxQos",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "8afe2d8034b8cfd4282d638715086fb6ede67ac0fe7503e3c996064b645d461a518370ab12f228e5f2be5c3ff170a725",
-    "12D3KooWKY2gxqPsJ11gweKWvYGZd4F2Z1T8dYEaYRc49Bz2JGVN",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "b78794fd6708cec1b7ab0716fe48d9b72e0b89015a0c3d3c86c24310569f9cbff389910cfc147fd7f7d59b0b34cb7025",
-    "12D3KooWNUDP3wtdJXxEubzPtEuWqF142TP9fmJrGrQKRKdvJUvB",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "ae1b41871f821517561cd6430772d75e28e21f971dbe119f31025672ec49c696d7e70fae05af7cc9e0fe0ecbac97acca",
-    "12D3KooWLrZaV4NfuSZCm3f731Yf8AxM8csVTv498ikCTdYm6anc",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "800772dfa8a53fef9f075380a7ab835f2dd07c88a608400e8c02a96d031f69aa4a8f95b6e79a6a8787a86f0cb3409710",
-    "12D3KooWQUq7Y2KsCrMaFGnsNB6tC5f1W1uRXmLjBZYcsJewE5TL",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "afb35a4ca993d53647ade97788913fba1ffa658ab70bac01a661ed1d3fa7721c3979012c9ce5d6995d0726dd8fcc59a6",
-    "12D3KooWNZDZbdxGFEZY4XkP9ymzUVH65bWAxXPMUSta5Y1i6kxb",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ],
-  [
-    "93c027c2d9b9611affec8f785add787bbc548f2efe5e2c911c45d814e87a2cc5c39463fdda7d2137b8e8280902366a25",
-    "12D3KooWBhH9yj4Qwq4Dm99p6QzWeuUBQBjFD9jhsoF7LoUSezNs",
-    "80_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
-  ]
+    [
+        "833c9265b6443f2707e506081e2bc08c55d867c04dca6171f9203876fcf436335464703747b425458ce60b83036bfcba",
+        "12D3KooWNSC7ZnMRYu6f4CMAjfCc5KzUMhyd31UQXDfR2QFPPg9K",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "b8e9d87775aa2ad48f1e263434ff7f13c7c68c1c89c0e0031f791f35a3907ee1014ffc2d7b67fc534022da2fe5152d61",
+        "12D3KooWShbg7H3LSPZZrSYa6JyacX8eLFDiSSPha4gEWq5q1fd7",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "b4f5f2573109d4c33a95df26aed1727e5e388c5d37f446ede0576b98e23d1ea88fcc3cd1b981e45b2c584187a18f8fb6",
+        "12D3KooWLAHDwZMphR4akwzxzbpSWfqvzommPYftNu5cohNbtyUz",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "adcdcc405d4edaf804e6a96b912021ae2e5ef6000ff7cb9ce0012620b6525c80e1b015b18e172bb54cdf213af0ca070d",
+        "12D3KooWAZkrsNMmpje2ToBXAJMERbMg5HGC8aAzvTJwAR3VxQos",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "8afe2d8034b8cfd4282d638715086fb6ede67ac0fe7503e3c996064b645d461a518370ab12f228e5f2be5c3ff170a725",
+        "12D3KooWKY2gxqPsJ11gweKWvYGZd4F2Z1T8dYEaYRc49Bz2JGVN",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "b78794fd6708cec1b7ab0716fe48d9b72e0b89015a0c3d3c86c24310569f9cbff389910cfc147fd7f7d59b0b34cb7025",
+        "12D3KooWNUDP3wtdJXxEubzPtEuWqF142TP9fmJrGrQKRKdvJUvB",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "ae1b41871f821517561cd6430772d75e28e21f971dbe119f31025672ec49c696d7e70fae05af7cc9e0fe0ecbac97acca",
+        "12D3KooWLrZaV4NfuSZCm3f731Yf8AxM8csVTv498ikCTdYm6anc",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "800772dfa8a53fef9f075380a7ab835f2dd07c88a608400e8c02a96d031f69aa4a8f95b6e79a6a8787a86f0cb3409710",
+        "12D3KooWQUq7Y2KsCrMaFGnsNB6tC5f1W1uRXmLjBZYcsJewE5TL",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "afb35a4ca993d53647ade97788913fba1ffa658ab70bac01a661ed1d3fa7721c3979012c9ce5d6995d0726dd8fcc59a6",
+        "12D3KooWNZDZbdxGFEZY4XkP9ymzUVH65bWAxXPMUSta5Y1i6kxb",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
+    [
+        "93c027c2d9b9611affec8f785add787bbc548f2efe5e2c911c45d814e87a2cc5c39463fdda7d2137b8e8280902366a25",
+        "12D3KooWBhH9yj4Qwq4Dm99p6QzWeuUBQBjFD9jhsoF7LoUSezNs",
+        "80_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
+    ],
 ]
 
 # Reward parameters
@@ -94,4 +99,28 @@ consensus.gas_price = "4_761_904_800_000"
 consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params = { withdrawal_period = 1209600 } } }
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
+consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false, scilla_call_respects_evm_state_changes = false, only_mutated_accounts_update_state = false, scilla_call_gas_exempt_addrs = [
+], scilla_block_number_returns_current_block = false, scilla_maps_are_encoded_correctly = false, transfer_gas_fee_to_zero_account = false, apply_state_changes_only_if_transaction_succeeds = false, apply_scilla_delta_when_evm_succeeded = false, scilla_deduct_funds_from_actual_sender = false, fund_accounts_from_zero_account = [
+] }
+
+consensus.forks = [{ at_height = 4770088, executable_blocks = true }]
+
+api_servers = [
+    { port = 4201, enabled_apis = [
+        { namespace = "eth", apis = [
+            "blockNumber",
+        ] },
+    ] },
+    { port = 4202, enabled_apis = [
+        "admin",
+        "debug",
+        "erigon",
+        "eth",
+        "net",
+        "ots",
+        "trace",
+        "txpool",
+        "web3",
+        "zilliqa",
+    ] },
+]

--- a/z2/resources/chain-specs/zq2-testnet.toml
+++ b/z2/resources/chain-specs/zq2-testnet.toml
@@ -2,65 +2,70 @@ network = "zq2-testnet"
 p2p_port = 3333
 
 bootstrap_address = [
-  "12D3KooWPFzgn8XUdrvRMuJmSPXRZPBBzv2ZmDmeKM8HGE8gKDJP",
-  "/dns/bootstrap.zq2-testnet.zilliqa.com/tcp/3333"
+    "12D3KooWPFzgn8XUdrvRMuJmSPXRZPBBzv2ZmDmeKM8HGE8gKDJP",
+    "/dns/bootstrap.zq2-testnet.zilliqa.com/tcp/3333",
 ]
 
 [[nodes]]
 eth_chain_id = 33101
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [ ["0x214695413d1ea6a4a4453cd24ffd151fbc95496a", "900_000_000_000_000_000_000_000_000" ] ]
+consensus.genesis_accounts = [
+    [
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+        "900_000_000_000_000_000_000_000_000",
+    ],
+]
 consensus.genesis_deposits = [
-  [
-    "94ce9650426f5c5b7eeb8499b94bc2cc6b82b423f3bb235889d3120aedc75a1d8236c2912dda45b75a3226731a776cbf",
-    "12D3KooWQPkr3EGzqiVdRcLTBo3sjBA5J2HRbBR6kcxY3QNCDF1M",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "b2ba01dbc1989399ffca35c1e9c73613bbe678c94740feb035538d7299c4bd8ba98b28292982857534f60289ca2b663c",
-    "12D3KooWRuSPXcoiFHaFkxgfy3P4UnhB5vKtgShkXTWL9xfdVZ1V",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "ae776c587e6869d41331529c6dd0f59c31d1ef4c47f8b5ecb1acc54fa7452d9b2ba6f56bdad08a606d25761c8522b367",
-    "12D3KooWJyH1r2UfcFPiHbEFBYB3xWufR1va8cRK3veMwfUunfRD",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "95de7dae002295bba9c4cffd1b0df70a7ccd0cc68e6b10da06b1b91f8a7e9b305e19431fc42b7413c65a8ab6959e41c6",
-    "12D3KooWM5L182sQtJuARf5Xfg517xVqZRaPM9583BsmLcv5Ma2o",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "ae96338209ec4f1ad446a131e687bde02506207b750465cbc43d1ea4f5b32daa51ff060e8451c903d6de7f1c89951b1d",
-    "12D3KooWQpAM4F19CwJAAhHFgeD7feyQLHDTxzKu2hsVH4BQceSQ",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "a3a2419fba7962021d730f4e1eb087b5bf0d66140ef7d4ba758348b13fb2ffa9a75afbdbef988c65ce625544360dea42",
-    "12D3KooWAWoMVZAXJDkuhyzyBJHGHn2gYFyTbbdZGhHs4BuEN5Fe",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ],
-  [
-    "8093ea6fa4720ca0975559a5f9d3a2694c6ab8e63a8c54e986d11a28f9e958f006420e30a8d6f04d6b2df63fe6e0563d",
-    "12D3KooWNqZxaW4ZirvWUNj9KSRgTp55RsZHSFumDeRdCLZAjNNA",
-    "20_000_000_000_000_000_000_000_000",
-    "0x0000000000000000000000000000000000000000",
-    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
-  ]
+    [
+        "94ce9650426f5c5b7eeb8499b94bc2cc6b82b423f3bb235889d3120aedc75a1d8236c2912dda45b75a3226731a776cbf",
+        "12D3KooWQPkr3EGzqiVdRcLTBo3sjBA5J2HRbBR6kcxY3QNCDF1M",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "b2ba01dbc1989399ffca35c1e9c73613bbe678c94740feb035538d7299c4bd8ba98b28292982857534f60289ca2b663c",
+        "12D3KooWRuSPXcoiFHaFkxgfy3P4UnhB5vKtgShkXTWL9xfdVZ1V",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "ae776c587e6869d41331529c6dd0f59c31d1ef4c47f8b5ecb1acc54fa7452d9b2ba6f56bdad08a606d25761c8522b367",
+        "12D3KooWJyH1r2UfcFPiHbEFBYB3xWufR1va8cRK3veMwfUunfRD",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "95de7dae002295bba9c4cffd1b0df70a7ccd0cc68e6b10da06b1b91f8a7e9b305e19431fc42b7413c65a8ab6959e41c6",
+        "12D3KooWM5L182sQtJuARf5Xfg517xVqZRaPM9583BsmLcv5Ma2o",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "ae96338209ec4f1ad446a131e687bde02506207b750465cbc43d1ea4f5b32daa51ff060e8451c903d6de7f1c89951b1d",
+        "12D3KooWQpAM4F19CwJAAhHFgeD7feyQLHDTxzKu2hsVH4BQceSQ",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "a3a2419fba7962021d730f4e1eb087b5bf0d66140ef7d4ba758348b13fb2ffa9a75afbdbef988c65ce625544360dea42",
+        "12D3KooWAWoMVZAXJDkuhyzyBJHGHn2gYFyTbbdZGhHs4BuEN5Fe",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
+    [
+        "8093ea6fa4720ca0975559a5f9d3a2694c6ab8e63a8c54e986d11a28f9e958f006420e30a8d6f04d6b2df63fe6e0563d",
+        "12D3KooWNqZxaW4ZirvWUNj9KSRgTp55RsZHSFumDeRdCLZAjNNA",
+        "20_000_000_000_000_000_000_000_000",
+        "0x0000000000000000000000000000000000000000",
+        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
+    ],
 ]
 
 # Reward parameters
@@ -73,4 +78,28 @@ consensus.gas_price = "4_761_904_800_000"
 consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params = { withdrawal_period = 1209600 } } }
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 
-api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
+consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = false, failed_scilla_call_from_gas_exempt_caller_causes_revert = false, scilla_messages_can_call_evm_contracts = false, scilla_contract_creation_increments_account_balance = false, scilla_json_preserve_order = false, scilla_call_respects_evm_state_changes = false, only_mutated_accounts_update_state = false, scilla_call_gas_exempt_addrs = [
+], scilla_block_number_returns_current_block = false, scilla_maps_are_encoded_correctly = false, transfer_gas_fee_to_zero_account = false, apply_state_changes_only_if_transaction_succeeds = false, apply_scilla_delta_when_evm_succeeded = false, scilla_deduct_funds_from_actual_sender = false, fund_accounts_from_zero_account = [
+] }
+
+consensus.forks = [{ at_height = 8099088, executable_blocks = true }]
+
+api_servers = [
+    { port = 4201, enabled_apis = [
+        { namespace = "eth", apis = [
+            "blockNumber",
+        ] },
+    ] },
+    { port = 4202, enabled_apis = [
+        "admin",
+        "debug",
+        "erigon",
+        "eth",
+        "net",
+        "ots",
+        "trace",
+        "txpool",
+        "web3",
+        "zilliqa",
+    ] },
+]


### PR DESCRIPTION
I just need the `executable_blocks = true` at the ZQ2 cutover height, and false for ZQ1 blocks below that height. Otherwise, the blocks will fail verification since the ZQ1 hashes aren't computed the same as ZQ2.

I'm not sure of the suitable default values for the other fork settings. I just copied them over from the protomainnet/prototestnet chainspecs.

Please fix it as necessary.