### PR TITLE
Disable balance check for estimate/calls

### DIFF
--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -60,6 +60,7 @@ rand_chacha = "0.3.1"
 revm = { version = "29.0.0", features = [
     "optional_eip3607",
     "optional_no_base_fee",
+    "optional_balance_check"
 ] }
 revm-inspectors = { version = "0.30.1", features = ["js-tracer"] }
 revm-precompile = "27.0.0"

--- a/zilliqa/src/exec.rs
+++ b/zilliqa/src/exec.rs
@@ -630,6 +630,10 @@ impl State {
                     BaseFeeAndNonceCheck::Validate => false,
                     BaseFeeAndNonceCheck::Ignore => true,
                 };
+                cfg.disable_balance_check = match base_fee_and_nonce_check {
+                    BaseFeeAndNonceCheck::Validate => false,
+                    BaseFeeAndNonceCheck::Ignore => true,
+                };
                 cfg
             })
             .with_block(BlockEnv {


### PR DESCRIPTION
For estimates and  pure calls we shouldn't check the sender balance.