### PR TITLE
fix: DEVOPS-291 add swap configuration to prevent cascading OOM kills

### DIFF
--- a/infra/ansible/playbooks/configure_swap.yml
+++ b/infra/ansible/playbooks/configure_swap.yml
@@ -37,7 +37,10 @@
         cmd: swapon {{ swap_file_path }}
       register: swapon_result
       changed_when: swapon_result.rc == 0
-      failed_when: swapon_result.rc != 0 and 'already' not in (swapon_result.stderr | default(''))
+      failed_when: >-
+        swapon_result.rc != 0
+        and 'already' not in (swapon_result.stderr | default(''))
+        and 'busy' not in (swapon_result.stderr | default(''))
 
     - name: Add swap to fstab
       ansible.builtin.lineinfile:

--- a/infra/ansible/playbooks/configure_swap.yml
+++ b/infra/ansible/playbooks/configure_swap.yml
@@ -1,0 +1,54 @@
+---
+- name: Configure swap space
+  hosts: all:!role_apps
+  become: true
+  tags:
+    - install
+    - all
+
+  vars:
+    swap_file_path: /swapfile
+    swap_file_size_mb: 4096
+    vm_swappiness: 10
+
+  tasks:
+    - name: Check if swap file exists
+      ansible.builtin.stat:
+        path: "{{ swap_file_path }}"
+      register: swap_file
+
+    - name: Create swap file
+      ansible.builtin.command:
+        cmd: fallocate -l {{ swap_file_size_mb }}M {{ swap_file_path }}
+      when: not swap_file.stat.exists
+
+    - name: Set swap file permissions
+      ansible.builtin.file:
+        path: "{{ swap_file_path }}"
+        mode: '0600'
+
+    - name: Format swap file
+      ansible.builtin.command:
+        cmd: mkswap {{ swap_file_path }}
+      when: not swap_file.stat.exists
+
+    - name: Enable swap file
+      ansible.builtin.command:
+        cmd: swapon {{ swap_file_path }}
+      register: swapon_result
+      changed_when: swapon_result.rc == 0
+      failed_when: swapon_result.rc != 0 and 'already' not in (swapon_result.stderr | default(''))
+
+    - name: Add swap to fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        line: "{{ swap_file_path }} none swap sw 0 0"
+        state: present
+
+    - name: Set vm.swappiness
+      ansible.posix.sysctl:
+        name: vm.swappiness
+        value: "{{ vm_swappiness }}"
+        state: present
+        sysctl_set: true
+        reload: true

--- a/infra/ansible/playbooks/node_provision.yml
+++ b/infra/ansible/playbooks/node_provision.yml
@@ -3,6 +3,9 @@
 - name: Required packages installation
   ansible.builtin.import_playbook: install_packages.yml
 
+- name: Swap space configuration
+  ansible.builtin.import_playbook: configure_swap.yml
+
 - name: Mount data disk
   ansible.builtin.import_playbook: mount_data_disk.yml
 


### PR DESCRIPTION
## Summary
- Adds `infra/ansible/playbooks/configure_swap.yml` that creates a 4 GB swap file with `swappiness=10`
- Integrates into `node_provision.yml` early in the provisioning flow (before Docker/Zilliqa)
- Prevents cascading system service kills (sshd, journald, resolved) when the Zilliqa container is OOM-killed

## Context
`zq2-mainnet-api-ase1-8` became unreachable on 2026-04-06 after the Zilliqa container (v0.21.0-alpha3) hit its 7 GB cgroup memory limit. The OOM kill cascaded into system-wide memory pressure that killed sshd, journald, and resolved, requiring a manual stop/start. Swap provides a safety buffer so system services survive container OOM events.

## Test plan
- [x] Run playbook on a test VM: `ansible-playbook configure_swap.yml`
- [x] Verify swap is active: `swapon --show` and `free -h`
- [x] Verify persistence: reboot VM and confirm swap is still active
- [x] Verify idempotency: run playbook again, no errors or changes

Ref: DEVOPS-291