### PR TITLE
infra: add testnode role for playground VMs (DEVOPS-315)

### DIFF
--- a/infra/ansible/group_vars/network_playground/all.yml
+++ b/infra/ansible/group_vars/network_playground/all.yml
@@ -1,0 +1,26 @@
+---
+# Group vars for playground testnodes (DEVOPS-315).
+#
+# These hosts carry the label `zq2-network=playground` because they are not
+# members of any specific zq2 network; they are generic dev VMs that can be
+# pointed at any chain at runtime. The `network_playground` Ansible group is
+# produced automatically by inventory.gcp.yml's keyed_groups on the label.
+#
+# We deliberately do NOT set chain_name, eth_chain_id, zq2_image, stats_*,
+# checkpoint_url, enable_kms, enable_faucet, or any per-network image tags:
+# the playbooks that consume them (install_zilliqa, install_stats_agent,
+# install_monitoring, install_ops_agent, install_spout, install_otterscan,
+# install_stats_dashboard, install_checkpoint_service,
+# install_ethereum_metrics_exporter) are already scoped to exclude
+# role_testnode in node_provision.yml, so those vars never get dereferenced
+# for these hosts.
+#
+# What we DO need is the SSH/SCP arg template that the gcp-ssh-wrapper and
+# gcp-scp-wrapper rely on to forward --zone to gcloud. Without it the wrapper
+# falls back to the operator's local default zone, which will not match where
+# the testnode actually lives. `{{ zone }}` comes from the gcp_compute
+# inventory plugin and expands to the instance's full zone URL, which gcloud
+# accepts as a --zone argument.
+
+ansible_ssh_args: --tunnel-through-iap --zone={{ zone }} --no-user-output-enabled
+ansible_scp_extra_args: --tunnel-through-iap --zone={{ zone }} --quiet

--- a/infra/ansible/inventory.gcp.yml
+++ b/infra/ansible/inventory.gcp.yml
@@ -3,6 +3,7 @@ projects:
   - prj-d-zq2-devnet-c83bkpsd
   - prj-d-zq2-testnet-g13pnaa8
   - prj-p-zq2-mainnet-sn5n8wfl
+  - prj-d-playground-b7i4vh7s
 filters:
   - status = RUNNING
   - scheduling.automaticRestart = true AND status = RUNNING

--- a/infra/ansible/playbooks/configure_healthcheck.yml
+++ b/infra/ansible/playbooks/configure_healthcheck.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install and configure healthcheck service
-  hosts: all:!role_apps
+  hosts: all:!role_apps:!role_testnode
   become: true
   tags:
     - install

--- a/infra/ansible/playbooks/install_gcloud.yml
+++ b/infra/ansible/playbooks/install_gcloud.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install and configure Google Cloud SDK
-  hosts: all
+  hosts: all:!role_testnode
   become: true
   tags:
     - install

--- a/infra/ansible/playbooks/install_monitoring.yml
+++ b/infra/ansible/playbooks/install_monitoring.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install and configure Node Exporter and Process Exporter
-  hosts: all
+  hosts: all:!role_testnode
   become: true
   tags:
     - install

--- a/infra/ansible/playbooks/install_ops_agent.yml
+++ b/infra/ansible/playbooks/install_ops_agent.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install and configure Google Cloud Ops Agent
-  hosts: all
+  hosts: all:!role_testnode
   become: true
   tags:
     - install

--- a/infra/ansible/playbooks/node_provision.yml
+++ b/infra/ansible/playbooks/node_provision.yml
@@ -32,7 +32,7 @@
 - name: Zilliqa node installation
   ansible.builtin.import_playbook: install_zilliqa.yml
   vars:
-    target_group: all:!role_apps:!role_bootstrap:!role_fullnode
+    target_group: all:!role_apps:!role_bootstrap:!role_testnode
 
 - name: Healthcheck service configuration
   ansible.builtin.import_playbook: configure_healthcheck.yml

--- a/infra/ansible/playbooks/node_provision.yml
+++ b/infra/ansible/playbooks/node_provision.yml
@@ -32,7 +32,7 @@
 - name: Zilliqa node installation
   ansible.builtin.import_playbook: install_zilliqa.yml
   vars:
