### PR TITLE
Fix for invalid block hash errors during sync

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -1666,7 +1666,7 @@ mod tests {
             "SELECT block_hash, view, height, qc, signature, state_root_hash, transactions_root_hash, receipts_root_hash, timestamp, gas_used, gas_limit, agg FROM blocks WHERE is_canonical = true AND height = (SELECT MAX(height) FROM blocks WHERE is_canonical = TRUE)",
             "SELECT block_hash, view, height, qc, signature, state_root_hash, transactions_root_hash, receipts_root_hash, timestamp, gas_used, gas_limit, agg FROM blocks WHERE height = (SELECT MAX(height) FROM blocks) LIMIT 1",
             // "SELECT block_hash, blocks.view, height, qc, signature, state_root_hash, transactions_root_hash, receipts_root_hash, timestamp, gas_used, gas_limit, agg FROM blocks INNER JOIN tip_info ON blocks.view = tip_info.finalized_view", // tip_info is one record so scanning is fine
-            "SELECT data FROM transactions INNER JOIN receipts ON transactions.tx_hash = receipts.tx_hash WHERE receipts.block_hash = ?1",
+            "SELECT data, transactions.tx_hash FROM transactions INNER JOIN receipts ON transactions.tx_hash = receipts.tx_hash WHERE receipts.block_hash = ?1 ORDER BY receipts.tx_index ASC",
             // TODO: Add more queries
         ];
 

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -1258,7 +1258,7 @@ impl Db {
             .lock()
             .unwrap()
             .prepare_cached(
-                "SELECT data, transactions.tx_hash FROM transactions INNER JOIN receipts ON transactions.tx_hash = receipts.tx_hash WHERE receipts.block_hash = ?1",
+                "SELECT data, transactions.tx_hash FROM transactions INNER JOIN receipts ON transactions.tx_hash = receipts.tx_hash WHERE receipts.block_hash = ?1 ORDER BY receipts.tx_index ASC",
             )?
             .query_map([block.header.hash], |row| {
                 let txn: SignedTransaction = row.get(0)?;


### PR DESCRIPTION
The symptom was that syncing got stuck due to failures in verifying the block hash:
```
2025-07-31T05:23:58.429227Z  INFO zilliqa::sync: 794: sync::MultiBlockResponse : received range=484846..=484906 from=12D3KooWFPfLCWc3dTMM4FFBFKQGACjPEKG5juyQW9CzJdUQ7v8e
2025-07-31T05:23:58.430149Z  INFO zilliqa::consensus: 724: handling block proposal 9e1f472ec87c66684a3c25c30d0ea1db8ad32ed997bc1657950426cb9c3a5bab block_view=484865 block_number=484846 txns=148
2025-07-31T05:23:58.430234Z  WARN zilliqa::consensus: 759: invalid block proposal received! e=invalid hash 6c67581aca1076a953447d64972654f2de3ecd4787c869fe625fe15c7dd28276 != 9e1f472ec87c66684a3c25c30d0ea1db8ad32ed997bc1657950426cb9c3a5bab
2025-07-31T05:23:58.430341Z  INFO zilliqa::sync: 949: sync::MissingBlocks : requesting range=484907..=485006 from=12D3KooWCGuxFz1hszafDJ2Jn39iRfSqL7Rqtj5Mwjt6kwD7kx1f
```

The problem:
```sql
sqlite> SELECT hex(tx_hash) from receipts where block_hash=x'7b5d79394d1ad5f14d9bac292c5e1569e268e89aeb6620c8bc0779f98841db47' ORDER BY tx_index ASC;
5E07263FC9100351D138F671D82F81A792D4D84B2F9A016785692835F8CBBF33
C36055AF97F12633CEFDD091BE523E969F95450A8097B31A6C6BFD7077F0BFFF
205591934EA18D13FF9ECD6B83D91272A4EA5D69CB26DE42A9A3E4FBE93D00C8
22CCD5CB2E24BD0B816429982389529EF1201987E2C45B9A6D30FD167CF7F4EC
6F207461CFA0D22A55600E78C87FBE40BB4A294F9CF4A8AA84C6BAEF4DE9AB0C
5E7E748FF5E59E1CDA45E9854000A4CF49F5985338D92177D4955138B782BAF7
44EB0765196DAB0F8B3A08B7E8134E5BE82718FDEA50C70E83FF15791352DE73
6B077EBC91DC3B0B75986018442E8710AF0D044E380D7DAFC0DE412470FBAD8C
60F538C4EC6E8A132393A5BF7B81C7D31AF422E8BDE898CE92D8AF7CCB3C2F74
F95D02990995E61356CC090A25649B61F56127DA8F956688BBD6738DB10236BB
46BBC61D4852854029897C6B8A7CF18876499FFA30031D2A32B6F12BB693FFD7
FCB0CCC7094BDDEBC15D8E96C57AF9A5DA5FE81E0CCDE312216C9644BE19F658
B7312F87F3A478582193476E2BDCE17B4B22DF5B18500997FFAE2382B346E7A6
C5E329AD0C2922BA65CD721EA5BE13BA6A823E98FBE0BD736540FF412A2C71AD
8C5B887C5E83B447F6CDF9D89723173FDD3515FEED6FB2CFB9338004BBBE3B8E
FD08CC3975E95EF3D91C4889E27C2EA59EB01C3F549CD3FBA254A9645AB66FD4
E8D6CD780A203DB145635F7229C28708B5134C0CA4A49CEF9CEFFD64DAC7224A
95A13BFE80FE25E303338C39FE36A47EF491F21D411181FA2EE179FA116294EF
ADDE4E0A6ECE4C877EA0C1B0F5D2A024C92B040C3BF7777921B4E9D7CEB49575
9109498DA2C814913D5B669CB06E1EBC2B1EC76642865AA10DDD4CCE42C7B760
FEB680BA1B50784EE0B8F0F906C232E7FE5324A29D8836D9EF727E29E19BB084
F800786C54B1AE62F81904F62D563BF4CBB2B30983F1BB1F12A9AFB0F4C203A5
```
vs
```sql
sqlite> SELECT hex(transactions.tx_hash) from transactions INNER JOIN receipts ON transactions.tx_hash = receipts.tx_hash WHERE receipts.block_hash = x'7b5d79394d1ad5f14d9bac292c5e1569e268e89aeb6620c8bc0779f98841db47';
205591934EA18D13FF9ECD6B83D91272A4EA5D69CB26DE42A9A3E4FBE93D00C8
22CCD5CB2E24BD0B816429982389529EF1201987E2C45B9A6D30FD167CF7F4EC
44EB0765196DAB0F8B3A08B7E8134E5BE82718FDEA50C70E83FF15791352DE73
46BBC61D4852854029897C6B8A7CF18876499FFA30031D2A32B6F12BB693FFD7
5E07263FC9100351D138F671D82F81A792D4D84B2F9A016785692835F8CBBF33
5E7E748FF5E59E1CDA45E9854000A4CF49F5985338D92177D4955138B782BAF7
60F538C4EC6E8A132393A5BF7B81C7D31AF422E8BDE898CE92D8AF7CCB3C2F74
6B077EBC91DC3B0B75986018442E8710AF0D044E380D7DAFC0DE412470FBAD8C
6F207461CFA0D22A55600E78C87FBE40BB4A294F9CF4A8AA84C6BAEF4DE9AB0C
8C5B887C5E83B447F6CDF9D89723173FDD3515FEED6FB2CFB9338004BBBE3B8E
9109498DA2C814913D5B669CB06E1EBC2B1EC76642865AA10DDD4CCE42C7B760
95A13BFE80FE25E303338C39FE36A47EF491F21D411181FA2EE179FA116294EF
ADDE4E0A6ECE4C877EA0C1B0F5D2A024C92B040C3BF7777921B4E9D7CEB49575
B7312F87F3A478582193476E2BDCE17B4B22DF5B18500997FFAE2382B346E7A6
C36055AF97F12633CEFDD091BE523E969F95450A8097B31A6C6BFD7077F0BFFF
C5E329AD0C2922BA65CD721EA5BE13BA6A823E98FBE0BD736540FF412A2C71AD
E8D6CD780A203DB145635F7229C28708B5134C0CA4A49CEF9CEFFD64DAC7224A
F800786C54B1AE62F81904F62D563BF4CBB2B30983F1BB1F12A9AFB0F4C203A5
F95D02990995E61356CC090A25649B61F56127DA8F956688BBD6738DB10236BB
FCB0CCC7094BDDEBC15D8E96C57AF9A5DA5FE81E0CCDE312216C9644BE19F658
FD08CC3975E95EF3D91C4889E27C2EA59EB01C3F549CD3FBA254A9645AB66FD4
FEB680BA1B50784EE0B8F0F906C232E7FE5324A29D8836D9EF727E29E19BB084
```

And when sync tries to convert the data into a Proposal to be transmitted, it does it in database order, not receipt order.
```rust
    fn brt_to_proposal(&self, brt: crate::db::BlockAndReceiptsAndTransactions) -> Proposal {
        let block = brt.block;
        // since block must be valid, unwrap(s) are safe
        let txs = brt
            .transactions
            .into_iter()
            // handle verification on the client-side
            .map(|tx| (tx.tx, tx.hash))
            .collect_vec();
        Proposal::from_parts_with_hashes(block, txs)
    }
```

The problem was successfully replicated in `devnet` and the fix confirmed in `devnet` as well.