### PR TITLE
Reduce disk I/O for checkpoint

### DIFF
--- a/zilliqa/src/bin/convert-ckpt.rs
+++ b/zilliqa/src/bin/convert-ckpt.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
 
     let path = PathBuf::from(args.output.clone());
     let now = Instant::now();
-    println!("WRITE {}", args.output);
+    println!("WRITE {} -> {}", dbpath.display(), args.output);
     zilliqa::checkpoint::save_ckpt(
         path.as_path(),
         Arc::new(db.state_trie()?),

--- a/zilliqa/src/checkpoint.rs
+++ b/zilliqa/src/checkpoint.rs
@@ -1,6 +1,6 @@
 use std::{
     fs::File,
-    io::{BufReader, Read},
+    io::{BufReader, Read, Seek, Write},
     path::Path,
     sync::Arc,
 };
@@ -483,17 +483,27 @@ pub fn save_ckpt(
         bincode::encode_into_std_write(&serialised_account, &mut zipwriter, BIN_CONFIG)?;
 
         // iterate over account storage keys, and save them to the checkpoint file.
+        // use a single-pass strategy to reduce disk I/O and memory usage.
         let account_root = Account::try_from(serialised_account.as_slice())?.storage_root;
         let account_trie = EthTrie::new(trie_storage.clone()).at_root(account_root);
 
-        let count = account_trie.iter().count();
-        bincode::serde::encode_into_std_write(count, &mut zipwriter, BIN_CONFIG)?;
-
+        let mut count = 0;
+        // write to spooled file, avoiding OOM.
+        let mut spool = tempfile::spooled_tempfile(1024 * 1024);
         for (storage_key, storage_val) in account_trie.iter().flatten() {
-            bincode::encode_into_std_write(&storage_key, &mut zipwriter, BIN_CONFIG)?;
-            bincode::encode_into_std_write(&storage_val, &mut zipwriter, BIN_CONFIG)?;
-            record_count += 1;
+            bincode::encode_into_std_write(&storage_key, &mut spool, BIN_CONFIG)?;
+            bincode::encode_into_std_write(&storage_val, &mut spool, BIN_CONFIG)?;
+            count += 1;
         }
+        spool.flush()?; // flush data to spool
+
+        // copy account storage contents to zipfile
+        spool.rewind()?; // reset spool for reading
+        bincode::serde::encode_into_std_write(count, &mut zipwriter, BIN_CONFIG)?;
+        std::io::copy(&mut spool, &mut zipwriter)?; // copy to zipwriter
+
+        // increment counters
+        record_count += count;
         account_count += 1;
     }
 


### PR DESCRIPTION
The existing `save_ckpt()` function uses a 2-pass technique to save the state. I had assumed that the 1st pass should have loaded everything into the cache, allowing the 2nd pass to be *free* but empirical measurements showed a saturation of disk I/O on the node causing it to take an extremely long time to complete.

This PR alters the logic slightly to complete the process in 1-pass instead. It also introduces some memory optimisations to reduce memory growth - another issue that seemingly cropped up on checkpoint nodes. RocksDB uses up a bunch of *untracked* memory for a variety of things. Further optimisations are possible.

Before: 6h later than `v0.18.0`.
```xml
<Contents>
<Key>previous/012700800.ckpt</Key>
<Generation>1762412657131414</Generation>
<MetaGeneration>1</MetaGeneration>
<LastModified>2025-11-06T07:04:17.139Z</LastModified>
<ETag>"5bfd188582e076fc3e1bf04e44dbd7dd"</ETag>
<Size>494454710</Size>
</Contents>
<Contents>
<Key>previous/012700800.dat</Key>
<Generation>1762390133570602</Generation>
<MetaGeneration>1</MetaGeneration>
<LastModified>2025-11-06T00:48:53.627Z</LastModified>
<ETag>"acbb50aafb38825b3ece30828225848e"</ETag>
<Size>985126636</Size>
</Contents>
```

After: 45m earlier than `v0.18.0`
```xml
<Contents>
<Key>013132800.ckpt</Key>
<Generation>1762805550183318</Generation>
<MetaGeneration>1</MetaGeneration>
<LastModified>2025-11-10T20:12:30.189Z</LastModified>
<ETag>"67eb7e5d0d56896db659c099e6cec517"</ETag>
<Size>494624471</Size>
</Contents>
<Contents>
<Key>013132800.dat</Key>
<Generation>1762808260899763</Generation>
<MetaGeneration>1</MetaGeneration>
<LastModified>2025-11-10T20:57:40.908Z</LastModified>
<ETag>"32a983250f4e570cf4173a715d88f4fd"</ETag>
<Size>985326490</Size>
</Contents>
```

Although somewhat better, it still takes ~7h to generate a checkpoint. This should not be the case since a standalone `convert-ckpt` run takes less than 1h to do so.

But I'd like to get this PR in first while I continue to investigate the issue.