### PR TITLE
feat: DEVOPS-77 throttle ips and custom rules in security policies

### DIFF
--- a/infra/tf/variables.tf
+++ b/infra/tf/variables.tf
@@ -79,14 +79,18 @@ variable "api" {
       os_images = optional(map(string), {})
     })), [])
     allow_ip_ranges = optional(map(object({
-      priority      = number
-      description   = string
-      src_ip_ranges = list(string)
+      priority         = number
+      description      = string
+      src_ip_ranges    = list(string)
+      action           = optional(string, "throttle")
+      rate_limit_count = optional(number, 30000)
     })), {})
     allow_custom_rules = optional(map(object({
-      priority    = number
-      description = string
-      expression  = string
+      priority         = number
+      description      = string
+      expression       = string
+      action           = optional(string, "throttle")
+      rate_limit_count = optional(number, 30000)
     })), {})
   })
   default = {}


### PR DESCRIPTION
Adding the throttling action option for the security policies IP and custom rules.

By default:
- action: throttling 
- rate limit count: 30000

On this configuration we can throttle the IPs and keys that by-pass the standard rate limit.

Also adding the parameter ban_duration_sec on the rate_limit_options, to avoid these rules to always recreate.