### PR TITLE
feat: DEVOPS-151 start persistence backup if node is synced

### DIFF
--- a/infra/ansible/playbooks/templates/persistence.py.j2
+++ b/infra/ansible/playbooks/templates/persistence.py.j2
@@ -36,7 +36,11 @@ logger = cloud_logging_client.logger(CONFIG['log_name'])
 def log_message(message: str, level: str = 'INFO') -> None:
     """Log message to Google Cloud Logging."""
     log_level = getattr(logging, level.upper())
-    logger.log_text(message, severity=level)
+    logger.log_text(
+        message, 
+        severity=level,
+        labels={"service": "persistence"}
+    )
     print(f"[{level}] {message}")
 
 def acquire_lock() -> bool:
@@ -77,6 +81,29 @@ def get_current_block() -> Optional[int]:
     except Exception as e:
         log_message(f"Failed to get current block: {str(e)}", "ERROR")
         return None
+
+def is_node_synced() -> bool:
+    """Return True if node is synced (eth_syncing result is False), else False."""
+    try:
+        response = requests.post(
+            CONFIG['rpc_endpoint'],
+            json={
+                "jsonrpc": "2.0",
+                "method": "eth_syncing",
+                "params": [],
+                "id": 1
+            },
+            timeout=10
+        )
+        response.raise_for_status()
+        result = response.json()
+        syncing_status = result.get('result')
+        if syncing_status is False:
+            return True
+        return False
+    except Exception as e:
+        log_message(f"Failed to check node sync status: {str(e)}", "ERROR")
+        return False
 
 def get_last_backup_block() -> Optional[int]:
     """Get last backup block number from state file."""
@@ -169,6 +196,10 @@ def perform_backup(block_number: int) -> bool:
     start_time = time.time()
     log_message(f"Starting backup process at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} at block {block_number}")
     
+    if not is_node_synced():
+        log_message("Skipping backup: node is not fully synced", "WARNING")
+        return False
+
     if not stop_zilliqa_service():
         return False
     


### PR DESCRIPTION
- Verifying if the node is syncing to start the backup. If not, it will skip until the next block attempt.
- Adding an identifier to the persistence backup logs (labels=service). Right now there is no way to filter the origin of the logs, and labels is supported by the cloud_logging object.

Tests:
1. By installing the new code and the node was synced the process went normal.
2. By installing the new code and the node wasn't synced:
 
The persistence backup didn't start.
<img width="766" height="502" alt="image" src="https://github.com/user-attachments/assets/76626b6b-e434-4e12-a6a2-f839adc0a2ab" />

Zilliqa process kept running. 
<img width="370" height="47" alt="image" src="https://github.com/user-attachments/assets/8aa149b3-bd0b-45fa-bab4-f337beba8cda" />

Backup was not created.
<img width="232" height="95" alt="image" src="https://github.com/user-attachments/assets/f5261fb0-d634-4e6c-b1dc-cb22814ca339" />
