### PR TITLE
Call do_migration with sleep_time in NodeLauncher

### DIFF
--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -495,18 +495,11 @@ impl Node {
     // handle timeout - true if something happened
     pub fn handle_timeout(&self) -> Result<bool> {
         let network_message = self.consensus.write().timeout()?;
-        if let Some(network_message) = network_message {
-            self.handle_network_message_response(network_message)?;
-            return Ok(true);
-        }
-        Ok(false)
-    }
 
-    pub fn handle_reset(&self, sleep_time: Duration) -> Result<()> {
-        // migrate as many blocks as possible, otherwise
         if self.db.config.state_sync {
+            let (_, remaining, _) = self.consensus.read().get_consensus_timeout_params()?;
+            let period = Duration::from_millis(remaining) / 4; // steal < 250ms
             let now = Instant::now();
-            let period = self.config.consensus.block_time.min(sleep_time) / 2; // steal < 500ms
             while now.elapsed() < period {
                 match self.consensus.write().migrate_state_trie() {
                     Ok(done) if done => break,
@@ -515,7 +508,12 @@ impl Node {
                 };
             }
         }
-        Ok(())
+
+        if let Some(network_message) = network_message {
+            self.handle_network_message_response(network_message)?;
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     pub fn create_transaction(&self, txn: VerifiedTransaction) -> Result<(Hash, TxAddResult)> {

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -322,11 +322,7 @@ impl NodeLauncher {
                     let sleep_time = r.expect("reset timeout stream should be infinite");
                     trace!(?sleep_time, "timeout reset");
                     consensus_sleep.as_mut().reset(Instant::now() + sleep_time);
-                    if let Err(e) = self.node.handle_reset(sleep_time) {
-                        error!("Failed to migrate {e}");
-                    }
                 },
-
                 () = &mut mempool_sleep => {
                     self.node.process_transactions_to_broadcast()?;
                     mempool_sleep.as_mut().reset(Instant::now() + Duration::from_millis(50));


### PR DESCRIPTION
State migration was only previously triggered upon consensus timing out. So, it would rarely get triggered and migration will be slow. Moved it so that it gets triggered upon both normal consensus processing; and during timeouts.