### PR TITLE
Return stack trace when API calls panic

### DIFF
--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -113,9 +113,63 @@ macro_rules! declare_module {
 
                     let start = std::time::SystemTime::now();
 
+                    // Thread-local storage for panic info
+                    thread_local! {
+                        static PANIC_INFO: std::cell::RefCell<Option<(String, String)>> = std::cell::RefCell::new(None);
+                    }
+
+                    // Store the original panic hook
+                    let original_hook = std::panic::take_hook();
+
+                    // Set our custom panic hook to capture backtrace
+                    std::panic::set_hook(Box::new(|panic_info| {
+                        let backtrace = std::backtrace::Backtrace::force_capture();
+                        let panic_msg = if let Some(s) = panic_info.payload().downcast_ref::<&str>() {
+                            s.to_string()
+                        } else if let Some(s) = panic_info.payload().downcast_ref::<String>() {
+                            s.clone()
+                        } else {
+                            "Unknown panic".to_string()
+                        };
+
+                        let location = if let Some(location) = panic_info.location() {
+                            format!(" at {}:{}:{}", location.file(), location.line(), location.column())
+                        } else {
+                            String::new()
+                        };
+
+                        let full_panic_msg = format!("{}{}", panic_msg, location);
+
+                        PANIC_INFO.with(|info| {
+                            *info.borrow_mut() = Some((full_panic_msg, format!("{}", backtrace)));
+                        });
+                    }));
+
                     #[allow(clippy::redundant_closure_call)]
-                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $method(params, context))).unwrap_or_else(|cause| {
-                        Err(anyhow::anyhow!("Unhandled panic in RPC handler {} : {:?}", $name, cause))
+                    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| $method(params, context)));
+
+                    // Restore the original panic hook
+                    std::panic::set_hook(original_hook);
+
+                    let result = result.unwrap_or_else(|_cause| {
+                        // Get the panic info we captured
+                        let (panic_msg, backtrace) = PANIC_INFO.with(|info| {
+                            info.borrow_mut().take().unwrap_or_else(|| {
+                                ("Unknown panic (no info captured)".to_string(), "No backtrace available".to_string())
+                            })
+                        });
+
+                        let error_msg = format!(
+                            "Unhandled panic in RPC handler {}: {}\n\nBacktrace:\n{}",
+                            $name,
+                            panic_msg,
+                            backtrace
+                        );
+
+                        // Log the panic as an error with full details
+                        tracing::error!("PANIC in RPC handler {}: {}\nBacktrace:\n{}", $name, panic_msg, backtrace);
+
+                        Err(anyhow::anyhow!(error_msg))
                     });
 
                     let result = result.map_err(|e| {


### PR DESCRIPTION
This should make it easier to debug panics that happen during API calls in future.
Also logs the stack trace