### PR TITLE
Fixing failed eoa transfers via zil api

### DIFF
--- a/z2/resources/chain-specs/zq2-devnet.toml
+++ b/z2/resources/chain-specs/zq2-devnet.toml
@@ -2,49 +2,44 @@ network = "zq2-devnet"
 p2p_port = 3333
 
 bootstrap_address = [
-    "12D3KooWFPfLCWc3dTMM4FFBFKQGACjPEKG5juyQW9CzJdUQ7v8e",
-    "/dns/bootstrap.zq2-devnet.zilliqa.com/tcp/3333",
+  "12D3KooWFPfLCWc3dTMM4FFBFKQGACjPEKG5juyQW9CzJdUQ7v8e",
+  "/dns/bootstrap.zq2-devnet.zilliqa.com/tcp/3333"
 ]
 
 [[nodes]]
 eth_chain_id = 33469
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [
-    [
-        "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d",
-        "900_000_000_000_000_000_000_000_000",
-    ],
-]
+consensus.genesis_accounts = [ ["0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d", "900_000_000_000_000_000_000_000_000" ] ]
 consensus.genesis_deposits = [
-    [
-        "97cb791639a2a441fb62c2dbecc7349f9f6cbba1add3ebd43467aefc21492cfe425f1194ee6ce92cd5ed425f4c400875",
-        "12D3KooW9smiqhQLyy1dxVetgPps6JekzPxfaUyBFC4UrC3s66Hu",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d",
-    ],
-    [
-        "adbfec62c8bbf2536f0ac6edcd4b6753c9f90c4345761b0ac48f1420b79f59ae78c94ccd0c0b03d12e131c1033e18367",
-        "12D3KooWNsGCpys1vkat5snimm1r8UmndRPd8bzR12xp4WzBAX1U",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d",
-    ],
-    [
-        "8c3dc1e5ba40ed321d5e9a852b5bf39dbc6de318afd52e8913616cd7e675775afca6456d1b27b31fa6b49b3fcd43416e",
-        "12D3KooWSqaCxuoRU3dVjDBHQg6MGkD53S8UyiCWUg6HCgy8mcx5",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d",
-    ],
-    [
-        "805bf04b8b442f19ae5a20e09b9ada17fcf9a3d2329b3a6b214dfbda17d071ff056e30491267261e27651e2f95ca1e97",
-        "12D3KooWMiwhBUgxUwDmD8Pms4VC2MA2QFbch4vLqffwWDVFNYij",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d",
-    ],
+  [
+    "97cb791639a2a441fb62c2dbecc7349f9f6cbba1add3ebd43467aefc21492cfe425f1194ee6ce92cd5ed425f4c400875",
+    "12D3KooW9smiqhQLyy1dxVetgPps6JekzPxfaUyBFC4UrC3s66Hu",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d"
+  ],
+  [
+    "adbfec62c8bbf2536f0ac6edcd4b6753c9f90c4345761b0ac48f1420b79f59ae78c94ccd0c0b03d12e131c1033e18367",
+    "12D3KooWNsGCpys1vkat5snimm1r8UmndRPd8bzR12xp4WzBAX1U",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d"
+  ],
+  [
+    "8c3dc1e5ba40ed321d5e9a852b5bf39dbc6de318afd52e8913616cd7e675775afca6456d1b27b31fa6b49b3fcd43416e",
+    "12D3KooWSqaCxuoRU3dVjDBHQg6MGkD53S8UyiCWUg6HCgy8mcx5",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d"
+  ],
+  [
+    "805bf04b8b442f19ae5a20e09b9ada17fcf9a3d2329b3a6b214dfbda17d071ff056e30491267261e27651e2f95ca1e97",
+    "12D3KooWMiwhBUgxUwDmD8Pms4VC2MA2QFbch4vLqffwWDVFNYij",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xe4e8c170f79c8e155e3680fca3ff34a7f9d4001d"
+  ]
 ]
 
 # Reward parameters
@@ -58,22 +53,4 @@ consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params =
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 sync.ignore_passive = true
 
-api_servers = [
-    { port = 4201, enabled_apis = [
-        { namespace = "eth", apis = [
-            "blockNumber",
-        ] },
-    ] },
-    { port = 4202, enabled_apis = [
-        "admin",
-        "debug",
-        "erigon",
-        "eth",
-        "net",
-        "ots",
-        "trace",
-        "txpool",
-        "web3",
-        "zilliqa",
-    ] },
-]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]