-    target_group: all:!role_apps:!role_bootstrap
+    target_group: all:!role_apps:!role_bootstrap:!role_fullnode
 
 - name: Healthcheck service configuration
   ansible.builtin.import_playbook: configure_healthcheck.yml

--- a/infra/tf/modules/node/variables.tf
+++ b/infra/tf/modules/node/variables.tf
@@ -61,8 +61,8 @@ variable "role" {
   description = "VM role"
   type        = string
   validation {
-    condition     = contains(["bootstrap", "api", "validator", "apps", "opsnode", "private-api", "sentry", "fullnode"], var.role)
-    error_message = "The role value must be one of: 'bootstrap', 'api', 'validator', 'apps', 'opsnode', 'private-api', 'sentry', 'fullnode'."
+    condition     = contains(["bootstrap", "api", "validator", "apps", "opsnode", "private-api", "sentry", "testnode"], var.role)
+    error_message = "The role value must be one of: 'bootstrap', 'api', 'validator', 'apps', 'opsnode', 'private-api', 'sentry', 'testnode'."
   }
 }
 

--- a/infra/tf/modules/node/variables.tf
+++ b/infra/tf/modules/node/variables.tf
@@ -61,8 +61,8 @@ variable "role" {
   description = "VM role"
   type        = string
   validation {
-    condition     = contains(["bootstrap", "api", "validator", "apps", "opsnode", "private-api", "sentry"], var.role)
-    error_message = "The role value must be one of: 'bootstrap', 'api', 'validator', 'apps', 'opsnode', 'private-api', 'sentry'."
+    condition     = contains(["bootstrap", "api", "validator", "apps", "opsnode", "private-api", "sentry", "fullnode"], var.role)
+    error_message = "The role value must be one of: 'bootstrap', 'api', 'validator', 'apps', 'opsnode', 'private-api', 'sentry', 'fullnode'."
   }
 }
 


### PR DESCRIPTION
## Summary

- New \`testnode\` role whitelisted in \`infra/tf/modules/node\` so the playground GCP project can consume the module directly from the devops repo without pulling in the zq2 root stack (no LB, SSL, DNS, CDN or secret scaffolding).
- Ansible discovers hosts in \`prj-d-playground-b7i4vh7s\` and provisions them with the minimum the OS needs: \`install_packages\`, \`configure_swap\`, \`mount_data_disk\`, \`install_docker\`, \`configure_logrotate\`, \`install_rocksdb_tools\`. Monitoring, ops-agent, gcloud, healthcheck, stats agent and \`install_zilliqa\` are all explicitly excluded for \`role_testnode\` — developers install zq2 manually once the VM is up and point it at whichever chain they are testing.
- \`group_vars/network_playground/all.yml\` carries only the \`ansible_ssh_args\` / \`ansible_scp_extra_args\` template that injects \`--zone={{ zone }}\` into the gcp-ssh / gcp-scp wrappers, matching how devnet / testnet / mainnet do it.
- Labels / names are chain-neutral (\`zq2-network=playground\`, \`role=testnode\`) because these VMs can be pointed at any chain at runtime.

## Companion change

The Terraform caller lives in the devops repo at \`infra/live/gcp/non-production/prj-d-playground/zq2_testnodes.yaml\` (branch \`devops-315/playground-full-nodes\` there). It consumes this module via \`github.com/zilliqa/zq2//infra/tf/modules/node?ref=devops-315/playground-full-nodes\`. Flip the ref to \`main\` after this PR merges.

## Test plan

- [x] \`terraform validate\` on \`infra/tf\` stays green (module change is additive, backward-compatible).
- [x] \`ansible-inventory --graph -i inventory.gcp.yml\` discovers the playground project and groups testnodes under \`role_testnode\` and \`network_playground\`.
- [x] \`ansible-playbook playbooks/node_provision.yml --limit role_testnode\` runs end-to-end on a fresh playground VM (asia-southeast1) with no undefined-variable errors.
- [x] Sanity-check a \`terraform plan\` on devnet / testnet / mainnet shows zero drift against the module's additive role-whitelist change.