### PR TITLE
Block active-sync of ZQ1 blocks

### DIFF
--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -189,6 +189,12 @@ impl Sync {
 
         let ignore_passive = config.sync.ignore_passive; // defaults to servicing passive-sync requests
 
+        if latest_block_number < zq1_ceil_height {
+            return Err(anyhow::anyhow!(
+                "latest block number {latest_block_number} < ZQ2 height {zq1_ceil_height}"
+            ));
+        }
+
         Ok(Self {
             db,
             message_sender,
@@ -531,6 +537,12 @@ impl Sync {
             .db
             .get_highest_canonical_block_number()?
             .expect("no highest canonical block");
+        if self.started_at < self.zq1_ceil_height {
+            error!(
+                "Starting block {} is below ZQ2 height {}",
+                self.started_at, self.zq1_ceil_height
+            );
+        }
         Ok(())
     }
 

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -863,6 +863,11 @@ impl Sync {
             let Some(block) = self.db.get_block_by_hash(&hash)? else {
                 break; // that's all we have!
             };
+            if block.number() < self.zq1_ceil_height {
+                // do not active sync ZQ1 blocks
+                warn!("sync::MultiBlockRequest : skipping ZQ1");
+                break;
+            }
             proposals.push(self.block_to_proposal(block));
         }
 
@@ -1217,6 +1222,11 @@ impl Sync {
             let Some(block) = self.db.get_block_by_hash(&hash)? else {
                 break; // that's all we have!
             };
+
+            if block.number() < self.zq1_ceil_height {
+                warn!("sync::MetadataRequest : skipping ZQ1");
+                break;
+            }
 
             let encoded_size = self.size_cache.get(&hash).cloned().unwrap_or_else(|| {
                 // pseudo-LRU approximation


### PR DESCRIPTION
This PR does 2 things:
1. Send empty response for active-sync request of ZQ1 blocks.
2. Prevent the startup of nodes without a checkpoint, on testnet/mainnet.

So, it makes it clear that a testnet/mainnet node MUST be restored from a checkpoint. It cannot start active syncing from nothing.

This will break misconfigured 0.11 nodes. So, this will have to go out with 0.12 - and people are informed of the breaking change. Otherwise, they will just get stuck syncing - there is no other error for 0.11 nodes.

We should deploy this to validator nodes first, which won't break the network since the API nodes can still service 0.11 calls, until such time that we are comfortable to switch to 0.12 fully.