### PR TITLE
Skip invalid early proposal

### DIFF
--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -1885,24 +1885,6 @@ impl Consensus {
         Ok(inserted)
     }
 
-    pub fn try_early_proposal_after_txn_batch(&self) -> Result<()> {
-        if self.create_next_block_on_timeout.load(Ordering::SeqCst) {
-            let early_proposal = self.early_proposal.write();
-            if early_proposal.is_some() {
-                let pool = self.transaction_pool.write();
-                if pool.has_txn_ready() {
-                    trace!(
-                        "add transaction to early proposal {}",
-                        early_proposal.as_ref().unwrap().0.header.view
-                    );
-
-                    self.early_proposal_apply_transactions(pool, early_proposal)?;
-                }
-            }
-        }
-        Ok(())
-    }
-
     /// Provides a (cached) preview of the early proposal.
     pub fn get_pending_block(&self) -> Result<Option<Block>> {
         if let Some(early_proposal) = self.early_proposal.read().as_ref()
@@ -2136,9 +2118,9 @@ impl Consensus {
             return Ok(TxAddResult::Duplicate(txn.hash));
         }
 
-        // Perform insertion under early state, if available
+        // Perform insertion under early state, if available and recent
         let early_account = match self.early_proposal.read().as_ref() {
-            Some((block, _, _, _, _)) => {
+            Some((block, _, _, _, _)) if block.view() == self.get_view()? => {
                 let state = self.state.at_root(block.state_root_hash().into());
                 state.get_account(txn.signer)?
             }

--- a/zilliqa/src/consensus.rs
+++ b/zilliqa/src/consensus.rs
@@ -2118,14 +2118,8 @@ impl Consensus {
             return Ok(TxAddResult::Duplicate(txn.hash));
         }
 
-        // Perform insertion under early state, if available and recent
-        let early_account = match self.early_proposal.read().as_ref() {
-            Some((block, _, _, _, _)) if block.view() == self.get_view()? => {
-                let state = self.state.at_root(block.state_root_hash().into());
-                state.get_account(txn.signer)?
-            }
-            _ => self.state.get_account(txn.signer)?,
-        };
+        // Perform insertion under present state - https://github.com/Zilliqa/zq2/issues/3596
+        let early_account = self.state.get_account(txn.signer)?;
 
         let eth_chain_id = self.config.eth_chain_id;
 

--- a/zilliqa/src/node.rs
+++ b/zilliqa/src/node.rs
@@ -309,10 +309,6 @@ impl Node {
         Ok(())
     }
 
-    pub fn try_to_apply_transactions(&mut self) -> Result<()> {
-        self.consensus.write().try_early_proposal_after_txn_batch()
-    }
-
     pub fn handle_request(
         &self,
         from: PeerId,


### PR DESCRIPTION
On an API node, the pending block only gets updated when manually triggered by an appropriate call. A new transaction is validated against the state in the pending block. So, stale state is used to validate transactions upon submission. This PR ignores the pending block and always checks against the present state.

This issue surfaced on `devnet` because it does not get much traffic and the pending block does not get updated regularly.