### PR TITLE
fix: DEVOPS-292 handle RPC errors in healthcheck to prevent TypeError crash

### DIFF
--- a/infra/ansible/playbooks/templates/healthcheck.py.j2
+++ b/infra/ansible/playbooks/templates/healthcheck.py.j2
@@ -21,7 +21,12 @@ def get_rpc_response(method, params=[]):
         response = requests.post(NODE_URL, json=payload, headers=HEADERS, timeout=3)
         response.raise_for_status()
         response_json = response.json()
-        return response_json.get("result")
+        if "error" in response_json:
+            return (f"RPC error in {method}: {response_json['error'].get('message', 'unknown')}", 0)
+        result = response_json.get("result")
+        if result is None:
+            return (f"No result in RPC response for {method}", 0)
+        return result
     except requests.exceptions.RequestException as e:
         # Handle connection errors, timeouts, and HTTP errors
         return (f"Request error in {method}: {e}", 0)
@@ -37,6 +42,12 @@ def check_sync_status():
     # Query eth_blockNumber and eth_syncing
     block_number_hex = get_rpc_response("eth_blockNumber")
     sync_status = get_rpc_response("eth_syncing")
+
+    # Handle RPC errors
+    if isinstance(block_number_hex, tuple):
+        return jsonify({"error": f"Failed to get block number: {block_number_hex[0]}", "code": 503}), 503
+    if isinstance(sync_status, tuple):
+        return jsonify({"error": f"Failed to get sync status: {sync_status[0]}", "code": 503}), 503
 
     # Convert hex block number to integer
     block_number = int(block_number_hex, 16)
@@ -71,6 +82,8 @@ def check_pace_status():
     global pace_latest_block_number, pace_latest_block_number_obtained_at
 
     block_number_hex = get_rpc_response("eth_blockNumber")
+    if isinstance(block_number_hex, tuple):
+        return jsonify({"error": f"Failed to get block number: {block_number_hex[0]}", "code": 503}), 503
     block_number = int(block_number_hex, 16)
 
     current_time = time()


### PR DESCRIPTION
## Summary
- Hardens `get_rpc_response()` to return error tuples for RPC error responses and `None` results
- Adds tuple guards in `check_sync_status()` and `check_pace_status()` before `int(x, 16)` calls
- No logic changes to callers; all original response codes and branching preserved

## Context
The `/health` endpoint on `zq2-mainnet-api-ase1-8` was crashing with `TypeError: int() can't convert non-string with explicit base` after the Zilliqa node restarted following an OOM kill. The RPC was unreachable during startup, causing `get_rpc_response()` to return error tuples (or `None`), which were passed directly to `int()`. This made the load balancer mark the backend as unhealthy even after the node recovered.

`check_checkpoint_status()` already had this guard; the fix brings `check_sync_status()` and `check_pace_status()` to parity. The `None` gap was identified via Gemini second opinion.

## Test plan
- [x] Deploy healthcheck to a test node via Ansible
- [x] Verify healthy node returns 200: `curl http://localhost:8080/health`
- [x] Stop zilliqa container, verify 503 (not 500/crash): `curl http://localhost:8080/health`
- [x] Start zilliqa container, verify returns to 200 after sync

Ref: DEVOPS-292