### PR TITLE
Slow checkpoint

### DIFF
--- a/zilliqa/src/trie_storage.rs
+++ b/zilliqa/src/trie_storage.rs
@@ -126,8 +126,7 @@ impl eth_trie::DB for TrieStorage {
 
     fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Self::Error> {
         // L1 - in-memory cache
-        // does not mark the entry as MRU, but allows concurrent cache reads;
-        if let Some(cached) = self.cache.read().peek(key) {
+        if let Some(cached) = self.cache.write().get(key) {
             return Ok(Some(cached.to_vec()));
         }
 


### PR DESCRIPTION
It was observed that it takes a long time to generate checkpoints; enough so that the node was generating up to 4 checkpoints concurrently when syncing from switchover i.e. it progressed fast enough to spawn new threads while the older threads were still running. The same DB/state connections have to be shared between the checkpoint threads and the main ones.

So, this PR proposes to use a different strategy i.e.:
1. It disconnects the checkpoint node from the network, so that its message buffers do not get bloated due to incoming messages;
2. It performs a synchronous generation of the checkpoint in the main thread, which should only take about 2-hrs on mainnet; and
3. It reconnects to the network, and performs active-sync to catch up on the blocks it missed during that 2-hr window, which should take about half an hour.

Tested on `mainnet-checkpoint-ase1-0` successfully:
```
-rw-r--r-- 1 root root 472M Nov  1 07:04 12441600
-rw-r--r-- 1 root root 472M Nov  2 14:12 12528000
```

It now takes about 2-hrs to generate a checkpoint; which is visible on the dashboard i.e. the yellow bits that start around 1415 and finish before 1700.
<img width="363" height="215" alt="image" src="https://github.com/user-attachments/assets/e88674ed-896c-4451-8371-199d6b804973" />

Once merged, I'll cherry pick this into `release/0.19.0` and redeploy to the checkpoint nodes in `testnet` and `mainnet`.