### PR TITLE
Empty txpool content entries now ignored

### DIFF
--- a/zilliqa/src/api/txpool.rs
+++ b/zilliqa/src/api/txpool.rs
@@ -32,7 +32,7 @@ fn txpool_content(
     let mut node = node.write();
     let content = node.txpool_content();
 
-    let pending = content
+    let pending: HashMap<Address, HashMap<u64, Transaction>> = content
         .pending
         .into_iter()
         .map(|(k, v)| {
@@ -41,12 +41,13 @@ fn txpool_content(
                 v.iter()
                     .filter(|x| x.tx.nonce().is_some())
                     .map(|x| (x.tx.nonce().unwrap(), Transaction::new(x.clone(), None)))
-                    .collect(),
+                    .collect::<HashMap<u64, Transaction>>(),
             )
         })
+        .filter(|(_, v)| !v.is_empty())
         .collect();
 
-    let queued = content
+    let queued: HashMap<Address, HashMap<u64, Transaction>> = content
         .queued
         .into_iter()
         .map(|(k, v)| {
@@ -55,9 +56,10 @@ fn txpool_content(
                 v.iter()
                     .filter(|x| x.tx.nonce().is_some())
                     .map(|x| (x.tx.nonce().unwrap(), Transaction::new(x.clone(), None)))
-                    .collect(),
+                    .collect::<HashMap<u64, Transaction>>(),
             )
         })
+        .filter(|(_, v)| !v.is_empty())
         .collect();
 
     let result = types::txpool::TxPoolContent { pending, queued };

--- a/zilliqa/src/api/types/txpool.rs
+++ b/zilliqa/src/api/types/txpool.rs
@@ -7,17 +7,13 @@ use super::eth::Transaction;
 
 #[derive(Clone, Serialize)]
 pub struct TxPoolContent {
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub pending: HashMap<Address, HashMap<u64, Transaction>>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub queued: HashMap<Address, HashMap<u64, Transaction>>,
 }
 
 #[derive(Clone, Serialize)]
 pub struct TxPoolInspect {
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub pending: HashMap<Address, HashMap<u64, String>>,
-    #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub queued: HashMap<Address, HashMap<u64, String>>,
 }
 

--- a/zilliqa/tests/it/txpool.rs
+++ b/zilliqa/tests/it/txpool.rs
@@ -18,11 +18,21 @@ async fn txpool_content(mut network: Network) {
         .expect("Failed to call txpool_content API");
 
     assert!(
-        empty_response.get("pending").is_none(),
+        empty_response
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending transactions"
     );
     assert!(
-        empty_response.get("queued").is_none(),
+        empty_response
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued transactions"
     );
 
@@ -78,11 +88,21 @@ async fn txpool_content(mut network: Network) {
         .expect("Failed to call txpool_content API");
 
     assert!(
-        final_response.get("pending").is_none(),
+        final_response
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending transactions after mining"
     );
     assert!(
-        final_response.get("queued").is_none(),
+        final_response
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued transactions after mining"
     );
 }
@@ -130,11 +150,21 @@ async fn txpool_content_from(mut network: Network) {
         .expect("Failed to call txpool_contentFrom API with random address");
 
     assert!(
-        empty_response.get("pending").is_none(),
+        empty_response
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending transactions for random address"
     );
     assert!(
-        empty_response.get("queued").is_none(),
+        empty_response
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued transactions for random address"
     );
 }
@@ -187,11 +217,21 @@ async fn txpool_content_from_with_queued(mut network: Network) {
         .expect("Failed to call txpool_contentFrom API with random address");
 
     assert!(
-        empty_content.get("pending").is_none(),
+        empty_content
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending for random address"
     );
     assert!(
-        empty_content.get("queued").is_none(),
+        empty_content
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued for random address"
     );
 }
@@ -210,11 +250,21 @@ async fn txpool_inspect(mut network: Network) {
         .expect("Failed to call txpool_inspect API");
 
     assert!(
-        empty_response.get("pending").is_none(),
+        empty_response
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending transactions"
     );
     assert!(
-        empty_response.get("queued").is_none(),
+        empty_response
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued transactions"
     );
 
@@ -287,11 +337,21 @@ async fn txpool_inspect(mut network: Network) {
         .expect("Failed to call txpool_inspect API");
 
     assert!(
-        final_response.get("pending").is_none(),
+        final_response
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending transactions after mining"
     );
     assert!(
-        final_response.get("queued").is_none(),
+        final_response
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued transactions after mining"
     );
 }
@@ -382,11 +442,21 @@ async fn txpool_inspect_with_queued(mut network: Network) {
         .expect("Failed to call txpool_inspect API");
 
     assert!(
-        final_inspect.get("pending").is_none(),
+        final_inspect
+            .get("pending")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty pending transactions after mining"
     );
     assert!(
-        final_inspect.get("queued").is_none(),
+        final_inspect
+            .get("queued")
+            .unwrap()
+            .as_object()
+            .unwrap()
+            .is_empty(),
         "Expected empty queued transactions after mining"
     );
 }


### PR DESCRIPTION
If pending or queued are fully empty they're ignored too