### PR TITLE
feat: DEVOPS-63 block project-wide ssh access

### DIFF
--- a/infra/tf/modules/node/main.tf
+++ b/infra/tf/modules/node/main.tf
@@ -136,6 +136,7 @@ resource "google_compute_instance" "this" {
     {
       "enable-guest-attributes" = "TRUE"
       "enable-osconfig"         = "TRUE"
+      "block-project-ssh-keys"  = "TRUE"
     },
     var.metadata,
   )


### PR DESCRIPTION
Since we are already using Identity-Aware Proxy (IAP), blocking these keys is the natural next step to align with a Zero-Trust security model.