### PR TITLE
Improve read performance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10958,6 +10958,7 @@ dependencies = [
  "jsonrpsee 0.25.1",
  "k256",
  "libp2p",
+ "lru 0.16.3",
  "lz4",
  "once_cell",
  "opentelemetry",

--- a/z2/resources/config.tera.toml
+++ b/z2/resources/config.tera.toml
@@ -1,6 +1,5 @@
 network = "{{ network }}"
 p2p_port = 3333
-
 bootstrap_address = {{ bootstrap_address }}
 
 [[nodes]]
@@ -38,18 +37,15 @@ consensus.epochs_per_checkpoint=24
 sync.ignore_passive = true
 {%- endif %}
 {%- if role == "private-api" %}
-db.rocksdb_cache_size = 3758096384
 db.rocksdb_cache_index_filters = true
 sync.ignore_passive = true
 max_missed_view_age = 1000000000000
 {%- endif %}
 {%- if role == "api" %}
-db.rocksdb_cache_size = 3758096384
 db.rocksdb_cache_index_filters = true
 max_missed_view_age = 1000000000000
 {%- endif %}
 {%- if role == "opsnode" %}
-db.rocksdb_cache_size = 3758096384
 db.rocksdb_cache_index_filters = true
 max_missed_view_age = 1000000000000
 {%- endif %}

--- a/zilliqa/Cargo.toml
+++ b/zilliqa/Cargo.toml
@@ -115,6 +115,7 @@ arc-swap = "1.8.0"
 redis = { version = "0.32.7", features = ["keep-alive", "r2d2", "tcp_nodelay"], default-features = false }
 alloy = { version = "1.4.3", default-features = false, features = ["consensus", "dyn-abi", "eips", "json-abi", "k256", "rlp", "rpc-types", "rpc-types-trace", "serde", "sol-types"] }
 crossbeam = "0.8.4"
+lru = "0.16.3"
 
 [dev-dependencies]
 alloy = { version = "1.4.3", default-features = false, features = ["consensus", "dyn-abi", "eips", "json-abi", "k256", "rlp", "rpc-types", "rpc-types-trace", "serde", "sol-types", "pubsub", "json-rpc", "contract", "signer-local"] }

--- a/zilliqa/src/cfg.rs
+++ b/zilliqa/src/cfg.rs
@@ -1,9 +1,4 @@
-use std::{
-    collections::HashMap,
-    ops::{Deref, Div},
-    str::FromStr,
-    time::Duration,
-};
+use std::{collections::HashMap, ops::Deref, str::FromStr, time::Duration};
 
 use alloy::{primitives::Address, rlp::Encodable};
 use anyhow::{Result, anyhow};
@@ -50,9 +45,8 @@ pub struct Config {
 }
 
 pub fn slow_rpc_queries_handlers_count_default() -> usize {
-    // half the workers; or 1
-    let num_workers = crate::tokio_worker_count();
-    num_workers.div(2).max(1)
+    let n = crate::available_threads().saturating_sub(1);
+    n.max(4)
 }
 
 #[derive(Debug, Clone)]
@@ -192,6 +186,23 @@ pub struct DbConfig {
     /// RocksDB cache index/filters
     #[serde(default = "rocksdb_cache_index_filters_default")]
     pub rocksdb_cache_index_filters: bool,
+    /// State cache size
+    #[serde(default = "rocksdb_state_cache_size_default")]
+    pub rocksdb_state_cache_size: usize,
+    /// Block size
+    #[serde(default = "rocksdb_block_size_default")]
+    pub rocksdb_block_size: usize,
+    /// Target File Size
+    #[serde(default = "rocksdb_target_file_size_default")]
+    pub rocksdb_target_file_size: u64,
+}
+
+fn rocksdb_block_size_default() -> usize {
+    1 << 14 // 16KB reduces in-memory indexes
+}
+
+fn rocksdb_target_file_size_default() -> u64 {
+    1 << 28 // 256MB reduces number of open files
 }
 
 fn rocksdb_cache_index_filters_default() -> bool {
@@ -207,7 +218,11 @@ fn rocksdb_compaction_period_default() -> u64 {
 }
 
 fn rocksdb_cache_size_default() -> usize {
-    1024 * 1024 * 1024 // 1GB is enough for normal nodes
+    1 << 30 // 1GB is enough for normal nodes
+}
+
+fn rocksdb_state_cache_size_default() -> usize {
+    1 << 31
 }
 
 fn sql_cache_size_default() -> usize {
@@ -228,6 +243,9 @@ impl Default for DbConfig {
             rocksdb_compaction_period: rocksdb_compaction_period_default(),
             rocksdb_max_open_files: rocksdb_max_open_files_default(),
             rocksdb_cache_index_filters: rocksdb_cache_index_filters_default(),
+            rocksdb_state_cache_size: rocksdb_state_cache_size_default(),
+            rocksdb_block_size: rocksdb_block_size_default(),
+            rocksdb_target_file_size: rocksdb_target_file_size_default(),
         }
     }
 }
@@ -360,7 +378,7 @@ impl NodeConfig {
 
         anyhow::ensure!(
             self.state_cache_size == state_cache_size_default(),
-            "state_cache_size is deprecated. Use db.rocksdb_cache_size instead."
+            "state_cache_size is deprecated. Use db.rocksdb_cache_size and db.rocksdb_state_cache_size instead."
         );
 
         anyhow::ensure!(

--- a/zilliqa/src/checkpoint.rs
+++ b/zilliqa/src/checkpoint.rs
@@ -480,7 +480,7 @@ pub fn save_ckpt(
 
     let mut account_count = u64::MIN;
     let mut record_count = u64::MIN;
-    let num_workers = crate::tokio_worker_count().max(1) * 2; // 2 x CPUs
+    let num_workers = crate::available_threads().max(1) * 2; // 2 x CPUs
     let (work_tx, work_rx) = crossbeam::channel::bounded::<(Vec<u8>, Vec<u8>)>(num_workers * 2); // 2 x Threads
     let (blob_tx, blob_rx) = crossbeam::channel::bounded::<AccountBlob>(num_workers * 2); // 2 x Threads
 

--- a/zilliqa/src/credits/rpc_credit_store.rs
+++ b/zilliqa/src/credits/rpc_credit_store.rs
@@ -25,7 +25,7 @@ impl RpcCreditStore {
 
         // spin up redis connection pool
         let pool = uri.as_ref().and_then(|url| {
-            let num_workers = crate::tokio_worker_count().max(4) as u32;
+            let num_workers = crate::available_threads().max(4) as u32;
             Pool::builder()
                 .max_size(num_workers * 2)
                 .min_idle(Some(1))

--- a/zilliqa/src/db.rs
+++ b/zilliqa/src/db.rs
@@ -3,6 +3,7 @@ use std::{
     fmt::Debug,
     fs::{self, OpenOptions},
     io::{Read, Seek, SeekFrom, Write},
+    num::NonZeroUsize,
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::Arc,
@@ -13,6 +14,8 @@ use alloy::primitives::Address;
 use anyhow::{Context, Result, anyhow};
 #[allow(unused_imports)]
 use eth_trie::{DB, EthTrie, MemoryDB, Trie};
+use lru::LruCache;
+use parking_lot::RwLock;
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
 use rocksdb::{BlockBasedOptions, Cache, DBWithThreadMode, Options, SingleThreaded};
@@ -31,7 +34,7 @@ use crate::{
     precompiles::ViewHistory,
     time::SystemTime,
     transaction::{EvmGas, Log, SignedTransaction, TransactionReceipt, VerifiedTransaction},
-    trie_storage::{BLOCK_SIZE, TrieStorage},
+    trie_storage::TrieStorage,
 };
 
 const MAX_KEYS_IN_SINGLE_QUERY: usize = 32765;
@@ -246,6 +249,7 @@ const CURRENT_DB_VERSION: &str = "1";
 pub struct Db {
     pool: Arc<Pool<SqliteConnectionManager>>,
     kvdb: Arc<rocksdb::DB>,
+    cache: Arc<RwLock<LruCache<Vec<u8>, Vec<u8>>>>,
     path: Option<Box<Path>>,
     /// The block height at which ZQ2 blocks begin.
     /// This value should be required only for proto networks to distinguise between ZQ1 and ZQ2 blocks.
@@ -299,7 +303,7 @@ impl Db {
         };
 
         // Build connection pool
-        let num_workers = crate::tokio_worker_count().max(4) as u32;
+        let num_workers = crate::available_threads().max(4) as u32;
         let builder = Pool::builder().min_idle(Some(1)).max_size(num_workers * 2); // more than enough connections
         debug!("SQLite {builder:?}");
 
@@ -311,26 +315,31 @@ impl Db {
         let mut block_opts = BlockBasedOptions::default();
         // reduce disk and memory usage - https://github.com/facebook/rocksdb/wiki/RocksDB-Bloom-Filter#ribbon-filter
         block_opts.set_ribbon_filter(10.0);
-        block_opts.set_block_size(BLOCK_SIZE);
         block_opts.set_optimize_filters_for_memory(true); // reduce memory wastage with JeMalloc
         // Mitigate OOM
         block_opts.set_cache_index_and_filter_blocks(config.rocksdb_cache_index_filters);
         // Improve cache utilisation
         block_opts.set_pin_top_level_index_and_filter(true);
         block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
-        block_opts.set_partition_filters(true);
         block_opts.set_index_type(rocksdb::BlockBasedIndexType::TwoLevelIndexSearch);
-        block_opts.set_metadata_block_size(BLOCK_SIZE);
+        block_opts.set_partition_filters(true);
+        block_opts.set_block_size(config.rocksdb_block_size);
+        block_opts.set_metadata_block_size(config.rocksdb_block_size);
 
-        let cache = Cache::new_hyper_clock_cache(config.rocksdb_cache_size, BLOCK_SIZE); // set this to the block size
+        let cache =
+            Cache::new_hyper_clock_cache(config.rocksdb_cache_size, config.rocksdb_block_size);
         block_opts.set_block_cache(&cache);
 
         let mut rdb_opts = Options::default();
         rdb_opts.create_if_missing(true);
         rdb_opts.set_block_based_table_factory(&block_opts);
         rdb_opts.set_periodic_compaction_seconds(config.rocksdb_compaction_period);
-        // Mitigate OOM
-        rdb_opts.set_max_open_files(config.rocksdb_max_open_files); // prevent opening too many files at a time
+        // Mitigate OOM - prevent opening too many files at a time
+        rdb_opts.set_max_open_files(config.rocksdb_max_open_files);
+        // Reduce reads
+        rdb_opts.set_level_compaction_dynamic_level_bytes(true);
+        rdb_opts.set_target_file_size_base(config.rocksdb_target_file_size);
+        rdb_opts.set_max_bytes_for_level_base(config.rocksdb_target_file_size << 2);
 
         // Should be safe in single-threaded mode
         // https://docs.rs/rocksdb/latest/rocksdb/type.DB.html#limited-performance-implication-for-single-threaded-mode
@@ -346,11 +355,16 @@ impl Db {
             rdb.latest_sequence_number()
         );
 
+        // Percentiles: P50: 414.93 P75: 497.53 P99: 576.82 P99.9: 579.79 P99.99: 12678.76
+        let cache =
+            LruCache::new(NonZeroUsize::new(config.rocksdb_state_cache_size / 500).unwrap());
+
         Ok(Db {
             pool: Arc::new(pool),
             path,
             executable_blocks_height,
             kvdb: Arc::new(rdb),
+            cache: Arc::new(RwLock::new(cache)),
             config,
         })
     }
@@ -790,7 +804,11 @@ impl Db {
     }
 
     pub fn state_trie(&self) -> Result<TrieStorage> {
-        Ok(TrieStorage::new(self.pool.clone(), self.kvdb.clone()))
+        Ok(TrieStorage::new(
+            self.pool.clone(),
+            self.kvdb.clone(),
+            self.cache.clone(),
+        ))
     }
 
     pub fn with_sqlite_tx(&self, operations: impl FnOnce(&Connection) -> Result<()>) -> Result<()> {

--- a/zilliqa/src/lib.rs
+++ b/zilliqa/src/lib.rs
@@ -34,8 +34,6 @@ pub mod transaction;
 pub mod trie_storage;
 pub mod zq1_proto;
 
-pub fn tokio_worker_count() -> usize {
-    tokio::runtime::Handle::try_current()
-        .map(|h| h.metrics().num_workers())
-        .unwrap_or_default()
+pub fn available_threads() -> usize {
+    std::thread::available_parallelism().unwrap().get()
 }


### PR DESCRIPTION
Example of a super long query:

Before:
```json
{"timestamp":"2026-01-30T06:41:24.768160Z","level":"ERROR","fields":{"message":"API Call long: GetSmartContractStateParams(Some(\"[\\\"31bFa2054\\\"]\")), took 459.764517668s"},"target":"zilliqa::api::zilliqa","line_number":61}
...
{"timestamp":"2026-01-30T06:55:17.466469Z","level":"ERROR","fields":{"message":"API Call long: GetSmartContractStateParams(Some(\"[\\\"31bFa2054\\\"]\")), took 398.520538661s"},"target":"zilliqa::api::zilliqa","line_number":61}
```

After:
```json
{"timestamp":"2026-02-03T06:08:21.248804Z","level":"ERROR","fields":{"message":"API Call long: GetSmartContractStateParams(Some(\"[\\\"31bFa2054\\\"]\")), took 268.935526205s"},"target":"zilliqa::api::zilliqa","line_number":61}
```