### PR TITLE
chore(ansible): switch OTLP metrics_mode to GMP (DEVOPS-316)

### DIFF
--- a/infra/ansible/playbooks/templates/ops-agent-config.yaml.j2
+++ b/infra/ansible/playbooks/templates/ops-agent-config.yaml.j2
@@ -2,7 +2,7 @@ combined:
   receivers:
     otlp:
       type: otlp
-      metrics_mode: googlecloudmonitoring
+      metrics_mode: googlemanagedprometheus
 logging:
   receivers:
     zilliqa:

--- a/infra/ansible/playbooks/templates/process_exporter.sh.j2
+++ b/infra/ansible/playbooks/templates/process_exporter.sh.j2
@@ -6,7 +6,7 @@ start() {
 process_names:
   - name: "{{ '{{' }}.Comm{{ '}}' }}"
     cmdline:
-    - '.+'
+    - 'dockerd|containerd|zilliqa'
 EOL
     docker ps -a --filter "name=process-exporter" --format "{{'{{'}}.ID{{'}}'}}" | xargs -r docker rm -f &> /dev/null || echo 0
     docker run -td -p 9256:9256 --name process-exporter \


### PR DESCRIPTION
## Summary

- Switches the Ops Agent OTLP receiver from `metrics_mode: googlecloudmonitoring` to `googlemanagedprometheus` in `infra/ansible/playbooks/templates/ops-agent-config.yaml.j2`. This reroutes the three driving OTLP metrics (`rpc.server.duration`, `messaging.process.duration`, `validator_earned_reward`) from the `workload.googleapis.com/` "Metric Volume" SKU ($0.258/MiB) to `prometheus.googleapis.com/` "Prometheus Samples" SKU. Net saving across devnet+testnet+mainnet: **~$1,250/month / ~$15,000/year** (after accounting for the additional ~725M Prometheus samples; see DEVOPS-316 comments for the corrected pricing math).
- Tightens `process_exporter.sh.j2` cmdline regex from `'.+'` to `'dockerd|containerd|zilliqa'` to drop ~100 stale process groups on the prometheus.googleapis.com SKU.

Pre-flight (verified in DEVOPS-316 + re-verified live 2026-05-04):
- Ops Agent v2.63–v2.64 on all RUNNING VMs (minimum required: v2.34.0)
- Explicit-bucket histograms (clean Prometheus representation)
- Label keys already underscore-separated (no Grafana label rename needed)
- All 9 OTLP descriptors active in the 3 projects; `prometheus.googleapis.com/node_*` pipeline healthy in each project

Linear: https://linear.app/zilliqa/issue/DEVOPS-316

## Rollout (staggered Ansible runs after merge)

| Step | Target | Command | Notes |
|---|---|---|---|
| T0 | testnet (12 VMs, ~$297/mo) | `ansible-playbook playbooks/install_ops_agent.yml --limit network_zq2_testnet --diff` | Primary canary. Devnet is currently fully terminated, so testnet replaces devnet as the canary |
| T0 + 24h | mainnet (9 VMs, ~$857/mo, includes the gZIL private-API node) | `ansible-playbook playbooks/install_ops_agent.yml --limit network_zq2_mainnet --diff` | Cut over only if testnet verifications pass |
| later | devnet (7 VMs, currently TERMINATED) | picked up automatically on next provisioning / next manual run | No action needed while the env is offline |

Rollback: revert this PR + re-run `install_ops_agent.yml --limit network_zq2_<env>`. Idempotent (no server-side schema migration).

## Test plan

- [ ] Pre-stage the Grafana dashboards using PromQL versions of the affected panels for testnet, then for mainnet, before each cut-over (avoids the visibility gap at agent restart)
- [ ] After testnet Ansible run: Ansible play recap = 0 failed; spot-check 1 VM via IAP for `/etc/google-cloud-ops-agent/config.yaml` showing the new `metrics_mode`
- [ ] PromQL probe `count(rpc_server_duration_count) > 0` against testnet's GMP endpoint returns non-zero within ~10 min
- [ ] Cloud Monitoring `monitoring.googleapis.com/billing/bytes_ingested` filtered on `metric_domain="workload.googleapis.com"` for testnet trends to ~0 within ~10 min
- [ ] Pre-staged Grafana dashboards render the new PromQL queries with live data
- [ ] No regression in node_exporter / process_exporter / ethereum_metrics_exporter prometheus pipelines on testnet
- [ ] After 24h soak: repeat all of the above for mainnet (including notification to the gZIL operator about the metric path change before cut-over)
- [ ] After ≥7 days mainnet stability: separate ticket / cleanup PR for stale `workload.googleapis.com/*` metric descriptors and a process_exporter cardinality verification