### PR TITLE
feat: DEVOPS-125 alternative ssl domains for private apis

### DIFF
--- a/infra/tf/private_api.tf
+++ b/infra/tf/private_api.tf
@@ -16,12 +16,13 @@ locals {
       ]
     ]) :
     item.instance.name => {
-      idx         = item.idx
-      zone        = item.zone
-      instance    = item.instance
-      config      = var.private_api[item.idx]
-      dns_name    = var.private_api[item.idx].dns_names[item.num]
-      external_ip = item.external_ip
+      idx                     = item.idx
+      zone                    = item.zone
+      instance                = item.instance
+      config                  = var.private_api[item.idx]
+      dns_name                = var.private_api[item.idx].dns_names[item.num]
+      alternative_ssl_domains = var.private_api[item.idx].alternative_ssl_domains.default
+      external_ip             = item.external_ip
     }
   }
 }
@@ -144,7 +145,10 @@ resource "google_compute_managed_ssl_certificate" "private_api" {
   name = each.key
 
   managed {
-    domains = ["${each.value.dns_name}.${var.subdomain}"]
+    domains = concat(
+      ["${each.value.dns_name}.${var.subdomain}"],
+      each.value.alternative_ssl_domains
+    )
   }
 }
 

--- a/infra/tf/variables.tf
+++ b/infra/tf/variables.tf
@@ -251,6 +251,9 @@ variable "private_api" {
     detach_load_balancer   = optional(bool, false)
     firewall_source_ranges = optional(list(string), [])
     dns_names              = optional(list(string), [])
+    alternative_ssl_domains = optional(object({
+      default = optional(list(string), [])
+    }), {})
     nodes = optional(list(object({
       count  = number
       region = optional(string)


### PR DESCRIPTION
Adding alternative ssl domains support for certificates for private apis. This function is already integrated in the apps, apis and checkpoints. The objective is to provide an additional domain in the certificate for the specific private api.

Usage example:
```
        rarible:
          disk_size: 1200
          instance_type: e2-highcpu-8
          provisioning_model: STANDARD
          generate_external_ip: false
          firewall_source_ranges: ["0.0.0.0/0"]
          dns_names: [rarible]
          alternative_ssl_domains: 
            default: ["debridge.zq2-mainnet.zilliqa.com"]
          nodes:
          - count: 1
            region: asia-southeast1
```