### PR TITLE
feat: DEVOPS-2184 memory limit for ethereum-metrics-exporter

### DIFF
--- a/infra/ansible/playbooks/templates/ethereum_metrics_exporter.sh.j2
+++ b/infra/ansible/playbooks/templates/ethereum_metrics_exporter.sh.j2
@@ -33,6 +33,7 @@ EOL
         --log-driver json-file --log-opt max-size=1g --log-opt max-file=1 \
         --net=host \
         --cpus=".5" \
+        --memory=512m \
         -v $(pwd)/config.yaml:/config.yaml \
         --restart=unless-stopped --pull=always \
         ${ETHEREUM_METRICS_EXPORTER_IMAGE} --config=/config.yaml


### PR DESCRIPTION
Constant memory usage is:
namedprocess_namegroup_memory_bytes(virtual) -> 1.19GiB 
namedprocess_namegroup_memory_bytes(resident) -> 44.5 MiB

Docker Memory Limit Should Be Based on RSS
Setting it to a limit of 512m, to avoid affecting other services, and keeping it high, because the current usage of the instance is 15% approx. In case of OOM, the container will restart and will go back to the expected constant usage.