### PR TITLE
feat: DEVOPS-180 workflows switch to hosted gha runner

### DIFF
--- a/.github/workflows/backfill_benchmarks.yaml
+++ b/.github/workflows/backfill_benchmarks.yaml
@@ -16,7 +16,7 @@ on:
 jobs:
   backfill_benchmarks:
     name: Backfill Benchmarks
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-16-cores
     timeout-minutes: 2880
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/base_benchmarks.yaml
+++ b/.github/workflows/base_benchmarks.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Continuous Benchmarking
     permissions:
       checks: write
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
           file_pattern: "*.sol"
           status_options: "--untracked-files=no"
   check:
-    runs-on: [self-hosted, gcp]
+    runs-on: ubuntu-latest-16-cores
     steps:
       - name: Install Rust
         run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/.github/workflows/docker-release.yaml
+++ b/.github/workflows/docker-release.yaml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
       contents: write
     if: ${{ github.ref_name != 'main' && github.ref_type == 'tag' }} 
-    runs-on: [ self-hosted, gcp]
+    runs-on: ubuntu-latest-16-cores
     env:
       GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
       GCP_REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-public
@@ -62,7 +62,7 @@ jobs:
         id-token: write
         contents: write
       if: ${{ github.ref_name == 'main' }} || ${{ github.event_name == 'workflow_dispatch' }}
-      runs-on: [ self-hosted, gcp]
+      runs-on: ubuntu-latest-16-cores
       env:
         GCP_REGISTRY_DOMAIN: asia-docker.pkg.dev
         GCP_REGISTRY: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private

--- a/.github/workflows/pr_benchmarks.yaml
+++ b/.github/workflows/pr_benchmarks.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       pull-requests: write
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-16-cores
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/test_performance.yaml
+++ b/.github/workflows/test_performance.yaml
@@ -68,7 +68,7 @@ jobs:
       id-token: write
       contents: write
     name: Jmeter test
-    runs-on: self-hosted
+    runs-on: ubuntu-latest-16-cores
     container:
       image: alpine/jmeter:5.6
     if: github.actor != 'dependabot[bot]'


### PR DESCRIPTION
Based on the findings of https://linear.app/zilliqa/issue/DEVOPS-171/resize-self-hosted-runners we are moving the zq2 workloads to the hosted 16 core runners.