--- a/z2/resources/chain-specs/zq2-mainnet.toml
+++ b/z2/resources/chain-specs/zq2-mainnet.toml
@@ -2,91 +2,86 @@ network = "zq2-mainnet"
 p2p_port = 3333
 
 bootstrap_address = [
-    "12D3KooWLQ9Uu31ZVn2wMwt5HgunwHYRh4V12cLuTa9qqyFKxkqS",
-    "/dns/bootstrap.zq2-mainnet.zilliqa.com/tcp/3333",
+  "12D3KooWLQ9Uu31ZVn2wMwt5HgunwHYRh4V12cLuTa9qqyFKxkqS",
+  "/dns/bootstrap.zq2-mainnet.zilliqa.com/tcp/3333"
 ]
 
 [[nodes]]
 eth_chain_id = 32769
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [
-    [
-        "0xa50581ea4c4cec6b53262ca16b5b003d34c820be",
-        "100_000_000_000_000_000_000",
-    ],
-]
+consensus.genesis_accounts = [ ["0xa50581ea4c4cec6b53262ca16b5b003d34c820be", "100_000_000_000_000_000_000" ] ]
 consensus.genesis_deposits = [
-    [
-        "833c9265b6443f2707e506081e2bc08c55d867c04dca6171f9203876fcf436335464703747b425458ce60b83036bfcba",
-        "12D3KooWNSC7ZnMRYu6f4CMAjfCc5KzUMhyd31UQXDfR2QFPPg9K",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "b8e9d87775aa2ad48f1e263434ff7f13c7c68c1c89c0e0031f791f35a3907ee1014ffc2d7b67fc534022da2fe5152d61",
-        "12D3KooWShbg7H3LSPZZrSYa6JyacX8eLFDiSSPha4gEWq5q1fd7",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "b4f5f2573109d4c33a95df26aed1727e5e388c5d37f446ede0576b98e23d1ea88fcc3cd1b981e45b2c584187a18f8fb6",
-        "12D3KooWLAHDwZMphR4akwzxzbpSWfqvzommPYftNu5cohNbtyUz",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "adcdcc405d4edaf804e6a96b912021ae2e5ef6000ff7cb9ce0012620b6525c80e1b015b18e172bb54cdf213af0ca070d",
-        "12D3KooWAZkrsNMmpje2ToBXAJMERbMg5HGC8aAzvTJwAR3VxQos",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "8afe2d8034b8cfd4282d638715086fb6ede67ac0fe7503e3c996064b645d461a518370ab12f228e5f2be5c3ff170a725",
-        "12D3KooWKY2gxqPsJ11gweKWvYGZd4F2Z1T8dYEaYRc49Bz2JGVN",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "b78794fd6708cec1b7ab0716fe48d9b72e0b89015a0c3d3c86c24310569f9cbff389910cfc147fd7f7d59b0b34cb7025",
-        "12D3KooWNUDP3wtdJXxEubzPtEuWqF142TP9fmJrGrQKRKdvJUvB",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "ae1b41871f821517561cd6430772d75e28e21f971dbe119f31025672ec49c696d7e70fae05af7cc9e0fe0ecbac97acca",
-        "12D3KooWLrZaV4NfuSZCm3f731Yf8AxM8csVTv498ikCTdYm6anc",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "800772dfa8a53fef9f075380a7ab835f2dd07c88a608400e8c02a96d031f69aa4a8f95b6e79a6a8787a86f0cb3409710",
-        "12D3KooWQUq7Y2KsCrMaFGnsNB6tC5f1W1uRXmLjBZYcsJewE5TL",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "afb35a4ca993d53647ade97788913fba1ffa658ab70bac01a661ed1d3fa7721c3979012c9ce5d6995d0726dd8fcc59a6",
-        "12D3KooWNZDZbdxGFEZY4XkP9ymzUVH65bWAxXPMUSta5Y1i6kxb",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
-    [
-        "93c027c2d9b9611affec8f785add787bbc548f2efe5e2c911c45d814e87a2cc5c39463fdda7d2137b8e8280902366a25",
-        "12D3KooWBhH9yj4Qwq4Dm99p6QzWeuUBQBjFD9jhsoF7LoUSezNs",
-        "80_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0xf865745c75E585718c8f115A9317E7Fc8e1195f3",
-    ],
+  [
+    "833c9265b6443f2707e506081e2bc08c55d867c04dca6171f9203876fcf436335464703747b425458ce60b83036bfcba",
+    "12D3KooWNSC7ZnMRYu6f4CMAjfCc5KzUMhyd31UQXDfR2QFPPg9K",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "b8e9d87775aa2ad48f1e263434ff7f13c7c68c1c89c0e0031f791f35a3907ee1014ffc2d7b67fc534022da2fe5152d61",
+    "12D3KooWShbg7H3LSPZZrSYa6JyacX8eLFDiSSPha4gEWq5q1fd7",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "8afe2d8034b8cfd4282d638715086fb6ede67ac0fe7503e3c996064b645d461a518370ab12f228e5f2be5c3ff170a725",
+    "12D3KooWKY2gxqPsJ11gweKWvYGZd4F2Z1T8dYEaYRc49Bz2JGVN",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "b78794fd6708cec1b7ab0716fe48d9b72e0b89015a0c3d3c86c24310569f9cbff389910cfc147fd7f7d59b0b34cb7025",
+    "12D3KooWNUDP3wtdJXxEubzPtEuWqF142TP9fmJrGrQKRKdvJUvB",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "800772dfa8a53fef9f075380a7ab835f2dd07c88a608400e8c02a96d031f69aa4a8f95b6e79a6a8787a86f0cb3409710",
+    "12D3KooWQUq7Y2KsCrMaFGnsNB6tC5f1W1uRXmLjBZYcsJewE5TL",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "afb35a4ca993d53647ade97788913fba1ffa658ab70bac01a661ed1d3fa7721c3979012c9ce5d6995d0726dd8fcc59a6",
+    "12D3KooWNZDZbdxGFEZY4XkP9ymzUVH65bWAxXPMUSta5Y1i6kxb",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "93c027c2d9b9611affec8f785add787bbc548f2efe5e2c911c45d814e87a2cc5c39463fdda7d2137b8e8280902366a25",
+    "12D3KooWBhH9yj4Qwq4Dm99p6QzWeuUBQBjFD9jhsoF7LoUSezNs",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "b4f5f2573109d4c33a95df26aed1727e5e388c5d37f446ede0576b98e23d1ea88fcc3cd1b981e45b2c584187a18f8fb6",
+    "12D3KooWLAHDwZMphR4akwzxzbpSWfqvzommPYftNu5cohNbtyUz",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "adcdcc405d4edaf804e6a96b912021ae2e5ef6000ff7cb9ce0012620b6525c80e1b015b18e172bb54cdf213af0ca070d",
+    "12D3KooWAZkrsNMmpje2ToBXAJMERbMg5HGC8aAzvTJwAR3VxQos",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ],
+  [
+    "ae1b41871f821517561cd6430772d75e28e21f971dbe119f31025672ec49c696d7e70fae05af7cc9e0fe0ecbac97acca",
+    "12D3KooWLrZaV4NfuSZCm3f731Yf8AxM8csVTv498ikCTdYm6anc",
+    "80_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0xf865745c75E585718c8f115A9317E7Fc8e1195f3"
+  ]
 ]
 
 # Reward parameters
@@ -100,55 +95,17 @@ consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params =
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 sync.ignore_passive = true
 
-api_servers = [
-    { port = 4201, enabled_apis = [
-        { namespace = "eth", apis = [
-            "blockNumber",
-        ] },
-    ] },
-    { port = 4202, enabled_apis = [
-        "admin",
-        "debug",
-        "erigon",
-        "eth",
-        "net",
-        "ots",
-        "trace",
-        "txpool",
-        "web3",
-        "zilliqa",
-    ] },
-]
-consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [
-], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [
-], scilla_delta_maps_are_applied_correctly = false, scilla_server_unlimited_response_size = false, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false, evm_exec_failure_causes_scilla_precompile_to_fail = false, revert_restore_xsgd_contract = false, scilla_fix_contract_code_removal_on_evm_tx = false, restore_ignite_wallet_contracts = false, prevent_zil_transfer_from_evm_to_scilla_contract = false, scilla_failed_txn_correct_gas_fee_charged = false, check_minimum_gas_price = false, inject_access_list = false, use_max_gas_priority_fee = false }
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
+consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [], scilla_delta_maps_are_applied_correctly = false, scilla_server_unlimited_response_size = false, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false, evm_exec_failure_causes_scilla_precompile_to_fail = false, revert_restore_xsgd_contract = false, scilla_fix_contract_code_removal_on_evm_tx = false, restore_ignite_wallet_contracts = false, prevent_zil_transfer_from_evm_to_scilla_contract = false, scilla_failed_txn_correct_gas_fee_charged = false, check_minimum_gas_price = false, inject_access_list = false, use_max_gas_priority_fee = false, failed_zil_transfers_to_eoa_proper_fee_deduction = false }
 consensus.forks = [
     { at_height = 4770088, executable_blocks = true },
     { at_height = 4854500, scilla_delta_maps_are_applied_correctly = true },
-    { at_height = 4957200, scilla_call_gas_exempt_addrs = [
-        "0x95347b860Bd49818AFAccCA8403C55C23e7BB9ED",
-        "0xe64cA52EF34FdD7e20C0c7fb2E392cc9b4F6D049",
-        "0x63B991C17010C21250a0eA58C6697F696a48cdf3",
-        "0x241c677D9969419800402521ae87C411897A029f",
-        "0x2274005778063684fbB1BfA96a2b725dC37D75f9",
-        "0x598FbD8B68a8B7e75b8B7182c750164f348907Bc",
-        "0x2938fF251Aecc1dfa768D7d0276eB6d073690317",
-        "0x17D5af5658A24bd964984b36d28e879a8626adC3",
-        "0xCcF3Ea256d42Aeef0EE0e39Bfc94bAa9Fa14b0Ba",
-        "0xc6F3dede529Af9D98a11C5B32DbF03Bf34272ED5",
-        "0x7D2fF48c6b59229d448473D267a714d29F078D3E",
-        "0xE9D47623bb2B3C497668B34fcf61E101a7ea4058",
-        "0x03A79429acc808e4261a68b0117aCD43Cb0FdBfa",
-        "0x097C26F8A93009fd9d98561384b5014D64ae17C2",
-        "0x01035e423c40a9ad4F6be2E6cC014EB5617c8Bd6",
-        "0x9C3fE3f471d8380297e4fB222eFb313Ee94DFa0f",
-        "0x20Dd5D5B5d4C72676514A0eA1052d0200003d69D",
-        "0xbfDe2156aF75a29d36614bC1F8005DD816Bd9200",
-    ] },
+    { at_height = 4957200, scilla_call_gas_exempt_addrs = ["0x95347b860Bd49818AFAccCA8403C55C23e7BB9ED", "0xe64cA52EF34FdD7e20C0c7fb2E392cc9b4F6D049", "0x63B991C17010C21250a0eA58C6697F696a48cdf3", "0x241c677D9969419800402521ae87C411897A029f", "0x2274005778063684fbB1BfA96a2b725dC37D75f9", "0x598FbD8B68a8B7e75b8B7182c750164f348907Bc", "0x2938fF251Aecc1dfa768D7d0276eB6d073690317", "0x17D5af5658A24bd964984b36d28e879a8626adC3", "0xCcF3Ea256d42Aeef0EE0e39Bfc94bAa9Fa14b0Ba", "0xc6F3dede529Af9D98a11C5B32DbF03Bf34272ED5", "0x7D2fF48c6b59229d448473D267a714d29F078D3E", "0xE9D47623bb2B3C497668B34fcf61E101a7ea4058", "0x03A79429acc808e4261a68b0117aCD43Cb0FdBfa", "0x097C26F8A93009fd9d98561384b5014D64ae17C2", "0x01035e423c40a9ad4F6be2E6cC014EB5617c8Bd6", "0x9C3fE3f471d8380297e4fB222eFb313Ee94DFa0f", "0x20Dd5D5B5d4C72676514A0eA1052d0200003d69D", "0xbfDe2156aF75a29d36614bC1F8005DD816Bd9200"] },
     { at_height = 4986000, scilla_server_unlimited_response_size = true },
     { at_height = 5528557, scilla_failed_txn_correct_balance_deduction = true, scilla_transition_proper_order = true, evm_to_scilla_value_transfer_zero = true, restore_xsgd_contract = true },
     { at_height = 5910029, evm_exec_failure_causes_scilla_precompile_to_fail = true, scilla_fix_contract_code_removal_on_evm_tx = true },
     { at_height = 6283082, prevent_zil_transfer_from_evm_to_scilla_contract = true, restore_ignite_wallet_contracts = true },
     { at_height = 6771996, scilla_failed_txn_correct_gas_fee_charged = true, check_minimum_gas_price = true },
     { at_height = 7000000, inject_access_list = true, use_max_gas_priority_fee = true },
+    { at_height = 9583198, failed_zil_transfers_to_eoa_proper_fee_deduction = true },
 ]

