### PR TITLE
Update withdrawal_period for deposit_v7 and adjust scripts path

### DIFF
--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -115,7 +115,9 @@ impl Chain {
                 }),
                 deposit_v7: Some(ContractUpgradeConfig {
                     height: 15984000,
-                    reinitialise_params: Some(ReinitialiseParams::default()),
+                    reinitialise_params: Some(ReinitialiseParams {
+                        withdrawal_period: 461680,
+                    }), // https://github.com/Zilliqa/zq2/pull/3221
                 }),
             },
             Self::Zq2Mainnet => ContractUpgrades {
@@ -131,7 +133,9 @@ impl Chain {
                 }),
                 deposit_v7: Some(ContractUpgradeConfig {
                     height: 11998800,
-                    reinitialise_params: Some(ReinitialiseParams::default()),
+                    reinitialise_params: Some(ReinitialiseParams {
+                        withdrawal_period: 461680,
+                    }), // https://github.com/Zilliqa/zq2/pull/3221
                 }),
             },
             _ => ContractUpgrades::default(),

--- a/z2/src/chain/node.rs
+++ b/z2/src/chain/node.rs
@@ -705,7 +705,6 @@ impl ChainNode {
             json!({
                 "port": 4201,
                 "enabled_apis": [
-                    "debug",
                     "erigon",
                     "eth",
                     "net",
@@ -726,7 +725,6 @@ impl ChainNode {
                             "traceTransaction",
                         ],
                     },
-                    "trace",
                     "txpool",
                     "web3",
                     "zilliqa",

--- a/z2/update-chain-specs.sh
+++ b/z2/update-chain-specs.sh
@@ -1,1 +1,1 @@
-for network in {mainnet,testnet,devnet,infratest}; do z2 deployer get-config-file zq2-$network.yaml --out z2/resources/chain-specs/zq2-$network.toml; done
+for network in {mainnet,testnet,devnet,infratest}; do ./scripts/z2 deployer get-config-file zq2-$network.yaml --out z2/resources/chain-specs/zq2-$network.toml; done

--- a/zq2-devnet.yaml
+++ b/zq2-devnet.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.18.1
+  zq2: v0.19.0-alpha

--- a/zq2-infratest.yaml
+++ b/zq2-infratest.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.18.1
+  zq2: v0.19.0-alpha

--- a/zq2-testnet.yaml
+++ b/zq2-testnet.yaml
@@ -9,4 +9,4 @@ roles:
   - persistence
   - private-api
 versions:
-  zq2: v0.18.1
+  zq2: v0.19.0-alpha


### PR DESCRIPTION
Set withdrawal_period to 461680 for deposit_v7 upgrades on Zq2Mainnet and Zq2Testnet. Remove debug and trace APIs from ChainNode config. Update update-chain-specs.sh to use ./scripts/z2 path.