### PR TITLE
Bypass txn validation during sync recovery

### DIFF
--- a/zq2-devnet.yaml
+++ b/zq2-devnet.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.17.1
+  zq2: v0.17.2

--- a/zq2-infratest.yaml
+++ b/zq2-infratest.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.17.1
+  zq2: v0.17.2

--- a/zq2-mainnet.yaml
+++ b/zq2-mainnet.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.17.1
+  zq2: v0.17.2

--- a/zq2-testnet.yaml
+++ b/zq2-testnet.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.17.1
+  zq2: v0.17.2


### PR DESCRIPTION
There seems to be a toctou-like issue in some instances introduced by #3070.
This PR bypasses the failing check during sync, as it no longer makes sense to check that since the transaction has already been executed in other nodes prior.