--- a/z2/resources/chain-specs/zq2-testnet.toml
+++ b/z2/resources/chain-specs/zq2-testnet.toml
@@ -2,70 +2,65 @@ network = "zq2-testnet"
 p2p_port = 3333
 
 bootstrap_address = [
-    "12D3KooWPFzgn8XUdrvRMuJmSPXRZPBBzv2ZmDmeKM8HGE8gKDJP",
-    "/dns/bootstrap.zq2-testnet.zilliqa.com/tcp/3333",
+  "12D3KooWPFzgn8XUdrvRMuJmSPXRZPBBzv2ZmDmeKM8HGE8gKDJP",
+  "/dns/bootstrap.zq2-testnet.zilliqa.com/tcp/3333"
 ]
 
 [[nodes]]
 eth_chain_id = 33101
 allowed_timestamp_skew = { secs = 60, nanos = 0 }
 data_dir = "/data"
-consensus.genesis_accounts = [
-    [
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-        "900_000_000_000_000_000_000_000_000",
-    ],
-]
+consensus.genesis_accounts = [ ["0x214695413d1ea6a4a4453cd24ffd151fbc95496a", "900_000_000_000_000_000_000_000_000" ] ]
 consensus.genesis_deposits = [
-    [
-        "94ce9650426f5c5b7eeb8499b94bc2cc6b82b423f3bb235889d3120aedc75a1d8236c2912dda45b75a3226731a776cbf",
-        "12D3KooWQPkr3EGzqiVdRcLTBo3sjBA5J2HRbBR6kcxY3QNCDF1M",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
-    [
-        "b2ba01dbc1989399ffca35c1e9c73613bbe678c94740feb035538d7299c4bd8ba98b28292982857534f60289ca2b663c",
-        "12D3KooWRuSPXcoiFHaFkxgfy3P4UnhB5vKtgShkXTWL9xfdVZ1V",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
-    [
-        "ae776c587e6869d41331529c6dd0f59c31d1ef4c47f8b5ecb1acc54fa7452d9b2ba6f56bdad08a606d25761c8522b367",
-        "12D3KooWJyH1r2UfcFPiHbEFBYB3xWufR1va8cRK3veMwfUunfRD",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
-    [
-        "95de7dae002295bba9c4cffd1b0df70a7ccd0cc68e6b10da06b1b91f8a7e9b305e19431fc42b7413c65a8ab6959e41c6",
-        "12D3KooWM5L182sQtJuARf5Xfg517xVqZRaPM9583BsmLcv5Ma2o",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
-    [
-        "ae96338209ec4f1ad446a131e687bde02506207b750465cbc43d1ea4f5b32daa51ff060e8451c903d6de7f1c89951b1d",
-        "12D3KooWQpAM4F19CwJAAhHFgeD7feyQLHDTxzKu2hsVH4BQceSQ",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
-    [
-        "a3a2419fba7962021d730f4e1eb087b5bf0d66140ef7d4ba758348b13fb2ffa9a75afbdbef988c65ce625544360dea42",
-        "12D3KooWAWoMVZAXJDkuhyzyBJHGHn2gYFyTbbdZGhHs4BuEN5Fe",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
-    [
-        "8093ea6fa4720ca0975559a5f9d3a2694c6ab8e63a8c54e986d11a28f9e958f006420e30a8d6f04d6b2df63fe6e0563d",
-        "12D3KooWNqZxaW4ZirvWUNj9KSRgTp55RsZHSFumDeRdCLZAjNNA",
-        "20_000_000_000_000_000_000_000_000",
-        "0x0000000000000000000000000000000000000000",
-        "0x214695413d1ea6a4a4453cd24ffd151fbc95496a",
-    ],
+  [
+    "94ce9650426f5c5b7eeb8499b94bc2cc6b82b423f3bb235889d3120aedc75a1d8236c2912dda45b75a3226731a776cbf",
+    "12D3KooWQPkr3EGzqiVdRcLTBo3sjBA5J2HRbBR6kcxY3QNCDF1M",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ],
+  [
+    "b2ba01dbc1989399ffca35c1e9c73613bbe678c94740feb035538d7299c4bd8ba98b28292982857534f60289ca2b663c",
+    "12D3KooWRuSPXcoiFHaFkxgfy3P4UnhB5vKtgShkXTWL9xfdVZ1V",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ],
+  [
+    "ae776c587e6869d41331529c6dd0f59c31d1ef4c47f8b5ecb1acc54fa7452d9b2ba6f56bdad08a606d25761c8522b367",
+    "12D3KooWJyH1r2UfcFPiHbEFBYB3xWufR1va8cRK3veMwfUunfRD",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ],
+  [
+    "95de7dae002295bba9c4cffd1b0df70a7ccd0cc68e6b10da06b1b91f8a7e9b305e19431fc42b7413c65a8ab6959e41c6",
+    "12D3KooWM5L182sQtJuARf5Xfg517xVqZRaPM9583BsmLcv5Ma2o",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ],
+  [
+    "ae96338209ec4f1ad446a131e687bde02506207b750465cbc43d1ea4f5b32daa51ff060e8451c903d6de7f1c89951b1d",
+    "12D3KooWQpAM4F19CwJAAhHFgeD7feyQLHDTxzKu2hsVH4BQceSQ",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ],
+  [
+    "a3a2419fba7962021d730f4e1eb087b5bf0d66140ef7d4ba758348b13fb2ffa9a75afbdbef988c65ce625544360dea42",
+    "12D3KooWAWoMVZAXJDkuhyzyBJHGHn2gYFyTbbdZGhHs4BuEN5Fe",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ],
+  [
+    "8093ea6fa4720ca0975559a5f9d3a2694c6ab8e63a8c54e986d11a28f9e958f006420e30a8d6f04d6b2df63fe6e0563d",
+    "12D3KooWNqZxaW4ZirvWUNj9KSRgTp55RsZHSFumDeRdCLZAjNNA",
+    "20_000_000_000_000_000_000_000_000",
+    "0x0000000000000000000000000000000000000000",
+    "0x214695413d1ea6a4a4453cd24ffd151fbc95496a"
+  ]
 ]
 
 # Reward parameters
@@ -79,45 +74,12 @@ consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params =
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 sync.ignore_passive = true
 
-consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [
-], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [
-], scilla_delta_maps_are_applied_correctly = false, scilla_server_unlimited_response_size = false, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false, evm_exec_failure_causes_scilla_precompile_to_fail = false, revert_restore_xsgd_contract = false, scilla_fix_contract_code_removal_on_evm_tx = false, restore_ignite_wallet_contracts = false, prevent_zil_transfer_from_evm_to_scilla_contract = false, scilla_failed_txn_correct_gas_fee_charged = false, check_minimum_gas_price = false, inject_access_list = false, use_max_gas_priority_fee = false }
-api_servers = [
-    { port = 4201, enabled_apis = [
-        { namespace = "eth", apis = [
-            "blockNumber",
-        ] },
-    ] },
-    { port = 4202, enabled_apis = [
-        "admin",
-        "debug",
-        "erigon",
-        "eth",
-        "net",
-        "ots",
-        "trace",
-        "txpool",
-        "web3",
-        "zilliqa",
-    ] },
-]
+api_servers = [{ port = 4201, enabled_apis = [{ namespace = "eth", apis = ["blockNumber"] }] }, { port = 4202, enabled_apis = ["admin", "debug", "erigon", "eth", "net", "ots", "trace", "txpool", "web3", "zilliqa"] }]
+consensus.genesis_fork = { at_height = 0, executable_blocks = false, call_mode_1_sets_caller_to_parent_caller = true, failed_scilla_call_from_gas_exempt_caller_causes_revert = true, scilla_messages_can_call_evm_contracts = true, scilla_contract_creation_increments_account_balance = true, scilla_json_preserve_order = true, scilla_call_respects_evm_state_changes = true, only_mutated_accounts_update_state = true, scilla_call_gas_exempt_addrs = [], scilla_block_number_returns_current_block = true, scilla_maps_are_encoded_correctly = true, transfer_gas_fee_to_zero_account = true, apply_state_changes_only_if_transaction_succeeds = true, apply_scilla_delta_when_evm_succeeded = true, scilla_deduct_funds_from_actual_sender = true, fund_accounts_from_zero_account = [], scilla_delta_maps_are_applied_correctly = false, scilla_server_unlimited_response_size = false, scilla_failed_txn_correct_balance_deduction = false, scilla_transition_proper_order = false, evm_to_scilla_value_transfer_zero = false, restore_xsgd_contract = false, evm_exec_failure_causes_scilla_precompile_to_fail = false, revert_restore_xsgd_contract = false, scilla_fix_contract_code_removal_on_evm_tx = false, restore_ignite_wallet_contracts = false, prevent_zil_transfer_from_evm_to_scilla_contract = false, scilla_failed_txn_correct_gas_fee_charged = false, check_minimum_gas_price = false, inject_access_list = false, use_max_gas_priority_fee = false, failed_zil_transfers_to_eoa_proper_fee_deduction = false }
 consensus.forks = [
     { at_height = 8099088, executable_blocks = true },
     { at_height = 8371376, scilla_delta_maps_are_applied_correctly = true },
-    { at_height = 8377200, scilla_call_gas_exempt_addrs = [
-        "0x60E6b5b1B8D3E373E1C04dC0b4f5624776bcBB60",
-        "0x7013Da2653453299Efb867EfcCCcB1A6d5FE1384",
-        "0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3",
-        "0xE90Dd366D627aCc5feBEC126211191901A69f8a0",
-        "0x5900Ac075A67742f5eA4204650FEad9E674c664F",
-        "0x28e8d39fc68eaa27c88797eb7d324b4b97d5b844",
-        "0x51b9f3ddb948bcc16b89b48d83b920bc01dbed55",
-        "0x1fD09F6701a1852132A649fe9D07F2A3b991eCfA",
-        "0x878c5008A348A60a5B239844436A7b483fAdb7F2",
-        "0x8895Aa1bEaC254E559A3F91e579CF4a67B70ce02",
-        "0x453b11386FBd54bC532892c0217BBc316fc7b918",
-        "0xaD581eC62eA08831c8FE2Cd7A1113473fE40A057",
-    ] },
+    { at_height = 8377200, scilla_call_gas_exempt_addrs = ["0x60E6b5b1B8D3E373E1C04dC0b4f5624776bcBB60", "0x7013Da2653453299Efb867EfcCCcB1A6d5FE1384", "0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3", "0xE90Dd366D627aCc5feBEC126211191901A69f8a0", "0x5900Ac075A67742f5eA4204650FEad9E674c664F", "0x28e8d39fc68eaa27c88797eb7d324b4b97d5b844", "0x51b9f3ddb948bcc16b89b48d83b920bc01dbed55", "0x1fD09F6701a1852132A649fe9D07F2A3b991eCfA", "0x878c5008A348A60a5B239844436A7b483fAdb7F2", "0x8895Aa1bEaC254E559A3F91e579CF4a67B70ce02", "0x453b11386FBd54bC532892c0217BBc316fc7b918", "0xaD581eC62eA08831c8FE2Cd7A1113473fE40A057"] },
     { at_height = 9340000, scilla_server_unlimited_response_size = true },
     { at_height = 9341630, scilla_failed_txn_correct_balance_deduction = true, scilla_transition_proper_order = true, evm_to_scilla_value_transfer_zero = true, restore_xsgd_contract = true },
     { at_height = 9500000, evm_exec_failure_causes_scilla_precompile_to_fail = true },
@@ -125,4 +87,5 @@ consensus.forks = [
     { at_height = 10109366, prevent_zil_transfer_from_evm_to_scilla_contract = true },
     { at_height = 10854709, scilla_failed_txn_correct_gas_fee_charged = true, check_minimum_gas_price = true },
     { at_height = 11300000, inject_access_list = true, use_max_gas_priority_fee = true },
+    { at_height = 12706907, failed_zil_transfers_to_eoa_proper_fee_deduction = true },
 ]

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -134,6 +134,7 @@ impl Chain {
                 "check_minimum_gas_price": false,
                 "inject_access_list": false,
                 "use_max_gas_priority_fee": false,
+                "failed_zil_transfers_to_eoa_proper_fee_deduction": false,
             })),
             Chain::Zq2Mainnet => Some(json!({
                 "at_height": 0,
@@ -168,6 +169,7 @@ impl Chain {
                 "check_minimum_gas_price": false,
                 "inject_access_list": false,
                 "use_max_gas_priority_fee": false,
+                "failed_zil_transfers_to_eoa_proper_fee_deduction": false,
             })),
             _ => None,
         }
@@ -209,6 +211,8 @@ impl Chain {
                 json!({ "at_height": 10854709, "scilla_failed_txn_correct_gas_fee_charged": true, "check_minimum_gas_price": true}),
                 // estimated: 2025-08-02T12.00.00Z
                 json!({ "at_height": 11300000, "inject_access_list": true, "use_max_gas_priority_fee": true}),
+                // esimated: 2025-08-20T12.00.00Z
+                json!({ "at_height": 12706907, "failed_zil_transfers_to_eoa_proper_fee_deduction": true}),
             ]),
             Chain::Zq2Mainnet => Some(vec![
                 json!({ "at_height": 4770088, "executable_blocks": true }),
@@ -249,6 +253,8 @@ impl Chain {
                 json!({ "at_height": 6771996, "scilla_failed_txn_correct_gas_fee_charged": true, "check_minimum_gas_price": true}),
                 // estimated: 2025-08-04T12.00.00Z
                 json!({ "at_height": 7000000, "inject_access_list": true, "use_max_gas_priority_fee": true}),
+                // esimated: 2025-09-15T12.00.00Z
+                json!({ "at_height": 9583198, "failed_zil_transfers_to_eoa_proper_fee_deduction": true}),
             ]),
             _ => None,
         }

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -638,6 +638,7 @@ pub struct Fork {
     pub check_minimum_gas_price: bool,
     pub inject_access_list: bool,
     pub use_max_gas_priority_fee: bool,
+    pub failed_zil_transfers_to_eoa_proper_fee_deduction: bool,
 }
 
 pub enum ForkName {
@@ -771,6 +772,8 @@ pub struct ForkDelta {
     pub inject_access_list: Option<bool>,
     /// if true, use max gas priority fee
     pub use_max_gas_priority_fee: Option<bool>,
+    /// if true, a proper fee is charged for failed zil transfers to eoa
+    pub failed_zil_transfers_to_eoa_proper_fee_deduction: Option<bool>,
 }
 
 impl Fork {
@@ -869,6 +872,9 @@ impl Fork {
             use_max_gas_priority_fee: delta
                 .use_max_gas_priority_fee
                 .unwrap_or(self.use_max_gas_priority_fee),
+            failed_zil_transfers_to_eoa_proper_fee_deduction: delta
+                .failed_zil_transfers_to_eoa_proper_fee_deduction
+                .unwrap_or(self.failed_zil_transfers_to_eoa_proper_fee_deduction),
         }
     }
 }
@@ -968,6 +974,7 @@ pub fn genesis_fork_default() -> Fork {
         check_minimum_gas_price: true,
         inject_access_list: true,
         use_max_gas_priority_fee: true,
+        failed_zil_transfers_to_eoa_proper_fee_deduction: true,
     }
 }
 
@@ -1119,6 +1126,7 @@ mod tests {
                 check_minimum_gas_price: None,
                 inject_access_list: None,
                 use_max_gas_priority_fee: None,
+                failed_zil_transfers_to_eoa_proper_fee_deduction: None,
             }],
             ..Default::default()
         };
