### PR TITLE
Update fork height for Scilla precompile failure to 9494740

### DIFF
--- a/z2/resources/chain-specs/zq2-testnet.toml
+++ b/z2/resources/chain-specs/zq2-testnet.toml
@@ -82,6 +82,8 @@ consensus.forks = [
     { at_height = 8377200, scilla_call_gas_exempt_addrs = ["0x60E6b5b1B8D3E373E1C04dC0b4f5624776bcBB60", "0x7013Da2653453299Efb867EfcCCcB1A6d5FE1384", "0x8618d39a8276D931603c6Bc7306af6A53aD2F1F3", "0xE90Dd366D627aCc5feBEC126211191901A69f8a0", "0x5900Ac075A67742f5eA4204650FEad9E674c664F", "0x28e8d39fc68eaa27c88797eb7d324b4b97d5b844", "0x51b9f3ddb948bcc16b89b48d83b920bc01dbed55", "0x1fD09F6701a1852132A649fe9D07F2A3b991eCfA", "0x878c5008A348A60a5B239844436A7b483fAdb7F2", "0x8895Aa1bEaC254E559A3F91e579CF4a67B70ce02", "0x453b11386FBd54bC532892c0217BBc316fc7b918", "0xaD581eC62eA08831c8FE2Cd7A1113473fE40A057"] },
     { at_height = 9340000, scilla_server_unlimited_response_size = true },
     { at_height = 9341630, scilla_failed_txn_correct_balance_deduction = true, scilla_transition_proper_order = true, evm_to_scilla_value_transfer_zero = true, restore_xsgd_contract = true },
+    { at_height = 9494740, evm_exec_failure_causes_scilla_precompile_to_fail = true },
+    { at_height = 9498974, evm_exec_failure_causes_scilla_precompile_to_fail = false },
     { at_height = 9500000, evm_exec_failure_causes_scilla_precompile_to_fail = true },
     { at_height = 9780700, revert_restore_xsgd_contract = true, scilla_fix_contract_code_removal_on_evm_tx = true },
     { at_height = 10109366, prevent_zil_transfer_from_evm_to_scilla_contract = true },

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -244,6 +244,8 @@ impl Chain {
                 // estimated: 2025-07-09T07.00.00Z
                 json!({ "at_height": 9341630, "scilla_failed_txn_correct_balance_deduction": true, "scilla_transition_proper_order": true, "evm_to_scilla_value_transfer_zero": true, "restore_xsgd_contract": true }),
                 // estimated: 2025-07-11T07.00.00Z
+                json!({ "at_height": 9494740, "evm_exec_failure_causes_scilla_precompile_to_fail": true }),
+                json!({ "at_height": 9498974, "evm_exec_failure_causes_scilla_precompile_to_fail": false }),
                 json!({ "at_height": 9500000, "evm_exec_failure_causes_scilla_precompile_to_fail": true }),
                 // estimated: 2025-07-14T12.00.00Z
                 json!({ "at_height": 9780700, "revert_restore_xsgd_contract": true, "scilla_fix_contract_code_removal_on_evm_tx": true}),


### PR DESCRIPTION
Will merge this once it passes with the node in `testnet` 