### PR TITLE
Fix "unable to verify block" issue

### DIFF
--- a/z2/resources/chain-specs/zq2-testnet.toml
+++ b/z2/resources/chain-specs/zq2-testnet.toml
@@ -90,6 +90,7 @@ consensus.forks = [
     { at_height = 11300000, inject_access_list = true, use_max_gas_priority_fee = true },
     { at_height = 12998790, failed_zil_transfers_to_eoa_proper_fee_deduction = true },
     { at_height = 14997600, validator_jailing = true },
-    { at_height = 99999999, scilla_empty_maps_are_encoded_correctly = true },
-    { at_height = 99999999, cancun_active = true },
+    { at_height = 23080419, scilla_empty_maps_are_encoded_correctly = true },
+    { at_height = 23080419, cancun_active = true },
+
 ]

--- a/z2/src/chain.rs
+++ b/z2/src/chain.rs
@@ -268,9 +268,9 @@ impl Chain {
                 // estimated: 2025-09-19T12.00.00Z
                 json!({ "at_height": 14997600, "validator_jailing": true}),
                 // estimated: 2026-01-07T11.00.00Z
-                json!({ "at_height": 99999999, "scilla_empty_maps_are_encoded_correctly": true}),
+                json!({ "at_height": 23080419, "scilla_empty_maps_are_encoded_correctly": true}),
                 // estimated: 2026-01-07T11.00.00Z
-                json!({ "at_height": 99999999, "cancun_active": true}),
+                json!({ "at_height": 23080419, "cancun_active": true}),
             ]),
             Chain::Zq2Mainnet => Some(vec![
                 json!({ "at_height": 4770088, "executable_blocks": true }),


### PR DESCRIPTION
There is a subtle regression that caused the in-memory view history to not be written to disk. This PR fixes this specific issue.