### PR TITLE
Added some spamming mitigations

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -241,7 +241,7 @@ impl Consensus {
     // range of views to buffer votes for
     const VIEW_BUFFER_RANGE: u64 = 500;
     // maximum number of votes to buffer for each view
-    const MAX_VOTES_PER_VIEW: usize = crate::message::MAX_COMMITTEE_SIZE * 2 / 3;
+    const MAX_VOTES_PER_VIEW: usize = crate::message::MAX_COMMITTEE_SIZE;
 
     pub fn new(
         secret_key: SecretKey,

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -238,10 +238,8 @@ pub struct Consensus {
 impl Consensus {
     // determined empirically
     const PROP_SIZE_THRESHOLD: usize = 921 * 1024; // 90% of 1MB
-    // range of views to buffer votes for
-    const VIEW_BUFFER_RANGE: u64 = 500;
-    // maximum number of votes to buffer for each view
-    const MAX_VOTES_PER_VIEW: usize = crate::message::MAX_COMMITTEE_SIZE;
+    // view buffer size limit
+    const VIEW_BUFFER_THRESHOLD: usize = 1000;
 
     pub fn new(
         secret_key: SecretKey,
@@ -1109,7 +1107,10 @@ impl Consensus {
         if block_view + 1 < current_view {
             trace!("vote is too old");
             return Ok(None);
-        } else if block_view > current_view + Self::VIEW_BUFFER_RANGE {
+        } else if block_view > current_view + 500 {
+            // when stuck in exponential backoff, +500 is effectively forever;
+            // when active syncing at ~30 blk/s, means that we're > 3 views behind.
+            // in either case, that vote is quite meaningless at this point and can be ignored.
             trace!("vote is too early");
             return Ok(None);
         }
@@ -1122,15 +1123,25 @@ impl Consensus {
 
         // Retrieve the actual block this vote is for.
         let Some(block) = self.get_block(&block_hash)? else {
+            // We try to limit the size of the buffered votes to prevent memory exhaustion.
+            // If the buffered votes exceed the threshold, we purge as many stale votes as possible.
+            // While this is not guaranteed to reduce the size of the buffered votes, it is a best-effort attempt.
+            if self.buffered_votes.len() > Self::VIEW_BUFFER_THRESHOLD {
+                self.buffered_votes.retain(|_hash, votes| {
+                    // purge stale votes
+                    votes.first().map(|(_p, v)| v.view + 1).unwrap_or_default() >= current_view
+                });
+            }
             // If we don't have the block yet, we buffer the vote in case we recieve the block later. Note that we
             // don't know the leader of this view without the block, so we may be storing this unnecessarily, however
             // non-malicious nodes should only have sent us this vote if they thought we were the leader.
             let mut buf = self.buffered_votes.entry(block_hash).or_default();
-            if buf.len() < Self::MAX_VOTES_PER_VIEW {
+            if buf.len() < MAX_COMMITTEE_SIZE {
+                // we only ever need 2/3 of the committee, so it should not exceed this number.
                 trace!("vote for unknown block, buffering");
                 buf.push((peer_id, vote));
             } else {
-                trace!("vote for unknown block, dropping");
+                error!(%peer_id, view=%block_view, "vote for unknown block, dropping");
             }
             return Ok(None);
         };

--- a/zilliqa/src/p2p_node.rs
+++ b/zilliqa/src/p2p_node.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use libp2p::{
     PeerId, StreamProtocol, Swarm, autonat,
     futures::StreamExt,
-    gossipsub::{self, IdentTopic, MessageAuthenticity, TopicHash},
+    gossipsub::{self, IdentTopic, MessageAcceptance, MessageAuthenticity, TopicHash},
     identify,
     kad::{self, store::MemoryStore},
     multiaddr::{Multiaddr, Protocol},
@@ -149,8 +149,9 @@ impl P2pNode {
                             .duplicate_cache_time(Duration::from_secs(3600))
                             // Increase the queue duration to reduce the likelihood of dropped messages.
                             // https://github.com/Zilliqa/zq2/issues/2823
-                            .publish_queue_duration(Duration::from_secs(50))
+                            .publish_queue_duration(Duration::from_secs(60))
                             .forward_queue_duration(Duration::from_secs(30)) // might be helpful too
+                            .validate_messages() // manual forwarding is required
                             .build()
                             .map_err(|e| anyhow!(e))?,
                     )
@@ -378,13 +379,18 @@ impl P2pNode {
                             debug!(%source, %to, %external_message, %topic_hash, "broadcast received");
 
                             match external_message {
+                                ExternalMessage::BatchedTransactions(_) | ExternalMessage::NewView(_) => {
+                                    self.swarm.behaviour_mut().gossipsub.report_message_validation_result(&msg_id, &source, MessageAcceptance::Accept); // forward
+                                    self.send_to(&topic_hash, |c| c.broadcasts.send((source, external_message, ResponseChannel::Local)))?;
+                                },
                                 // Route broadcasts to speed-up Proposal processing, with faux request-id
-                                ExternalMessage::Proposal(_) =>
-                                    self.send_to(&topic_hash, |c| c.requests.send((source, msg_id.to_string(), external_message, ResponseChannel::Local)))?,
-                                ExternalMessage::BatchedTransactions(_) | ExternalMessage::NewView(_) =>
-                                    self.send_to(&topic_hash, |c| c.broadcasts.send((source, external_message, ResponseChannel::Local)))?,
+                                ExternalMessage::Proposal(_) => {
+                                    self.swarm.behaviour_mut().gossipsub.report_message_validation_result(&msg_id, &source, MessageAcceptance::Accept); // forward
+                                    self.send_to(&topic_hash, |c| c.requests.send((source, msg_id.to_string(), external_message, ResponseChannel::Local)))?;
+                                },
                                 // Drop invalid libp2p gossips
                                 _ => {
+                                    self.swarm.behaviour_mut().gossipsub.report_message_validation_result(&msg_id, &source, MessageAcceptance::Reject); // drop and punish
                                     error!(%source, %to, %external_message, %topic_hash, "unhandled libp2p broadcast");
                                 }
                             }

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -145,7 +145,7 @@ impl Sync {
     // Speed up by fetching multiple segments in Phase 1.
     const MAX_CONCURRENT_PEERS: usize = 10;
     // Mitigate DoS
-    const MAX_BATCH_SIZE: usize = 1000;
+    const MAX_BATCH_SIZE: usize = 100;
     // Cache recent block sizes
     const MAX_CACHE_SIZE: usize = 10000;
     // Timeout for passive-sync/prune
@@ -164,11 +164,11 @@ impl Sync {
         let max_batch_size = config
             .sync
             .block_request_batch_size
-            .clamp(100, Self::MAX_BATCH_SIZE);
-        let max_blocks_in_flight = config
-            .sync
-            .max_blocks_in_flight
-            .clamp(max_batch_size, Self::MAX_BATCH_SIZE);
+            .clamp(10, Self::MAX_BATCH_SIZE); // reduce the max batch size - 100 is more than sufficient; less may work too.
+        let max_blocks_in_flight = config.sync.max_blocks_in_flight.clamp(
+            max_batch_size,
+            Self::MAX_BATCH_SIZE * Self::MAX_CONCURRENT_PEERS, // phase 2 buffering - 1000 is more than sufficient; more may work too.
+        );
         let sync_base_height = config.sync.base_height;
         let prune_interval = config.sync.prune_interval;
         // Start from reset, or continue sync


### PR DESCRIPTION
Currently deployed in `devnet`.
It addresses some potential issues with spamming - details in issue #2990 

1. It does a rudimentary sanity check on gossipsub and punishes any node that broadcasts spam.
2. It reduces the maximum range of a sync request to a reasonable number to mitigate sync spam.
3. It prunes stale buffered votes, which it did not do previously, to mitigate vote spam.