@@ -1173,6 +1181,7 @@ mod tests {
                     check_minimum_gas_price: None,
                     inject_access_list: None,
                     use_max_gas_priority_fee: None,
+                    failed_zil_transfers_to_eoa_proper_fee_deduction: None,
                 },
                 ForkDelta {
                     at_height: 20,
@@ -1207,6 +1216,7 @@ mod tests {
                     check_minimum_gas_price: None,
                     inject_access_list: None,
                     use_max_gas_priority_fee: None,
+                    failed_zil_transfers_to_eoa_proper_fee_deduction: None,
                 },
             ],
             ..Default::default()
@@ -1275,6 +1285,7 @@ mod tests {
                     check_minimum_gas_price: None,
                     inject_access_list: None,
                     use_max_gas_priority_fee: None,
+                    failed_zil_transfers_to_eoa_proper_fee_deduction: None,
                 },
                 ForkDelta {
                     at_height: 10,
@@ -1309,6 +1320,7 @@ mod tests {
                     check_minimum_gas_price: None,
                     inject_access_list: None,
                     use_max_gas_priority_fee: None,
+                    failed_zil_transfers_to_eoa_proper_fee_deduction: None,
                 },
             ],
             ..Default::default()
@@ -1368,6 +1380,7 @@ mod tests {
                 check_minimum_gas_price: true,
                 inject_access_list: true,
                 use_max_gas_priority_fee: true,
+                failed_zil_transfers_to_eoa_proper_fee_deduction: true,
             },
             forks: vec![],
             ..Default::default()
