### PR TITLE
fix ZQ1 faux txn-hash issue.

### DIFF
--- a/z2/src/converter.rs
+++ b/z2/src/converter.rs
@@ -569,7 +569,7 @@ pub async fn convert_persistence(
                 if let Err(err) = zq2_db.insert_transaction_with_db_tx(
                     sqlite_tx,
                     hash,
-                    &transaction.clone().verify_bypass()?,
+                    &transaction.clone().verify_bypass(*hash)?,
                 ) {
                     warn!(
                         "Unable to insert transaction with id: {:?} to db, err: {:?}",

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -1458,7 +1458,7 @@ impl Sync {
                             // FIXME: ZQ1 bypass
                             error!(number = %block.number(), index = %rt.index, hash = %rt.tx_hash, "sync::StoreProposals : unverifiable");
                             self.db
-                                .insert_transaction_with_db_tx(sqlite_tx, &rt.tx_hash, &st.verify_bypass()?)?;
+                                .insert_transaction_with_db_tx(sqlite_tx, &rt.tx_hash, &st.verify_bypass(rt.tx_hash)?)?;
                         } else {
                             anyhow::bail!(
                                 "sync::StoreProposal : unverifiable transaction {}/{}/{}",

--- a/zilliqa/src/transaction.rs
+++ b/zilliqa/src/transaction.rs
@@ -400,14 +400,14 @@ impl SignedTransaction {
     }
 
     pub fn verify(self) -> Result<VerifiedTransaction> {
-        self.verify_inner(false)
+        self.verify_inner(false, Hash::ZERO)
     }
 
-    pub fn verify_bypass(self) -> Result<VerifiedTransaction> {
-        self.verify_inner(true)
+    pub fn verify_bypass(self, hash: Hash) -> Result<VerifiedTransaction> {
+        self.verify_inner(true, hash)
     }
 
-    fn verify_inner(self, force: bool) -> Result<VerifiedTransaction> {
+    fn verify_inner(self, force: bool, hash: Hash) -> Result<VerifiedTransaction> {
         let (tx, signer, hash) = match self {
             SignedTransaction::Legacy { tx, sig } => {
                 let signed = tx.into_signed(sig);
@@ -440,7 +440,7 @@ impl SignedTransaction {
                 let signer = Address::new(bytes.into());
 
                 let tx = SignedTransaction::Zilliqa { tx, key, sig };
-                let hash = tx.calculate_hash();
+                let hash = if !force { tx.calculate_hash() } else { hash };
                 (tx, signer, hash)
             }
             SignedTransaction::Intershard { tx, from } => {


### PR DESCRIPTION
Reproduced and tested by deploying this *fix* to the `api*` nodes. Since then, only panics are from non-api nodes.
https://cloudlogging.app.goo.gl/cevwTMeZFJECgpyG9