### PR TITLE
Replace `unsafe` code with `ArcSwap` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,6 +741,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1940,7 +1946,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2807,7 +2813,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4643,7 +4649,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.0",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5150,7 +5156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7151,7 +7157,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.8",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7830,7 +7836,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7843,7 +7849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7932,7 +7938,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8685,7 +8691,7 @@ dependencies = [
  "solar-config",
  "solar-data-structures",
  "solar-macros",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "tracing",
  "unicode-width",
 ]
@@ -8934,7 +8940,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "url",
  "zip 2.4.1",
 ]
@@ -9098,7 +9104,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.2",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10208,7 +10214,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10852,6 +10858,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "arc-swap",
  "base64 0.22.1",
  "bitvec",
  "clap",
@@ -11006,6 +11013,7 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "anyhow",
+ "arc-swap",
  "async-trait",
  "base64 0.22.1",
  "bech32 0.11.0",

--- a/z2/Cargo.toml
+++ b/z2/Cargo.toml
@@ -29,6 +29,7 @@ alloy = { version = "0.12.4", default-features = false, features = [
     "signer-local",
 ] }
 anyhow = "1.0.99"
+arc-swap = "1.7.1"
 base64 = "0.22.1"
 bitvec = "1.0.1"
 clap = { version = "4.5.46", features = ["derive"] }

--- a/z2/src/docgen.rs
+++ b/z2/src/docgen.rs
@@ -6,13 +6,11 @@ use std::{
     convert::TryFrom,
     fmt,
     path::{Path, PathBuf},
-    sync::{
-        Arc,
-        atomic::{AtomicPtr, AtomicUsize},
-    },
+    sync::{Arc, atomic::AtomicUsize},
 };
 
 use anyhow::{Context as _, Result, anyhow};
+use arc_swap::ArcSwap;
 use parking_lot::RwLock;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
@@ -360,7 +358,7 @@ pub fn get_implemented_jsonrpc_methods() -> Result<HashMap<ApiMethod, PageStatus
 
     let peer_id = secret_key.to_libp2p_keypair().public().to_peer_id();
     let sync_peers = Arc::new(SyncPeers::new(peer_id));
-    let swarm_peers = Arc::new(AtomicPtr::new(Box::into_raw(Box::new(Vec::new()))));
+    let swarm_peers = Arc::new(ArcSwap::from_pointee(Vec::new()));
 
     let my_node = Arc::new(RwLock::new(zilliqa::node::Node::new(
         config,

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -136,6 +136,7 @@ rocksdb = { version = "0.24.0", default-features = false, features = [
 ] }
 zip = { version = "4.5.0", default-features = false, features = ["zstd"] }
 eth_trie = { git = "https://github.com/Zilliqa/eth-trie.rs.git", branch = "zilliqa" }
+arc-swap = "1.7.1"
 
 [dev-dependencies]
 alloy = { version = "0.12.4", default-features = false, features = [

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -1,13 +1,11 @@
 use std::{
     net::Ipv4Addr,
-    sync::{
-        Arc,
-        atomic::{AtomicPtr, AtomicUsize},
-    },
+    sync::{Arc, atomic::AtomicUsize},
     time::{Duration, SystemTime},
 };
 
 use anyhow::{Result, anyhow};
+use arc_swap::ArcSwap;
 use http::{Method, header};
 use jsonrpsee::server::ServerConfig;
 use libp2p::{PeerId, futures::StreamExt};
@@ -102,7 +100,7 @@ impl NodeLauncher {
         local_outbound_message_sender: UnboundedSender<LocalMessageTuple>,
         request_responses_sender: UnboundedSender<(ResponseChannel, ExternalMessage)>,
         peer_num: Arc<AtomicUsize>,
-        swarm_peers: Arc<AtomicPtr<Vec<PeerId>>>,
+        swarm_peers: Arc<ArcSwap<Vec<PeerId>>>,
     ) -> Result<(Self, NodeInputChannels, Arc<SyncPeers>)> {
         /// Helper to create a (sender, receiver) pair for a channel.
         fn sender_receiver<T>() -> (UnboundedSender<T>, UnboundedReceiverStream<T>) {

--- a/zilliqa/tests/it/main.rs
+++ b/zilliqa/tests/it/main.rs
@@ -1,4 +1,5 @@
 use alloy::primitives::Address;
+use arc_swap::ArcSwap;
 use ethabi::Token;
 use ethers::{
     abi::Tokenize,
@@ -40,7 +41,7 @@ use std::{
     rc::Rc,
     sync::{
         Arc, Mutex,
-        atomic::{AtomicPtr, AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
     time::Duration,
 };
@@ -184,7 +185,7 @@ fn node(
 
     let peer_id = secret_key.to_libp2p_keypair().public().to_peer_id();
     let sync_peers = Arc::new(SyncPeers::new(peer_id));
-    let swarm_peers = Arc::new(AtomicPtr::new(Box::into_raw(Box::new(Vec::new()))));
+    let swarm_peers = Arc::new(ArcSwap::from_pointee(Vec::new()));
 
     let node = Node::new(
         NodeConfig {


### PR DESCRIPTION
This PR is to improve code hygiene. Replace use of `unsafe` code with the ArcSwap crate.