@@ -1415,6 +1428,7 @@ mod tests {
                     check_minimum_gas_price: None,
                     inject_access_list: None,
                     use_max_gas_priority_fee: None,
+                    failed_zil_transfers_to_eoa_proper_fee_deduction: None,
                 },
                 ForkDelta {
                     at_height: 20,
@@ -1449,6 +1463,7 @@ mod tests {
                     check_minimum_gas_price: None,
                     inject_access_list: None,
                     use_max_gas_priority_fee: None,
+                    failed_zil_transfers_to_eoa_proper_fee_deduction: None,
                 },
             ],
             ..Default::default()

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -2287,10 +2287,16 @@ pub fn scilla_call(
                 false => from_addr,
             };
 
-            let gas_used = if fork.scilla_failed_txn_correct_gas_fee_charged {
+            let gas_left = if fork.scilla_failed_txn_correct_gas_fee_charged {
                 gas.into()
             } else {
                 EvmGas(0)
+            };
+
+            let gas_used = if fork.failed_zil_transfers_to_eoa_proper_fee_deduction {
+                EvmGas::from(gas_limit) - gas_left
+            } else {
+                gas_left
             };
 
             if let Some(result) =


### PR DESCRIPTION
Gas returned is gas_used, not gas_left. Also there's some formatting applied to toml files (by running `z2/update-chain-specs.sh`).