### PR TITLE
Specify new `deposit_v7` upgrade block height

### DIFF
--- a/z2/resources/chain-specs/zq2-testnet.toml
+++ b/z2/resources/chain-specs/zq2-testnet.toml
@@ -70,7 +70,7 @@ consensus.minimum_stake = "10_000_000_000_000_000_000_000_000"
 # Gas parameters
 consensus.eth_block_gas_limit = 84000000
 consensus.gas_price = "4_761_904_800_000"
-consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params = { withdrawal_period = 1209600 } }, deposit_v6 = { height = 14997600 }, deposit_v7 = { height = 16934100, reinitialise_params = { withdrawal_period = 461680 } } }
+consensus.contract_upgrades = { deposit_v5 = { height = 0, reinitialise_params = { withdrawal_period = 1209600 } }, deposit_v6 = { height = 14997600 }, deposit_v7 = { height = 17010000, reinitialise_params = { withdrawal_period = 461680 } } }
 consensus.new_view_broadcast_interval = { secs = 30, nanos = 0 }
 sync.ignore_passive = true
 

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -114,7 +114,7 @@ impl Chain {
                     reinitialise_params: None,
                 }),
                 deposit_v7: Some(ContractUpgradeConfig {
-                    height: 16934100,
+                    height: 17010000,
                     reinitialise_params: Some(ReinitialiseParams {
                         withdrawal_period: 461680,
                     }), // https://github.com/Zilliqa/zq2/pull/3221


### PR DESCRIPTION
The new block height is divisible by 3600, which is required to trigger the upgrade at an epoch boundary.