### PR TITLE
feat: DEVOPS-2354 rocksdb-tools installation

### DIFF
--- a/infra/ansible/playbooks/install_rocksdb_tools.yml
+++ b/infra/ansible/playbooks/install_rocksdb_tools.yml
@@ -1,0 +1,18 @@
+---
+- name: Install required packages
+  hosts: all:!role_apps
+  become: true
+  tags:
+    - install
+    - all
+  
+  tasks:
+
+    - name: Ensure rocksdb-tools is installed
+      ansible.builtin.apt:
+        name: rocksdb-tools
+        state: present
+        update_cache: yes
+      when:
+        - ansible_distribution == "Ubuntu"
+        - ansible_distribution_version is version("24.04", '>=')

--- a/infra/ansible/playbooks/node_provision.yml
+++ b/infra/ansible/playbooks/node_provision.yml
@@ -57,3 +57,6 @@
 - name: Ethereum Metrics Exporter installation
   ansible.builtin.import_playbook: install_ethereum_metrics_exporter.yml
   when: ethereum_metrics_exporter_image is defined and ethereum_metrics_exporter_image != ""
+
+- name: Import rocksdb-tools installation
+  ansible.builtin.import_playbook: install_rocksdb_tools.yml

--- a/infra/ansible/playbooks/upgrade_ubuntu.yml
+++ b/infra/ansible/playbooks/upgrade_ubuntu.yml
@@ -24,7 +24,7 @@
     - all
 
   vars:
-    target_release: "24.04"
+    target_release: "{{ ubuntu_version }}"
 
   tasks:
     - name: Ensure update-manager-core is installed


### PR DESCRIPTION
Ensure the installation of the rocksdb-tools only if Ubuntu 24.04 is the distribution version.

Tests:
- Installed in Ubuntu 24.04 node:
```
TASK [Ensure rocksdb-tools is installed] ***************************************************
changed: [zq2-devnet-persistence-ase1-0] => {"cache_update_time": 1759482170, "cache_updated": true, "changed": true,
```
- Not installed in Apps node:
```
PLAY [Install required packages] ***********************************************************
skipping: no hosts matched
```
- Not installed in Ubuntu 24.04 or higher:
```
TASK [Ensure rocksdb-tools is installed] ***************************************************
skipping: [zq2-testnet-persistence-ase1-0] => {"changed": false, "false_condition": "ansible_distribution_version is version(\"24.04\", '>=')", "skip_reason": "Conditional result was False"}
```

Tool usage:
```
apt show rocksdb-tools
Package: rocksdb-tools
Version: 8.9.1-2
```
```
ldb
ldb - RocksDB Tool
commands MUST specify --db=<full_path_to_db_directory> when necessary
```