### PR TITLE
Handle trie iteration errors and log warnings throughout code

### DIFF
--- a/z2/src/zq1/db.rs
+++ b/z2/src/zq1/db.rs
@@ -425,11 +425,15 @@ impl Db {
     }
 
     pub fn accounts(&self) -> impl Iterator<Item = (Address, ProtoAccountBase)> + '_ {
-        self.state.iter().flatten().map(|(k, v)| {
-            (
+        self.state.iter().filter_map(|kv| match kv {
+            Ok((k, v)) => Some((
                 Address::from_slice(&hex::decode(String::from_utf8(k).unwrap()).unwrap()),
                 ProtoAccountBase::decode(v.as_slice()).unwrap(),
-            )
+            )),
+            Err(e) => {
+                tracing::warn!("Trie error {e:?}");
+                None
+            }
         })
     }
 

--- a/zilliqa/src/checkpoint.rs
+++ b/zilliqa/src/checkpoint.rs
@@ -461,7 +461,14 @@ pub fn save_ckpt(
     let mut record_count = 0;
     // iterate over accounts and save the accounts to the checkpoint file.
     // do not save intermediate state trie values.
-    for (key, serialised_account) in accounts.iter().flatten() {
+    for akv in accounts.iter() {
+        let (key, serialised_account) = match akv {
+            Ok((k, v)) => (k, v),
+            Err(e) => {
+                tracing::warn!("Trie error: {e:?}");
+                continue;
+            }
+        };
         bincode::encode_into_std_write(&key, &mut zipwriter, BIN_CONFIG)?;
         bincode::encode_into_std_write(&serialised_account, &mut zipwriter, BIN_CONFIG)?;
 
@@ -471,7 +478,15 @@ pub fn save_ckpt(
         let account_trie = account_storage.at_root(account_root);
         let count = account_trie.iter().count();
         bincode::serde::encode_into_std_write(count, &mut zipwriter, BIN_CONFIG)?;
-        for (storage_key, storage_val) in account_trie.iter().flatten() {
+        for skv in account_trie.iter() {
+            let (storage_key, storage_val) = match skv {
+                Ok((k, v)) => (k, v),
+                Err(e) => {
+                    tracing::warn!("Trie error: {e:?}");
+                    continue;
+                }
+            };
+
             bincode::encode_into_std_write(&storage_key, &mut zipwriter, BIN_CONFIG)?;
             bincode::encode_into_std_write(&storage_val, &mut zipwriter, BIN_CONFIG)?;
             record_count += 1;

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -1628,7 +1628,14 @@ impl PendingState {
         let cached = account.storage.get(var_name);
 
         // Un-flatten the values from disk into their true representation.
-        for (k, v) in values_from_disk.into_iter().flatten() {
+        for kv in values_from_disk.into_iter() {
+            let (k, v) = match kv {
+                Ok((key, val)) => (key, val),
+                Err(e) => {
+                    tracing::warn!("Trie error: {e:?}");
+                    continue;
+                }
+            };
             let (disk_var_name, disk_indices) = split_storage_key(&k)?;
             if var_name != disk_var_name {
                 // There is a hazard caused by the storage key format when a contract contains a variable which is a


### PR DESCRIPTION
Instead of silently ignoring any trie errors, log them.