### PR TITLE
Fix state-migration corner case

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -3567,12 +3567,14 @@ impl Consensus {
         let state_trie = self.db.state_trie()?;
         let mut migrate_at = state_trie.get_migrate_at()?;
         if migrate_at == u64::MAX {
-            // TODO: Nothing to do
             return Ok(true); // done
         }
 
         // replay one block - writing new state to RocksDB.
-        let parent_hash = state_trie.get_root_hash(migrate_at.saturating_sub(1))?;
+        let Some(parent_hash) = state_trie.get_root_hash(migrate_at.saturating_sub(1))? else {
+            unimplemented!("parent state must exist!");
+        };
+
         let brt = self
             .db
             .get_block_and_receipts_and_transactions(BlockFilter::Height(migrate_at))?
@@ -3589,7 +3591,11 @@ impl Consensus {
         let cutover_at = state_trie.get_cutover_at()?;
         while migrate_at < cutover_at {
             migrate_at = migrate_at.saturating_add(1); // check next block
-            if state_trie.get_root_hash(migrate_at)? != block_hash {
+            let Some(hash) = state_trie.get_root_hash(migrate_at)? else {
+                tracing::warn!(number=%migrate_at,"State-sync retrying");
+                return Ok(true); // retry later
+            };
+            if hash != block_hash {
                 state_trie.set_migrate_at(migrate_at)?;
                 return Ok(false);
             }
@@ -3597,7 +3603,6 @@ impl Consensus {
         // done
         tracing::info!("State-sync complete!");
         state_trie.finish_migration()?;
-
-        Ok(false)
+        Ok(true)
     }
 }


### PR DESCRIPTION
There is a corner case, near `cutover_at`, where there might already be blocks that have been executed (but not yet marked as canonical). Those blocks would be missed by existing `migrate_state()`.

This PR fixes this situation by marking the `cutover_at` with the *highest known block + 2*, which goes well above known blocks i.e. blocks that may have any state in the database. Then it forces the `migrate_state()` function to retry these blocks until they are replayed.

Assuming that the migration code runs much later than at the start, it will just replay these handful of extra blocks, which may result in some additional state migration.

Assuming that the migration code runs immediately i.e. before these higher blocks are seen or marked canonical, the migration just keeps retrying them until it succeeds to replay them.