### PR TITLE
Fix passive-sync off-by-one error

### DIFF
--- a/zilliqa/src/constants.rs
+++ b/zilliqa/src/constants.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use revm::primitives::{B256, b256};
+
 use crate::transaction::{EvmGas, ScillaGas};
 
 // How big data slot a transaction can use
@@ -89,3 +91,7 @@ pub const MAX_REQUEST_SIZE: usize = 1024 * 1024;
 /// Size thresholds
 pub const PROPOSAL_THRESHOLD: usize = MAX_GOSSIP_SIZE * 8 / 10; // 80%
 pub const SYNC_THRESHOLD: usize = MAX_RESPONSE_SIZE - MAX_GOSSIP_SIZE;
+
+/// Empty state trie hash
+pub const EMPTY_ROOT_HASH: B256 =
+    b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -814,7 +814,7 @@ impl Db {
         hash: Hash,
         block: &Block,
     ) -> Result<()> {
-        sqlite_tx.prepare_cached("INSERT INTO blocks
+        sqlite_tx.prepare_cached("INSERT OR IGNORE INTO blocks
         (block_hash, view, height, qc, signature, state_root_hash, transactions_root_hash, receipts_root_hash, timestamp, gas_used, gas_limit, agg, is_canonical)
     VALUES (:block_hash, :view, :height, :qc, :signature, :state_root_hash, :transactions_root_hash, :receipts_root_hash, :timestamp, :gas_used, :gas_limit, :agg, TRUE)",)?.execute(
             named_params! {

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -374,7 +374,10 @@ impl Sync {
             SyncState::Retry1(_) if self.in_pipeline == 0 => {
                 self.retry_phase1()?;
             }
-            SyncState::Phase4(_) => self.request_passive_sync()?,
+            SyncState::Phase4((last, _)) => {
+                let range = self.sync_base_height..=last;
+                self.request_passive_sync(range)?;
+            }
             _ => {
                 debug!(in_pipeline = %self.in_pipeline, "DoSync : syncing");
             }
@@ -417,7 +420,7 @@ impl Sync {
 
         match (*range.start()).cmp(&self.sync_base_height) {
             Ordering::Equal => {
-                self.sync_base_height = u64::MAX;
+                self.recover_checkpoints(range)?;
             }
             // passive-sync above sync-base-height
             Ordering::Greater => {
@@ -427,12 +430,13 @@ impl Sync {
                 let last = *range.start();
                 let hash = self
                     .db
-                    .get_block(BlockFilter::Height(*range.start()))?
+                    .get_transactionless_block(BlockFilter::Height(*range.start()))?
                     .expect("must exist")
                     .hash();
 
                 self.state = SyncState::Phase4((last, hash));
-                self.request_passive_sync()?;
+                let range = self.sync_base_height..=last;
+                self.request_passive_sync(range)?;
             }
             Ordering::Less => {
                 let last_prune = self.prune_range(range)?;
@@ -443,6 +447,36 @@ impl Sync {
                 }
             }
         }
+        Ok(())
+    }
+
+    /// Recovers missing checkpoint parent block (if any)
+    /// It only impacts a handful of blocks.
+    fn recover_checkpoints(&mut self, range: RangeInclusive<u64>) -> Result<()> {
+        let start = range.start().saturating_div(86400);
+        let end = range.end().saturating_div(86400);
+
+        for n in start..=end {
+            let num = n.saturating_mul(86400).saturating_sub(1); // calculate checkpoint parent
+            let Some(block) = self
+                .db
+                .get_transactionless_block(BlockFilter::Height(num))?
+            else {
+                continue; // skip if block not found
+            };
+            if !self
+                .db
+                .get_transaction_receipts_in_block(&block.hash())?
+                .is_empty()
+            {
+                continue; // skip if any transaction receipts are available
+            }
+            tracing::info!(number=%block.number(), hash=%block.hash(), "Recovering checkpoint");
+            self.state = SyncState::Phase4((block.number(), block.hash()));
+            let range = block.number()..=block.number();
+            return self.request_passive_sync(range); // request 1 block only
+        }
+        self.sync_base_height = u64::MAX; // no more to process
         Ok(())
     }
 
@@ -743,8 +777,8 @@ impl Sync {
     /// Phase 4: Request Passive Sync
     ///
     /// Request for as much as possible, but will only receive partial response.
-    fn request_passive_sync(&mut self) -> Result<()> {
-        let SyncState::Phase4((last, hash)) = self.state else {
+    fn request_passive_sync(&mut self, range: RangeInclusive<u64>) -> Result<()> {
+        let SyncState::Phase4((_last, hash)) = self.state else {
             unimplemented!("PassiveSync : invalid state");
         };
 
@@ -755,7 +789,6 @@ impl Sync {
         }
 
         if let Some(peer_info) = self.peers.get_next_peer() {
-            let range = self.sync_base_height..=last;
             info!(?range, from = %peer_info.peer_id, "PassiveSync : requesting");
             let message = ExternalMessage::PassiveSyncRequest(RequestBlocksByHash {
                 request_at: SystemTime::now(),

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -464,6 +464,9 @@ impl Sync {
             else {
                 continue; // skip if block not found
             };
+            if block.transactions_root_hash().0 == crate::constants::EMPTY_ROOT_HASH.0 {
+                continue; // skip if block has empty transactions root hash
+            }
             if !self
                 .db
                 .get_transaction_receipts_in_block(&block.hash())?


### PR DESCRIPTION
This PR provides a fix for a off-by-one error, when running passive-sync from a checkpoint. The parent block in the checkpoint file is stored without any of its transactions, and passive-syncing starts from its parent (i.e. grand-parent) block. As a result, there is a possibility of missing transactions/receipts for the parent block.

This issue was missed in earlier testing because it turns out that most checkpoint blocks are empty blocks. Manual checking (`eth_getBlockByNumber`) shows that less than a handful of blocks in `mainnet` are impacted by this issue. Only nodes that have passive-synced from non-empty checkpoint parents are impacted.

This fix does two things:
1. Alter passive-sync to sync from the lowest block, inclusive (rather than exclusive, previously); and
2. Introduce a recovery mechanism that will scan all checkpoint parents and download any missing transactions/receipts for that block (this should only run once).