### PR TITLE
Restore previous error behaviour

### DIFF
--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -905,7 +905,7 @@ impl Db {
         hash: Hash,
         block: &Block,
     ) -> Result<()> {
-        sqlite_tx.prepare_cached("INSERT OR IGNORE INTO blocks
+        sqlite_tx.prepare_cached("INSERT INTO blocks
         (block_hash, view, height, qc, signature, state_root_hash, transactions_root_hash, receipts_root_hash, timestamp, gas_used, gas_limit, agg, is_canonical)
     VALUES (:block_hash, :view, :height, :qc, :signature, :state_root_hash, :transactions_root_hash, :receipts_root_hash, :timestamp, :gas_used, :gas_limit, :agg, TRUE)",)?.execute(
             named_params! {

--- a/zilliqa/src/sync.rs
+++ b/zilliqa/src/sync.rs
@@ -1484,10 +1484,10 @@ impl Sync {
                 "StoreProposals : applying",
             );
 
-            // Store/Ignore it; if it already exists.
+            // Store/Ignore - if it already exists.
             self.db.with_sqlite_tx(|sqlite_tx| {
                     // Insert block
-                    self.db.insert_block_with_db_tx(sqlite_tx, &block)?;
+                    self.db.insert_block_with_db_tx(sqlite_tx, &block).ok();
                     // Insert transactions/receipts
                     for (st, rt) in transaction_receipts {
                         // Verify transaction


### PR DESCRIPTION
This PR restores the previous behaviour where a syncing error will be triggered, instead of being silent, when a block fails to be inserted. With an error, the syncing process stops whereas the silent behaviour results in failing to sync forever.

In the specific case of a passive-sync, there is no real reason for an error since it involves a historical block. Any underlying SQL errors, such as connectivity issues, will be caught in the subsequent inserts.