### PR TITLE
Rocksdb - some quality of life improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5597,6 +5597,7 @@ dependencies = [
  "cc",
  "libc",
  "libz-sys",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -9196,6 +9197,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]

--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -33,7 +33,6 @@ do_checkpoints=true
 consensus.blocks_per_epoch=3600
 consensus.epochs_per_checkpoint=24
 # Reduce cache sizes, to prevent OOM.
-state_cache_size = 536870912
 db.conn_cache_size = 128
 {%- endif %}
 

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -116,10 +116,7 @@ dashmap = "6.1.0"
 sled = { version = "0.34.7", features = ["no_logs"] }
 r2d2 = "0.8.10"
 r2d2_sqlite = "0.31.0"
-rocksdb = { version = "0.24.0", default-features = false, features = [
-    "bindgen-runtime",
-    "snappy",
-] }
+rocksdb = { version = "0.24.0", default-features = false, features = ["bindgen-runtime", "jemalloc", "snappy"] }
 zip = { version = "5.1.1", default-features = false, features = ["zstd"] }
 eth_trie = { git = "https://github.com/Zilliqa/eth-trie.rs.git", branch = "zilliqa" }
 arc-swap = "1.7.1"

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -175,14 +175,21 @@ pub struct DbConfig {
     /// RocksDB block cache size, in bytes.
     #[serde(default = "rocksdb_cache_size_default")]
     pub rocksdb_cache_size: usize,
+    /// RocksDB periodic compaction seconds.
+    #[serde(default = "rocksdb_compaction_period_default")]
+    pub rocksdb_compaction_period: u64,
+}
+
+fn rocksdb_compaction_period_default() -> u64 {
+    86_400 * 7 // weekly expiry
 }
 
 fn rocksdb_cache_size_default() -> usize {
-    256 * 1024 * 1024
+    1024 * 1024 * 1024 // 1GB default
 }
 
 fn sql_cache_size_default() -> usize {
-    8_192
+    4_096 // 128MB default
 }
 
 fn sql_auto_checkpoint_default() -> usize {
@@ -196,6 +203,7 @@ impl Default for DbConfig {
             auto_checkpoint: sql_auto_checkpoint_default(),
             state_sync: false,
             rocksdb_cache_size: rocksdb_cache_size_default(),
+            rocksdb_compaction_period: rocksdb_compaction_period_default(),
         }
     }
 }

--- a/zilliqa/src/checkpoint.rs
+++ b/zilliqa/src/checkpoint.rs
@@ -474,7 +474,8 @@ pub fn save_ckpt(
     // iterate over accounts and save the accounts to the checkpoint file.
     // do not save intermediate state trie values.
     let state_trie = EthTrie::new(trie_storage.clone()).at_root(parent.state_root_hash().into());
-    for (key, serialised_account) in state_trie.iter().flatten() {
+    for akv in state_trie.iter() {
+        let (key, serialised_account) = akv?;
         if account_count % 10000 == 0 {
             tracing::debug!(account=%account_count, record=%record_count, "Saved");
         }
@@ -490,7 +491,8 @@ pub fn save_ckpt(
         let mut count = 0;
         // write to spooled file, avoiding OOM.
         let mut spool = tempfile::spooled_tempfile(1024 * 1024);
-        for (storage_key, storage_val) in account_trie.iter().flatten() {
+        for skv in account_trie.iter() {
+            let (storage_key, storage_val) = skv?;
             bincode::encode_into_std_write(&storage_key, &mut spool, BIN_CONFIG)?;
             bincode::encode_into_std_write(&storage_val, &mut spool, BIN_CONFIG)?;
             count += 1;

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -326,6 +326,14 @@ impl Db {
         let mut block_opts = BlockBasedOptions::default();
         // reduce disk and memory usage - https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter#ribbon-filter
         block_opts.set_ribbon_filter(10.0);
+        // reduce cache eviction for index/filter blocks
+        block_opts.set_cache_index_and_filter_blocks(true);
+        block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
+        // reduce block wastage
+        // Percentiles: P50: 414.93 P75: 497.53 P99: 576.82 P99.9: 579.79 P99.99: 12678.76
+        block_opts.set_block_size(1 << 10); // 1KB covers > 99.9% of data (4KB - default)
+        // reduce memory wastage with JeMalloc
+        block_opts.set_optimize_filters_for_memory(true);
 
         let cache = Cache::new_lru_cache(config.rocksdb_cache_size);
         if config.rocksdb_cache_size == 0 {
@@ -337,6 +345,9 @@ impl Db {
         let mut rdb_opts = Options::default();
         rdb_opts.create_if_missing(true);
         rdb_opts.set_block_based_table_factory(&block_opts);
+        // https://github.com/facebook/rocksdb/wiki/Leveled-Compaction#level_compaction_dynamic_level_bytes-is-true-recommended-default-since-version-84
+        rdb_opts.set_level_compaction_dynamic_level_bytes(true);
+        rdb_opts.set_periodic_compaction_seconds(config.rocksdb_compaction_period);
 
         // Should be safe in single-threaded mode
         // https://docs.rs/rocksdb/latest/rocksdb/type.DB.html#limited-performance-implication-for-single-threaded-mode


### PR DESCRIPTION
Some Rocksdb tuning:
1. Use Jemalloc allocator to mitigate memory-leaks that were causing the node to OOM from time to time.
2. Turned on background compaction to compact the database regularly.
3. Default block size is 4KB. Statistics show that 99.9% of state is under 1KB. Block size reduced to 1KB.
4. Other tuning parameters.