### PR TITLE
fix: DEVOPS-2113 apps https redirection disabled

### DIFF
--- a/infra/tf/api.tf
+++ b/infra/tf/api.tf
@@ -247,7 +247,7 @@ module "api_security_policies" {
       action      = "throttle"
       priority    = 990
       description = "Limit requests per IP"
-      expression  = "!inIpRange(origin.ip, '${local.monitoring_ip_range}')"
+      expression  = "request.method == 'POST' && !inIpRange(origin.ip, '${local.monitoring_ip_range}')"
       rate_limit_options = {
         enforce_on_key                       = "IP"
         exceed_action                        = "deny(429)"

--- a/infra/tf/apps.tf
+++ b/infra/tf/apps.tf
@@ -217,7 +217,7 @@ resource "google_compute_managed_ssl_certificate" "apps" {
 
 resource "google_compute_target_http_proxy" "apps" {
   name    = "${var.chain_name}-apps-target-proxy"
-  url_map = google_compute_url_map.apps_http_redirect.id
+  url_map = google_compute_url_map.apps.id
 }
 
 resource "google_compute_target_https_proxy" "apps" {


### PR DESCRIPTION
- Redirection is disabled as it is causing problems with stats. We will review this case in another ticket.
- Improving the condition on the Cloud Armor policy.