### PR TITLE
Disable EIP-3607, for ZQ1 compatibility.

### DIFF
--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -54,7 +54,7 @@ paste = "1.0.15"
 prost = "0.14.1"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
-revm = { version = "19.6.0", features = ["optional_no_base_fee"] }
+revm = { version = "19.6.0", features = ["optional_eip3607", "optional_no_base_fee"] }
 revm-inspectors = { version = "0.16.0", features = ["js-tracer"] }
 rusqlite = { version = "0.37.0", features = ["bundled", "trace"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -60,6 +60,7 @@ pub fn rpc_module(
             ("eth_blobBaseFee", blob_base_fee),
             ("eth_blockNumber", block_number),
             ("eth_call", call),
+            ("eth_callMany", call_many),
             ("eth_chainId", chain_id),
             ("eth_estimateGas", estimate_gas),
             ("eth_feeHistory", fee_history),
@@ -196,6 +197,11 @@ fn block_number(params: Params, node: &Arc<RwLock<Node>>) -> Result<String> {
     expect_end_of_params(&mut params.sequence(), 0, 0)?;
     let node = node.read();
     Ok(node.consensus.get_highest_canonical_block_number().to_hex())
+}
+
+fn call_many(_params: Params, _node: &Arc<RwLock<Node>>) -> Result<()> {
+    // TODO: disable_eip3607 for this call.
+    Err(anyhow!("API method eth_callMany is not implemented yet"))
 }
 
 fn call(params: Params, node: &Arc<RwLock<Node>>) -> Result<String> {
@@ -1172,6 +1178,7 @@ fn sign_transaction(_params: Params, _node: &Arc<RwLock<Node>>) -> Result<()> {
 /// eth_simulateV1
 /// Simulates a series of transactions at a specific block height with optional state overrides. This method allows you to test transactions with custom block and state parameters without actually submitting them to the network.
 fn simulate_v1(_params: Params, _node: &Arc<RwLock<Node>>) -> Result<()> {
+    // TODO: disable_eip3607 for this call.
     Err(anyhow!("API method eth_simulateV1 is not implemented yet"))
 }
 

--- a/zilliqa/src/api/trace.rs
+++ b/zilliqa/src/api/trace.rs
@@ -93,11 +93,13 @@ fn trace_block(params: Params, node: &Arc<RwLock<Node>>) -> Result<Vec<TraceResu
 
 /// trace_call
 fn trace_call(_params: Params, _node: &Arc<RwLock<Node>>) -> Result<()> {
+    // TODO: disable_eip3607 for this call.
     Err(anyhow!("API method trace_call is not implemented yet"))
 }
 
 /// trace_callMany
 fn trace_call_many(_params: Params, _node: &Arc<RwLock<Node>>) -> Result<()> {
+    // TODO: disable_eip3607 for this call.
     Err(anyhow!("API method trace_callMany is not implemented yet"))
 }
 

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -564,6 +564,7 @@ impl State {
             .with_handler_cfg(HandlerCfg { spec_id: SPEC_ID })
             .append_handler_register(scilla_call_handle_register)
             .modify_cfg_env(|c| {
+                c.disable_eip3607 = true;
                 c.chain_id = self.chain_id.eth;
                 c.disable_base_fee = match base_fee_check {
                     BaseFeeCheck::Validate => false,

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -902,7 +902,7 @@ impl Node {
             return Err(anyhow!("State required to execute request does not exist"));
         }
 
-        state.call_contract(from_addr, to_addr, data, amount, block.header)
+        state.call_contract(from_addr, to_addr, data, amount, block.header, true)
     }
 
     pub fn get_proposer_reward_address(&self, header: BlockHeader) -> Result<Option<Address>> {
@@ -959,6 +959,7 @@ impl Node {
             gas,
             gas_price,
             value,
+            true,
         )
     }
 


### PR DESCRIPTION
ZQ1 used SputnikVM (London) which did not have EIP3607 support. ZQ2 uses REVM (Shanghai) which has EIP3607 turned on by default.

This PR selectively disables EIP3607 for calls from `eth_call` and `eth_estimateGas` to emulate the previous ZQ1 behaviour.