### PR TITLE
Adjust passive-sync logic to handle blocks with missing transactions

### DIFF
--- a/zilliqa/src/crypto.rs
+++ b/zilliqa/src/crypto.rs
@@ -14,6 +14,7 @@ use blsful::{
 };
 use itertools::Itertools;
 use k256::ecdsa::{Signature as EcdsaSignature, VerifyingKey, signature::hazmat::PrehashVerifier};
+use revm::primitives::b256;
 use serde::{
     Deserialize, Serialize,
     de::{self, Unexpected},
@@ -326,6 +327,8 @@ pub struct Hash(pub [u8; 32]);
 impl Hash {
     pub const ZERO: Hash = Hash([0; Hash::LEN]);
     pub const LEN: usize = 32;
+    pub const EMPTY: Hash =
+        Hash(b256!("56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421").0);
 
     pub fn builder() -> HashBuilder {
         HashBuilder(Keccak256::new())


### PR DESCRIPTION
A previous fix https://github.com/Zilliqa/zq2/pull/3145 attempted to solve the issue of checkpoint parents missing transactions, by simply re-syncing the lowest block, at all times - forcibly syncing any checkpoint parent.

This causes an issue with a rare case, where only 1 block is able to fit into a response payload (either due to size or time). In such a case, it is possible for the passive-sync to get stuck repeatedly syncing only the lowest block. Re-syncing the lowest block is needed only for the checkpoint parent, which is stored without any associated transactions.