### PR TITLE
Moved db wrapper to accepting and returning verified transactions

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -569,7 +569,7 @@ pub async fn convert_persistence(
                 if let Err(err) = zq2_db.insert_transaction_with_db_tx(
                     sqlite_tx,
                     hash,
-                    &transaction.clone().verify_override(),
+                    &transaction.clone().verify_bypass()?,
                 ) {
                     warn!(
                         "Unable to insert transaction with id: {:?} to db, err: {:?}",

--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -566,8 +566,11 @@ pub async fn convert_persistence(
             trace!("{} block inserted", block.number());
 
             for (hash, transaction) in &transactions {
-                if let Err(err) = zq2_db.insert_transaction_with_db_tx(sqlite_tx, hash, transaction)
-                {
+                if let Err(err) = zq2_db.insert_transaction_with_db_tx(
+                    sqlite_tx,
+                    hash,
+                    &transaction.clone().verify_override(),
+                ) {
                     warn!(
                         "Unable to insert transaction with id: {:?} to db, err: {:?}",
                         *hash, err

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1500,7 +1500,7 @@ impl Consensus {
         self.db.with_sqlite_tx(|sqlite_tx| {
             for tx in applied_txs {
                 self.db
-                    .insert_transaction_with_db_tx(sqlite_tx, &tx.hash, &tx.tx)?;
+                    .insert_transaction_with_db_tx(sqlite_tx, &tx.hash, tx)?;
             }
             Ok(())
         })?;
@@ -1648,7 +1648,7 @@ impl Consensus {
                 inspector::noop(),
                 false,
             )?;
-            self.db.insert_transaction(&txn.hash, &txn.tx)?;
+            self.db.insert_transaction(&txn.hash, &txn)?;
 
             // Skip transactions whose execution resulted in an error
             let Some(result) = result else {
@@ -2048,7 +2048,7 @@ impl Consensus {
 
     pub fn get_transaction_by_hash(&self, hash: Hash) -> Result<Option<VerifiedTransaction>> {
         Ok(match self.db.get_transaction(&hash)? {
-            Some(tx) => Some(tx.verify()?),
+            Some(tx) => Some(tx),
             None => self.transaction_pool.read().get_transaction(&hash).cloned(),
         })
     }
@@ -2294,7 +2294,7 @@ impl Consensus {
                             txn_hash,
                             parent.hash()
                         ))?;
-                        Ok::<_, anyhow::Error>(tx)
+                        Ok::<_, anyhow::Error>(tx.tx)
                     })
                     .collect::<Result<Vec<SignedTransaction>>>()?;
 
@@ -2334,7 +2334,7 @@ impl Consensus {
                     txn_hash,
                     parent.hash()
                 ))?;
-                Ok::<_, anyhow::Error>(tx)
+                Ok::<_, anyhow::Error>(tx.tx)
             })
             .collect::<Result<Vec<SignedTransaction>>>()?;
         let checkpoint_dir = self
@@ -2917,7 +2917,7 @@ impl Consensus {
             // block transactions need to be removed from self.transactions and re-injected
             let mut pool = self.transaction_pool.write();
             for tx_hash in &head_block.transactions {
-                let orig_tx = self.db.get_transaction(tx_hash)?.unwrap().verify()?;
+                let orig_tx = self.db.get_transaction(tx_hash)?.unwrap();
 
                 // Insert this unwound transaction back into the transaction pool.
                 let account = self.state.get_account(orig_tx.signer)?;
@@ -2977,15 +2977,7 @@ impl Consensus {
             let transactions = block_pointer.transactions.clone();
             let transactions = transactions
                 .iter()
-                .map(|tx_hash| {
-                    self.db
-                        .get_transaction(tx_hash)
-                        .unwrap()
-                        .unwrap()
-                        .verify()
-                        .unwrap()
-                        .tx
-                })
+                .map(|tx_hash| self.db.get_transaction(tx_hash).unwrap().unwrap().tx)
                 .collect();
             let parent = self
                 .get_block(&block_pointer.parent_hash())?
@@ -3148,7 +3140,7 @@ impl Consensus {
         self.db.with_sqlite_tx(|sqlite_tx| {
             for txn in &verified_txns {
                 self.db
-                    .insert_transaction_with_db_tx(sqlite_tx, &txn.hash, &txn.tx)?;
+                    .insert_transaction_with_db_tx(sqlite_tx, &txn.hash, txn)?;
             }
             for (addr, txn_hash) in touched_addresses {
                 self.db

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -28,7 +28,7 @@ use crate::{
     message::{AggregateQc, Block, BlockHeader, QuorumCertificate},
     state::Account,
     time::SystemTime,
-    transaction::{EvmGas, Log, SignedTransaction, TransactionReceipt},
+    transaction::{EvmGas, Log, SignedTransaction, TransactionReceipt, VerifiedTransaction},
 };
 
 macro_rules! sqlify_with_bincode {
@@ -852,14 +852,15 @@ impl Db {
             .collect::<Result<Vec<_>, _>>()?)
     }
 
-    pub fn get_transaction(&self, txn_hash: &Hash) -> Result<Option<SignedTransaction>> {
+    pub fn get_transaction(&self, txn_hash: &Hash) -> Result<Option<VerifiedTransaction>> {
         Ok(self
             .db
             .lock()
             .unwrap()
             .prepare_cached("SELECT data FROM transactions WHERE tx_hash = ?1")?
             .query_row([txn_hash], |row| row.get(0))
-            .optional()?)
+            .optional()?
+            .map(|x: SignedTransaction| x.verify_override()))
     }
 
     pub fn contains_transaction(&self, hash: &Hash) -> Result<bool> {
@@ -877,17 +878,17 @@ impl Db {
         &self,
         sqlite_tx: &Connection,
         hash: &Hash,
-        tx: &SignedTransaction,
+        tx: &VerifiedTransaction,
     ) -> Result<()> {
         sqlite_tx
             .prepare_cached("INSERT OR IGNORE INTO transactions (tx_hash, data) VALUES (?1, ?2)")?
-            .execute((hash, tx))?;
+            .execute((hash, tx.tx.clone()))?;
         Ok(())
     }
 
     /// Insert a transaction whose hash was precalculated, to save a call to calculate_hash() if it
     /// is already known
-    pub fn insert_transaction(&self, hash: &Hash, tx: &SignedTransaction) -> Result<()> {
+    pub fn insert_transaction(&self, hash: &Hash, tx: &VerifiedTransaction) -> Result<()> {
         self.insert_transaction_with_db_tx(&self.db.lock().unwrap(), hash, tx)
     }
 

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -1418,7 +1418,7 @@ impl Sync {
                             // FIXME: ZQ1 bypass
                             error!(number = %block.number(), index = %rt.index, hash = %rt.tx_hash, "sync::StoreProposals : unverifiable");
                             self.db
-                                .insert_transaction_with_db_tx(sqlite_tx, &rt.tx_hash, &st.verify_override())?;
+                                .insert_transaction_with_db_tx(sqlite_tx, &rt.tx_hash, &st.verify_bypass()?)?;
                         } else {
                             anyhow::bail!(
                                 "sync::StoreProposal : unverifiable transaction {}/{}/{}",

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -382,6 +382,14 @@ impl SignedTransaction {
     }
 
     pub fn verify(self) -> Result<VerifiedTransaction> {
+        self.verify_inner(false)
+    }
+
+    pub fn verify_override(self) -> VerifiedTransaction {
+        self.verify_inner(true).unwrap()
+    }
+
+    fn verify_inner(self, force: bool) -> Result<VerifiedTransaction> {
         let (tx, signer, hash) = match self {
             SignedTransaction::Legacy { tx, sig } => {
                 let signed = tx.into_signed(sig);
@@ -404,7 +412,10 @@ impl SignedTransaction {
             SignedTransaction::Zilliqa { tx, key, sig } => {
                 let txn_data = encode_zilliqa_transaction(&tx, key);
 
-                schnorr::verify(&txn_data, key, sig).ok_or_else(|| anyhow!("invalid signature"))?;
+                if !force {
+                    schnorr::verify(&txn_data, key, sig)
+                        .ok_or_else(|| anyhow!("invalid signature"))?;
+                }
 
                 let hashed = Sha256::digest(key.to_encoded_point(true).as_bytes());
                 let (_, bytes): (GenericArray<u8, U12>, GenericArray<u8, U20>) = hashed.split();

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -385,8 +385,8 @@ impl SignedTransaction {
         self.verify_inner(false)
     }
 
-    pub fn verify_override(self) -> VerifiedTransaction {
-        self.verify_inner(true).unwrap()
+    pub fn verify_bypass(self) -> Result<VerifiedTransaction> {
+        self.verify_inner(true)
     }
 
     fn verify_inner(self, force: bool) -> Result<VerifiedTransaction> {


### PR DESCRIPTION

- actual verification is skipped on retrieval
- Should fix error when retrieving some ZQ1 transactions
- I haven't actually changed what's stored in the db, that could come later if we like this approach

Let me know if this doesn't work for some reason - it just seemed nicer and more consistent than adding one-off ignoring verification