### PR TITLE
Added gas_used and cumulative_gas_used fields and deprecated cumulati…

### DIFF
--- a/docs/api/zilliqa/getsoftconfirmedtransaction.doc.md
+++ b/docs/api/zilliqa/getsoftconfirmedtransaction.doc.md
@@ -36,8 +36,8 @@ curl -d '{
     "gasPrice": "1000000000",
     "nonce": "1",
     "receipt": {
-      "cumulative_gas": "150",
-      "cumulative_gas_used": "50",
+      "cumulative_gas": "50",
+      "cumulative_gas_used": "150",
       "gas_used": "50",
       "epoch_num": "589763",
       "success": true

--- a/docs/api/zilliqa/getsoftconfirmedtransaction.doc.md
+++ b/docs/api/zilliqa/getsoftconfirmedtransaction.doc.md
@@ -10,6 +10,8 @@ transaction,soft,get,confirmed
 
 Returns the details of a specified Transaction.
 
+The `cumulative_gas` field is deprecated.
+
 # Curl
 
 ```shell
@@ -35,6 +37,8 @@ curl -d '{
     "nonce": "1",
     "receipt": {
       "cumulative_gas": "1",
+      "cumulative_gas_used": "1",
+      "gas_used": "1",
       "epoch_num": "589763",
       "success": true
     },

--- a/docs/api/zilliqa/getsoftconfirmedtransaction.doc.md
+++ b/docs/api/zilliqa/getsoftconfirmedtransaction.doc.md
@@ -36,9 +36,9 @@ curl -d '{
     "gasPrice": "1000000000",
     "nonce": "1",
     "receipt": {
-      "cumulative_gas": "1",
-      "cumulative_gas_used": "1",
-      "gas_used": "1",
+      "cumulative_gas": "150",
+      "cumulative_gas_used": "50",
+      "gas_used": "50",
       "epoch_num": "589763",
       "success": true
     },

--- a/docs/api/zilliqa/gettransaction.doc.md
+++ b/docs/api/zilliqa/gettransaction.doc.md
@@ -100,7 +100,7 @@ func GetTransaction() {
 # Response
 
 ```json
-// Note: If the transaction is a for payment.
+// Note: If the transaction is a payment preceeded by two other payments in the block.
 {
   "id": "1",
   "jsonrpc": "2.0",
@@ -111,9 +111,9 @@ func GetTransaction() {
     "gasPrice": "1000000000",
     "nonce": "1",
     "receipt": {
-      "cumulative_gas": "1",
-      "cumulative_gas_used": "1",
-      "gas_used": "1",
+      "cumulative_gas": "50",
+      "cumulative_gas_used": "150",
+      "gas_used": "50",
       "epoch_num": "589763",
       "success": true
     },

--- a/docs/api/zilliqa/gettransaction.doc.md
+++ b/docs/api/zilliqa/gettransaction.doc.md
@@ -23,7 +23,9 @@ Querying for non-existent transactions or transactions that have not yet been mi
 | `amount` | Number as string | The value of the transaction. This amount is always returned in units of Qa (10^-12 ZILs). For Zilliqa transactions, this means we return the exact amount that was passed into `CreateTransaction`. For Ethereum transactions, the true amount is truncated from 18 digits to 12.
 | `signature` | Hex string with `0x` | The transaction signature. Zilliqa signatures are 64 bytes, consisting of `r` followed by `s`. Ethereum signatures are 65 bytes, consisting of `r`, followed by `s`, followed by the `v` value in 'Electrum' notation. Intershard transactions have no signature, so contain an empty string here.
 | `receipt.accepted` | Optional boolean | If the transaction was a Zilliqa transaction and was a call to a Scilla contract, whether the called contract accepted the ZIL sent to it. |
-| `receipt.cumulative_gas` | Number as string | The gas used by this transactions and all transactions in the same block that preceded it. This amount is always returned in units of Scilla gas. Internally, gas is tracked in units of EVM gas. When the true amount is not an exact multiple of the EVM to Scilla gas exchange rate, this value will be rounded. |
+| `receipt.cumulative_gas_used` | Number as string | The gas used by this transactions and all transactions in the same block that preceded it. This amount is always returned in units of Scilla gas. Internally, gas is tracked in units of EVM gas. When the true amount is not an exact multiple of the EVM to Scilla gas exchange rate, this value will be rounded. |
+| `receipt.gas_used` | Number as string | The gas used by this transaction. This amount is always returned in units of Scilla gas. Internally, gas is tracked in units of EVM gas. When the true amount is not an exact multiple of the EVM to Scilla gas exchange rate, this value will be rounded. |
+| `receipt.cumulative_gas` | Number as string | Deprecated. The gas used by this transaction only, for backwards compatibility. This amount is always returned in units of Scilla gas. Internally, gas is tracked in units of EVM gas. When the true amount is not an exact multiple of the EVM to Scilla gas exchange rate, this value will be rounded. |
 | `receipt.epoch_num` | Number as string | The number of the block in which this transaction was mined. |
 | `receipt.event_logs` | Optional array | If the transaction was a Zilliqa transaction, the logs from any Scilla contracts that were executed. EVM logs are not included. |
 | `receipt.errors` | Optional map | If the transaction was a Zilliqa transaction, a map of error codes produced by Scilla contracts, indexed by their call depth. |
@@ -110,6 +112,8 @@ func GetTransaction() {
     "nonce": "1",
     "receipt": {
       "cumulative_gas": "1",
+      "cumulative_gas_used": "1",
+      "gas_used": "1",
       "epoch_num": "589763",
       "success": true
     },
@@ -136,6 +140,8 @@ func GetTransaction() {
     "nonce": "9",
     "receipt": {
       "cumulative_gas": "10481",
+      "cumulative_gas_used": "10481",
+      "gas_used": "10481",
       "epoch_num": "586524",
       "success": true
     },
@@ -162,6 +168,8 @@ func GetTransaction() {
     "receipt": {
       "accepted": true,
       "cumulative_gas": "878",
+      "cumulative_gas_used": "878",
+      "gas_used": "878",
       "epoch_num": "589742",
       "success": true,
       "transitions": [
@@ -199,6 +207,8 @@ func GetTransaction() {
     "nonce": "8260",
     "receipt": {
       "cumulative_gas": "1220",
+      "cumulative_gas_used": "1220",
+      "gas_used": "1220",
       "epoch_num": "588004",
       "errors": {
         "0": [7]

--- a/docs/api/zilliqa/gettxnbodiesfortxblock.doc.md
+++ b/docs/api/zilliqa/gettxnbodiesfortxblock.doc.md
@@ -76,9 +76,9 @@ func GetTxnBodiesForTxBlock() {
       "gasPrice": "1000000000",
       "nonce": "1",
       "receipt": {
-        "cumulative_gas": "1",
-        "cumulative_gas_used": "1",
-        "gas_used": "1",
+        "cumulative_gas": "50",
+        "cumulative_gas_used": "50",
+        "gas_used": "50",
         "epoch_num": "2",
         "success": true
       },
@@ -94,9 +94,9 @@ func GetTxnBodiesForTxBlock() {
       "gasPrice": "1000000000",
       "nonce": "2",
       "receipt": {
-        "cumulative_gas": "1",
-        "cumulative_gas_used": "1",
-        "gas_used": "1",
+        "cumulative_gas": "50",
+        "cumulative_gas_used": "100",
+        "gas_used": "50",
         "epoch_num": "2",
         "success": true
       },

--- a/docs/api/zilliqa/gettxnbodiesfortxblock.doc.md
+++ b/docs/api/zilliqa/gettxnbodiesfortxblock.doc.md
@@ -10,6 +10,8 @@ txn,get,bodies,tx,block,transaction
 
 Returns the validated transactions (in verbose form) included within a specified final transaction block.
 
+The `cumulative_gas` field is deprecated.
+
 # Curl
 
 ```shell
@@ -75,6 +77,8 @@ func GetTxnBodiesForTxBlock() {
       "nonce": "1",
       "receipt": {
         "cumulative_gas": "1",
+        "cumulative_gas_used": "1",
+        "gas_used": "1",
         "epoch_num": "2",
         "success": true
       },
@@ -91,6 +95,8 @@ func GetTxnBodiesForTxBlock() {
       "nonce": "2",
       "receipt": {
         "cumulative_gas": "1",
+        "cumulative_gas_used": "1",
+        "gas_used": "1",
         "epoch_num": "2",
         "success": true
       },
@@ -111,4 +117,3 @@ func GetTxnBodiesForTxBlock() {
 | `jsonrpc` | string | Required | `"2.0"`                                            |
 | `method`  | string | Required | `"GetTxnBodiesForTxBlock"`                         |
 | `params`  | string | Required | Specifed TX block number to return. Example: `"2"` |
-

--- a/docs/api/zilliqa/gettxnbodiesfortxblockex.doc.md
+++ b/docs/api/zilliqa/gettxnbodiesfortxblockex.doc.md
@@ -19,6 +19,8 @@ number.
 For example, to retrieve all the transactions for a block with `NumPages=3`, one
 must call `GetTxBodiesForTxBlockEx` three times with page number 0, 1, and 2.
 
+The `cumulative_gas` field is deprecated.
+
 ## Block Parameters
 
 | Parameter      | Type   | Required | Description                                              |
@@ -55,6 +57,8 @@ curl -d '{
         "nonce": "96538",
         "receipt": {
           "cumulative_gas": "1",
+          "cumulative_gas_used": "1",
+          "gas_used": "1",
           "epoch_num": "1002353",
           "success": true
         },
@@ -71,6 +75,8 @@ curl -d '{
         "nonce": "98068",
         "receipt": {
           "cumulative_gas": "1",
+          "cumulative_gas_used": "1",
+          "gas_used": "1",
           "epoch_num": "1002353",
           "success": true
         },
@@ -92,4 +98,3 @@ curl -d '{
 | `jsonrpc` | string | Required | `"2.0"`                      |
 | `method`  | string | Required | `"GetTxnBodiesForTxBlockEx"` |
 | `params`  | array  | Required | Block parameters             |
-

--- a/docs/api/zilliqa/gettxnbodiesfortxblockex.doc.md
+++ b/docs/api/zilliqa/gettxnbodiesfortxblockex.doc.md
@@ -56,9 +56,9 @@ curl -d '{
         "gasPrice": "2000000000",
         "nonce": "96538",
         "receipt": {
-          "cumulative_gas": "1",
-          "cumulative_gas_used": "1",
-          "gas_used": "1",
+          "cumulative_gas": "50",
+          "cumulative_gas_used": "50",
+          "gas_used": "50",
           "epoch_num": "1002353",
           "success": true
         },
@@ -74,9 +74,9 @@ curl -d '{
         "gasPrice": "2000000000",
         "nonce": "98068",
         "receipt": {
-          "cumulative_gas": "1",
-          "cumulative_gas_used": "1",
-          "gas_used": "1",
+          "cumulative_gas": "50",
+          "cumulative_gas_used": "150",
+          "gas_used": "50",
           "epoch_num": "1002353",
           "success": true
         },

--- a/zilliqa/src/api/types/zil.rs
+++ b/zilliqa/src/api/types/zil.rs
@@ -248,7 +248,11 @@ pub struct EventLog {
 pub struct GetTxResponseReceipt {
     pub accepted: bool,
     #[serde(with = "num_as_str")]
-    pub cumulative_gas: ScillaGas,
+    pub gas_used: ScillaGas,
+    #[serde(with = "num_as_str")]
+    pub cumulative_gas_used: ScillaGas,
+    #[serde(with = "num_as_str")]
+    pub cumulative_gas: ScillaGas, // deprecated
     #[serde(with = "num_as_str")]
     pub epoch_num: u64,
     pub transitions: Vec<Transition>,
@@ -331,7 +335,9 @@ impl GetTxResponse {
             amount,
             signature,
             receipt: GetTxResponseReceipt {
-                cumulative_gas: receipt.cumulative_gas_used.into(),
+                gas_used: receipt.gas_used.into(),
+                cumulative_gas_used: receipt.cumulative_gas_used.into(),
+                cumulative_gas: receipt.gas_used.into(), // for historic reasons, deprecated field
                 epoch_num: block_number,
                 transitions: receipt
                     .transitions


### PR DESCRIPTION
…ve_gas

cumulative_gas field was returning the cumulative gas, but clients were expecting to see the gas_used for historic reasons so we added explicit fields for the correct values, and will remove the old ambiguous field in next release but for now cumulative_gas is adjusted to equal gas_used

Zil receipts:
- added gas_used field
- added cumulative_gas_used field
- adjusted old cumulative_gas field to equal gas_used
- marked deprecated cumulative_gas field
- updated docs