### PR TITLE
feat: DEVOPS-2047 extending the blocks for gcs checkpoint failure condition

### DIFF
--- a/infra/ansible/playbooks/templates/healthcheck.py.j2
+++ b/infra/ansible/playbooks/templates/healthcheck.py.j2
@@ -220,7 +220,8 @@ def check_checkpoint_status():
             }), 500
         
         # Calculate the next checkpoint block
-        next_checkpoint_block = latest_checkpoint_block["upload"] + 86400
+        processing_blocks_difference = latest_checkpoint_block["upload"] - latest_checkpoint_block["production"]
+        next_checkpoint_block = latest_checkpoint_block["upload"] + 86400 + processing_blocks_difference
         
         # Check if current block is higher than the expected next checkpoint block
         if current_block > next_checkpoint_block:


### PR DESCRIPTION
Currently the condition to calculate the next checkpoint is it not considering that the time from the production to the upload can also increase. For that reason we have some micro alerts.

<img width="1893" height="786" alt="image" src="https://github.com/user-attachments/assets/ae85d0ca-0dab-4883-b4b8-289be4f59dc6" />

One solution is to extend the treshhold, but since we don't want to use a fixed number, we can just re-add the difference that took from produce to upload the checkpoint (for mainnet is 700 blocks, which will remove the alert).