### PR TITLE
Convert unnecessary write() locks to read() locks

### DIFF
--- a/zilliqa/src/api/txpool.rs
+++ b/zilliqa/src/api/txpool.rs
@@ -149,7 +149,7 @@ fn txpool_inspect(
 
 /// txpool_status
 fn txpool_status(_params: Params, node: &Arc<RwLock<Node>>) -> Result<types::txpool::TxPoolStatus> {
-    let mut node = node.write();
+    let node = node.read();
     let content = node.txpool_status();
 
     Ok(types::txpool::TxPoolStatus {

--- a/zilliqa/src/api/txpool.rs
+++ b/zilliqa/src/api/txpool.rs
@@ -29,7 +29,7 @@ fn txpool_content(
     _params: Params,
     node: &Arc<RwLock<Node>>,
 ) -> Result<Option<types::txpool::TxPoolContent>> {
-    let mut node = node.read();
+    let node = node.read();
     let content = node.txpool_content();
 
     let pending: HashMap<Address, HashMap<u64, Transaction>> = content
@@ -74,7 +74,7 @@ fn txpool_content_from(
 ) -> Result<types::txpool::TxPoolContent> {
     let address: super::zilliqa::ZilAddress = params.one()?;
     let address: Address = address.into();
-    let mut node = node.read();
+    let node = node.read();
     let content = node.txpool_content_from(&address);
 
     let mut result = types::txpool::TxPoolContent {
@@ -110,7 +110,7 @@ fn txpool_inspect(
     _params: Params,
     node: &Arc<RwLock<Node>>,
 ) -> Result<types::txpool::TxPoolInspect> {
-    let mut node = node.write();
+    let node = node.read();
     let content = node.txpool_content();
 
     let mut result = types::txpool::TxPoolInspect {

--- a/zilliqa/src/api/txpool.rs
+++ b/zilliqa/src/api/txpool.rs
@@ -74,7 +74,7 @@ fn txpool_content_from(
 ) -> Result<types::txpool::TxPoolContent> {
     let address: super::zilliqa::ZilAddress = params.one()?;
     let address: Address = address.into();
-    let mut node = node.write();
+    let mut node = node.read();
     let content = node.txpool_content_from(&address);
 
     let mut result = types::txpool::TxPoolContent {

--- a/zilliqa/src/api/txpool.rs
+++ b/zilliqa/src/api/txpool.rs
@@ -29,7 +29,7 @@ fn txpool_content(
     _params: Params,
     node: &Arc<RwLock<Node>>,
 ) -> Result<Option<types::txpool::TxPoolContent>> {
-    let mut node = node.write();
+    let mut node = node.read();
     let content = node.txpool_content();
 
     let pending: HashMap<Address, HashMap<u64, Transaction>> = content

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1075,7 +1075,7 @@ impl Consensus {
         Ok(Some(result))
     }
 
-    pub fn txpool_content(&mut self) -> TxPoolContent {
+    pub fn txpool_content(&self) -> TxPoolContent {
         let pool = self.transaction_pool.read();
         pool.preview_content()
     }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1085,7 +1085,7 @@ impl Consensus {
         pool.preview_content_from(address)
     }
 
-    pub fn txpool_status(&mut self) -> TxPoolStatus {
+    pub fn txpool_status(&self) -> TxPoolStatus {
         let pool = self.transaction_pool.read();
         pool.preview_status()
     }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1080,7 +1080,7 @@ impl Consensus {
         pool.preview_content()
     }
 
-    pub fn txpool_content_from(&mut self, address: &Address) -> TxPoolContentFrom {
+    pub fn txpool_content_from(&self, address: &Address) -> TxPoolContentFrom {
         let pool = self.transaction_pool.read();
         pool.preview_content_from(address)
     }

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1022,7 +1022,7 @@ impl Node {
         self.consensus.txpool_content()
     }
 
-    pub fn txpool_content_from(&mut self, address: &Address) -> crate::pool::TxPoolContentFrom {
+    pub fn txpool_content_from(&self, address: &Address) -> crate::pool::TxPoolContentFrom {
         self.consensus.txpool_content_from(address)
     }
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1018,7 +1018,7 @@ impl Node {
         self.consensus.get_transaction_by_hash(hash)
     }
 
-    pub fn txpool_content(&mut self) -> crate::pool::TxPoolContent {
+    pub fn txpool_content(&self) -> crate::pool::TxPoolContent {
         self.consensus.txpool_content()
     }
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -1026,7 +1026,7 @@ impl Node {
         self.consensus.txpool_content_from(address)
     }
 
-    pub fn txpool_status(&mut self) -> crate::pool::TxPoolStatus {
+    pub fn txpool_status(&self) -> crate::pool::TxPoolStatus {
         self.consensus.txpool_status()
     }
 

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -217,7 +217,7 @@ impl NodeLauncher {
 
                     let start = SystemTime::now();
                     if let ExternalMessage::BatchedTransactions(transactions) = message {
-                        let my_peer_id = self.node.write().consensus.peer_id();
+                        let my_peer_id = self.node.read().consensus.peer_id();
 
                         if source != my_peer_id {
                             let mut verified = Vec::with_capacity(transactions.len());


### PR DESCRIPTION
There were some unnecessary `write()` locks being taken, some that are triggered periodically e.g. `txpool_status()` rpc calls from the stats agent. Turn them all into `read()` locks to minimise any possible blocking, which may slow down RPC calls.