### PR TITLE
feat: DEVOPS-136 ulimits for zilliqa service

### DIFF
--- a/infra/ansible/playbooks/templates/zilliqa.sh.j2
+++ b/infra/ansible/playbooks/templates/zilliqa.sh.j2
@@ -7,7 +7,7 @@ SCILLA_SERVER_PORT="62831"
 start() {
     docker ps -a --filter "name=zilliqa-" --format "{{'{{'}}.ID{{'}}'}}" | xargs -r docker rm -f &> /dev/null || echo 0
     docker container prune -f
-    docker run -td -p 3333:3333/udp -p 4201:4201 -p 4202:4202 --cap-add=SYS_PTRACE --cap-add=PERFMON --cap-add=BPF --cap-add=SYS_ADMIN \
+    docker run --ulimit nofile=1000000:1000000 -td -p 3333:3333/udp -p 4201:4201 -p 4202:4202 --cap-add=SYS_PTRACE --cap-add=PERFMON --cap-add=BPF --cap-add=SYS_ADMIN \
         --net=host --name zilliqa-{{ zq2_version }} \
         -v /config.toml:/config.toml \
         -v /zilliqa.log:/zilliqa.log \

--- a/z2/resources/node_provision.tera.py
+++ b/z2/resources/node_provision.tera.py
@@ -93,7 +93,7 @@ ZQ2_IMAGE="{{ docker_image }}"
 start() {
     docker rm zilliqa-""" + VERSIONS.get('zilliqa') + """ &> /dev/null || echo 0
     docker container prune -f
-    docker run -td -p 3333:3333/udp -p 4201:4201 -p 4202:4202 --cap-add=SYS_PTRACE --cap-add=PERFMON --cap-add=BPF --cap-add=SYS_ADMIN \
+    docker run --ulimit nofile=1000000:1000000 -td -p 3333:3333/udp -p 4201:4201 -p 4202:4202 --cap-add=SYS_PTRACE --cap-add=PERFMON --cap-add=BPF --cap-add=SYS_ADMIN \
         --net=host --name zilliqa-""" + VERSIONS.get('zilliqa') + """ \
         -v /config.toml:/config.toml -v /zilliqa.log:/zilliqa.log -v /data:/data \
         --log-driver json-file --log-opt max-size=1g --log-opt max-file=1 --memory=6g \


### PR DESCRIPTION
We need to override the default resource limits to allow the Docker container to open more files. Required to avoid IO errors for RocksDB.