### PR TITLE
Added eth_call() with state-overrides

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -112,15 +112,15 @@ services:
       - RUST_LOG=error
       - CHAIN_ID=33468
       - CHAIN_NAME="ZQ2-localnet"
-      - NODE_HTTP=http://node2:4201
+      - NODE_HTTP=http://node2:4200
       - ENABLED_ENTRY_POINTS=v0.7
-      - SIGNER_PRIVATE_KEYS=56d7a450d75c6ba2706ef71da6ca80143ec4971add9c44d7d129a12fa7d3a364
+      - SIGNER_PRIVATE_KEYS=65d7f4da9bedc8fb79cbf6722342960bbdfb9759bc0d9e3fb4989e831ccbc227
     command: node
     ports:
       # RPC port
-      - "4203:3000"
+      - "5300:3000"
       # Metrics port
-      - "5300:8080"
+      - "5380:8080"
     networks:
       localnet:
         ipv4_address: 198.51.100.8

--- a/infra/config_docker.toml
+++ b/infra/config_docker.toml
@@ -25,7 +25,7 @@ api_servers = [
 # Connects to locally run network
 remote_chains = [
     {
-        watcher_url = "http://198.51.100.103:4201",
+        watcher_url = "http://198.51.100.103:4200",
         bundler_url = "http://198.51.100.8:3000",
         chain_id = 33468,
         entrypoint = "0x0000000071727de22e5e9d8baf0edac6f37da032",

--- a/zilliqa/src/api/bundler.rs
+++ b/zilliqa/src/api/bundler.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use jsonrpsee::RpcModule;
+
+use crate::{
+    api::{
+        HandlerType, disabled_err, format_panic_as_error, into_rpc_error, make_panic_hook,
+        rpc_base_attributes,
+    },
+    cfg::EnabledApi,
+    node::Node,
+};
+
+pub fn rpc_module(node: Arc<Node>, enabled_apis: &[EnabledApi]) -> RpcModule<Arc<Node>> {
+    super::declare_module!(
+        node,
+        enabled_apis,
+        [
+            (
+                "debug_traceCall",
+                super::debug::debug_trace_call,
+                HandlerType::Slow
+            ),
+            (
+                "debug_traceTransaction",
+                super::debug::debug_trace_transaction,
+                HandlerType::Slow
+            ),
+            ("eth_call", super::eth::call, HandlerType::Fast),
+            ("eth_feeHistory", super::eth::fee_history, HandlerType::Fast),
+            ("eth_getBalance", super::eth::get_balance, HandlerType::Fast),
+            ("eth_getLogs", super::eth::get_logs, HandlerType::Fast),
+        ],
+    )
+}

--- a/zilliqa/src/api/bundler.rs
+++ b/zilliqa/src/api/bundler.rs
@@ -1,6 +1,11 @@
 use std::sync::Arc;
 
-use jsonrpsee::RpcModule;
+use alloy::{
+    eips::BlockId,
+    rpc::types::{TransactionRequest, state::StateOverride},
+};
+use anyhow::Result;
+use jsonrpsee::{RpcModule, core::traits::ToRpcParams, types::Params};
 
 use crate::{
     api::{
@@ -11,25 +16,40 @@ use crate::{
     node::Node,
 };
 
+/// Bundler API
+///
+/// Provides bundler-specific API alternatives and implementations.
 pub fn rpc_module(node: Arc<Node>, enabled_apis: &[EnabledApi]) -> RpcModule<Arc<Node>> {
-    super::declare_module!(
+    let mut module = RpcModule::new(node.clone());
+    module
+        .merge(super::eth::rpc_module(node.clone(), enabled_apis))
+        .unwrap();
+    module
+        .merge(super::debug::rpc_module(node.clone(), enabled_apis))
+        .unwrap();
+
+    // Overrides
+    let overrides = super::declare_module!(
         node,
         enabled_apis,
-        [
-            (
-                "debug_traceCall",
-                super::debug::debug_trace_call,
-                HandlerType::Slow
-            ),
-            (
-                "debug_traceTransaction",
-                super::debug::debug_trace_transaction,
-                HandlerType::Slow
-            ),
-            ("eth_call", super::eth::call, HandlerType::Fast),
-            ("eth_feeHistory", super::eth::fee_history, HandlerType::Fast),
-            ("eth_getBalance", super::eth::get_balance, HandlerType::Fast),
-            ("eth_getLogs", super::eth::get_logs, HandlerType::Fast),
-        ],
-    )
+        [("eth_call", eth_call, HandlerType::Fast),],
+    );
+    for method_name in overrides.method_names() {
+        module.remove_method(method_name);
+    }
+    module.merge(overrides).unwrap();
+
+    module
+}
+
+fn eth_call(params: Params, node: &Arc<Node>) -> Result<String> {
+    let mut params = params.sequence();
+    let call_params: TransactionRequest = params.next()?;
+    let block_id: BlockId = params.optional_next()?.unwrap_or_default();
+    let _overrides: StateOverride = params.optional_next()?.unwrap_or_default();
+
+    let array_params = jsonrpsee::rpc_params!(call_params, block_id);
+    let string_params = array_params.to_rpc_params()?.unwrap().get().to_owned();
+    let params = Params::new(Some(&string_params));
+    super::eth::call(params, node)
 }

--- a/zilliqa/src/api/bundler.rs
+++ b/zilliqa/src/api/bundler.rs
@@ -2,18 +2,27 @@ use std::sync::Arc;
 
 use alloy::{
     eips::BlockId,
-    rpc::types::{TransactionRequest, state::StateOverride},
+    rpc::types::{
+        TransactionRequest,
+        state::{AccountOverride, StateOverride},
+    },
 };
-use anyhow::Result;
-use jsonrpsee::{RpcModule, core::traits::ToRpcParams, types::Params};
+use anyhow::{Result, anyhow};
+use eth_trie::{EthTrie, Trie as _};
+use jsonrpsee::{
+    RpcModule,
+    types::{ErrorObjectOwned, Params},
+};
 
 use crate::{
     api::{
         HandlerType, disabled_err, format_panic_as_error, into_rpc_error, make_panic_hook,
-        rpc_base_attributes,
+        rpc_base_attributes, to_hex::ToHex as _,
     },
     cfg::EnabledApi,
+    error::ensure_success,
     node::Node,
+    state::Code,
 };
 
 /// Bundler API
@@ -46,10 +55,92 @@ fn eth_call(params: Params, node: &Arc<Node>) -> Result<String> {
     let mut params = params.sequence();
     let call_params: TransactionRequest = params.next()?;
     let block_id: BlockId = params.optional_next()?.unwrap_or_default();
-    let _overrides: StateOverride = params.optional_next()?.unwrap_or_default();
+    let overrides: StateOverride = params.optional_next()?.unwrap_or_default();
 
-    let array_params = jsonrpsee::rpc_params!(call_params, block_id);
-    let string_params = array_params.to_rpc_params()?.unwrap().get().to_owned();
-    let params = Params::new(Some(&string_params));
-    super::eth::call(params, node)
+    let (mut evm_state, block) = {
+        let block = node.get_block(block_id)?.unwrap();
+        let state = node.get_state(&block)?;
+        (state, block)
+    };
+    if evm_state.is_empty() {
+        return Err(anyhow!("State required to execute request does not exist"));
+    }
+
+    // override state
+    // TODO: Do not commit changes to disk - simulation only.
+    for (
+        address,
+        AccountOverride {
+            balance,
+            nonce,
+            code,
+            state,
+            state_diff,
+            move_precompile_to,
+        },
+    ) in overrides.into_iter()
+    {
+        // The fake balance to set for the account before executing the call
+        if let Some(balance) = balance {
+            evm_state.mutate_account(address, |a| {
+                a.balance = balance.to::<u128>();
+                Ok(())
+            })?;
+        }
+        // The fake nonce to set for the account before executing the call
+        if let Some(nonce) = nonce {
+            evm_state.mutate_account(address, |a| {
+                a.nonce = nonce;
+                Ok(())
+            })?;
+        }
+        // The fake EVM bytecode to inject into the account before executing the call
+        if let Some(code) = code {
+            evm_state.mutate_account(address, |a| {
+                a.code = Code::Evm(code.into());
+                Ok(())
+            })?;
+        }
+        // The fake key-value mapping to override all slots in the account storage before executing the call
+        if let Some(state) = state {
+            let state_trie = Arc::new(node.db.state_trie()?);
+            let mut trie = EthTrie::new(state_trie);
+            for (k, v) in state.iter() {
+                trie.insert(k.0.as_slice(), v.0.as_slice())?;
+            }
+            let storage_root = trie.root_hash()?;
+            evm_state.mutate_account(address, |a| {
+                a.storage_root = storage_root;
+                Ok(())
+            })?;
+        }
+        // The fake key-value mapping to override individual slots in the account storage before executing the call
+        if let Some(state) = state_diff {
+            let mut trie = evm_state.get_account_trie(address)?;
+            for (k, v) in state.iter() {
+                trie.insert(k.0.as_slice(), v.0.as_slice())?;
+            }
+            let storage_root = trie.root_hash()?;
+            evm_state.mutate_account(address, |a| {
+                a.storage_root = storage_root;
+                Ok(())
+            })?;
+        }
+        if let Some(_move_precompile_to) = move_precompile_to {
+            unimplemented!()
+        }
+    }
+
+    let result = evm_state.call_contract(
+        call_params.from.unwrap_or_default(),
+        call_params.to.and_then(|to| to.into_to()),
+        call_params.input.into_input().unwrap_or_default().to_vec(),
+        u128::try_from(call_params.value.unwrap_or_default())?,
+        block.header,
+    )?;
+
+    match ensure_success(result) {
+        Ok(output) => Ok(output.to_hex()),
+        Err(err) => Err(ErrorObjectOwned::from(err).into()),
+    }
 }

--- a/zilliqa/src/api/debug.rs
+++ b/zilliqa/src/api/debug.rs
@@ -102,12 +102,12 @@ fn debug_trace_block_by_number(params: Params, node: &Arc<Node>) -> Result<Vec<T
 }
 
 /// debug_traceCall
-fn debug_trace_call(_params: Params, _node: &Arc<Node>) -> Result<()> {
+pub fn debug_trace_call(_params: Params, _node: &Arc<Node>) -> Result<()> {
     Err(anyhow!("API method debug_traceCall is not implemented yet"))
 }
 
 /// debug_traceTransaction
-fn debug_trace_transaction(params: Params, node: &Arc<Node>) -> Result<TraceResult> {
+pub fn debug_trace_transaction(params: Params, node: &Arc<Node>) -> Result<TraceResult> {
     let mut params = params.sequence();
     let txn_hash: B256 = params.next()?;
     let txn_hash: Hash = txn_hash.into();

--- a/zilliqa/src/api/debug.rs
+++ b/zilliqa/src/api/debug.rs
@@ -102,12 +102,12 @@ fn debug_trace_block_by_number(params: Params, node: &Arc<Node>) -> Result<Vec<T
 }
 
 /// debug_traceCall
-pub fn debug_trace_call(_params: Params, _node: &Arc<Node>) -> Result<()> {
+fn debug_trace_call(_params: Params, _node: &Arc<Node>) -> Result<()> {
     Err(anyhow!("API method debug_traceCall is not implemented yet"))
 }
 
 /// debug_traceTransaction
-pub fn debug_trace_transaction(params: Params, node: &Arc<Node>) -> Result<TraceResult> {
+fn debug_trace_transaction(params: Params, node: &Arc<Node>) -> Result<TraceResult> {
     let mut params = params.sequence();
     let txn_hash: B256 = params.next()?;
     let txn_hash: Hash = txn_hash.into();

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -337,7 +337,7 @@ fn estimate_gas(params: Params, node: &Arc<Node>) -> Result<String> {
     Ok(return_value.to_hex())
 }
 
-pub fn get_balance(params: Params, node: &Arc<Node>) -> Result<String> {
+fn get_balance(params: Params, node: &Arc<Node>) -> Result<String> {
     let mut params = params.sequence();
     let address: ZilAddress = params.next()?;
     let address: Address = address.into();
@@ -355,7 +355,7 @@ pub fn get_balance(params: Params, node: &Arc<Node>) -> Result<String> {
     Ok(state.get_account(address)?.balance.to_hex())
 }
 
-pub fn brt_to_eth_receipts(
+fn _brt_to_eth_receipts(
     btr: crate::db::BlockAndReceiptsAndTransactions,
 ) -> Vec<TransactionReceipt> {
     let block = btr.block;
@@ -727,7 +727,7 @@ fn get_block_transaction_count_by_number(
     ))
 }
 
-pub fn get_logs(params: Params, node: &Arc<Node>) -> Result<Vec<eth::Log>> {
+fn get_logs(params: Params, node: &Arc<Node>) -> Result<Vec<eth::Log>> {
     let mut seq = params.sequence();
     let params: alloy::rpc::types::Filter = seq.next()?;
     expect_end_of_params(&mut seq, 1, 1)?;
@@ -1168,7 +1168,7 @@ fn blob_base_fee(_params: Params, _node: &Arc<Node>) -> Result<()> {
 
 /// eth_feeHistory
 /// Returns the collection of historical gas information
-pub fn fee_history(params: Params, node: &Arc<Node>) -> Result<FeeHistory> {
+fn fee_history(params: Params, node: &Arc<Node>) -> Result<FeeHistory> {
     let mut params = params.sequence();
     let block_count: String = params.next()?;
     let block_count = if let Some(block_count) = block_count.strip_prefix("0x") {

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -262,7 +262,7 @@ fn call_many(_params: Params, _node: &Arc<Node>) -> Result<()> {
     Err(anyhow!("API method eth_callMany is not implemented yet"))
 }
 
-fn call(params: Params, node: &Arc<Node>) -> Result<String> {
+pub fn call(params: Params, node: &Arc<Node>) -> Result<String> {
     let mut params = params.sequence();
     let call_params: TransactionRequest = params.next()?;
     let block_id: BlockId = params.optional_next()?.unwrap_or_default();
@@ -337,7 +337,7 @@ fn estimate_gas(params: Params, node: &Arc<Node>) -> Result<String> {
     Ok(return_value.to_hex())
 }
 
-fn get_balance(params: Params, node: &Arc<Node>) -> Result<String> {
+pub fn get_balance(params: Params, node: &Arc<Node>) -> Result<String> {
     let mut params = params.sequence();
     let address: ZilAddress = params.next()?;
     let address: Address = address.into();
@@ -727,7 +727,7 @@ fn get_block_transaction_count_by_number(
     ))
 }
 
-fn get_logs(params: Params, node: &Arc<Node>) -> Result<Vec<eth::Log>> {
+pub fn get_logs(params: Params, node: &Arc<Node>) -> Result<Vec<eth::Log>> {
     let mut seq = params.sequence();
     let params: alloy::rpc::types::Filter = seq.next()?;
     expect_end_of_params(&mut seq, 1, 1)?;
@@ -1168,7 +1168,7 @@ fn blob_base_fee(_params: Params, _node: &Arc<Node>) -> Result<()> {
 
 /// eth_feeHistory
 /// Returns the collection of historical gas information
-fn fee_history(params: Params, node: &Arc<Node>) -> Result<FeeHistory> {
+pub fn fee_history(params: Params, node: &Arc<Node>) -> Result<FeeHistory> {
     let mut params = params.sequence();
     let block_count: String = params.next()?;
     let block_count = if let Some(block_count) = block_count.strip_prefix("0x") {

--- a/zilliqa/src/api/eth.rs
+++ b/zilliqa/src/api/eth.rs
@@ -262,7 +262,7 @@ fn call_many(_params: Params, _node: &Arc<Node>) -> Result<()> {
     Err(anyhow!("API method eth_callMany is not implemented yet"))
 }
 
-pub fn call(params: Params, node: &Arc<Node>) -> Result<String> {
+fn call(params: Params, node: &Arc<Node>) -> Result<String> {
     let mut params = params.sequence();
     let call_params: TransactionRequest = params.next()?;
     let block_id: BlockId = params.optional_next()?.unwrap_or_default();

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -44,9 +44,6 @@ pub fn rpc_module(node: Arc<Node>, enabled_apis: &[EnabledApi]) -> RpcModule<Arc
         .merge(web3::rpc_module(node.clone(), enabled_apis))
         .unwrap();
     module
-        .merge(bundler::rpc_module(node.clone(), enabled_apis))
-        .unwrap();
-    module
         .merge(zilliqa::rpc_module(node.clone(), enabled_apis))
         .unwrap();
 
@@ -68,6 +65,13 @@ pub fn all_enabled() -> Vec<crate::cfg::EnabledApi> {
     .into_iter()
     .map(|ns| crate::cfg::EnabledApi::EnableAll(ns.to_owned()))
     .collect()
+}
+
+pub fn bundler_enabled() -> Vec<crate::cfg::EnabledApi> {
+    ["debug", "eth"]
+        .into_iter()
+        .map(|ns| crate::cfg::EnabledApi::EnableAll(ns.to_owned()))
+        .collect()
 }
 
 use std::panic::PanicHookInfo;

--- a/zilliqa/src/api/mod.rs
+++ b/zilliqa/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod bundler;
 mod debug;
 mod erigon;
 pub mod eth;
@@ -41,6 +42,9 @@ pub fn rpc_module(node: Arc<Node>, enabled_apis: &[EnabledApi]) -> RpcModule<Arc
         .unwrap();
     module
         .merge(web3::rpc_module(node.clone(), enabled_apis))
+        .unwrap();
+    module
+        .merge(bundler::rpc_module(node.clone(), enabled_apis))
         .unwrap();
     module
         .merge(zilliqa::rpc_module(node.clone(), enabled_apis))

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -134,14 +134,39 @@ impl NodeLauncher {
             sync_peers.clone(),
             swarm_peers.clone(),
         )?;
-
         let node = Arc::new(node);
+
+        // Start Bundler RPC server
+        //
+        // A standalone RPC server is provided mainly to implement the API extensions needed to enable bundler support.
+        // A decision may be made to enable the same extensions on the regular API in the future, and to directly incorporate it to the main JSON-RPC.
+        let bundler_api = api::bundler::rpc_module(node.clone(), &crate::api::bundler_enabled());
+        let bundler_rpc = jsonrpsee::server::ServerBuilder::new()
+            .set_config(
+                ServerConfig::builder()
+                    .max_connections(JSON_RPC_HANDLERS_COUNT)
+                    .set_id_provider(EthIdProvider)
+                    .build(),
+            )
+            .build((Ipv4Addr::UNSPECIFIED, 4200)) // hard-coded port number
+            .await;
+        match bundler_rpc {
+            Ok(server) => {
+                let port = server.local_addr()?.port();
+                info!("BUNDLER-RPC server listening on port {}", port);
+                let handle = server.start(bundler_api);
+                tokio::spawn(handle.stopped());
+            }
+            Err(e) => {
+                error!("Failed to start BUNDLER-RPC server: {}", e);
+            }
+        }
+
         let credit_store = Arc::new(RpcCreditStore::new());
         let credit_rate = RpcCreditRate::new(config.credit_rates.clone());
-
         for api_server in &config.api_servers {
             // Collect all enabled modules
-            let rpc_module = api::rpc_module(Arc::clone(&node), &api_server.enabled_apis);
+            let json_api = api::rpc_module(Arc::clone(&node), &api_server.enabled_apis);
 
             // HTTP middleware
             let cors = CorsLayer::new()
@@ -168,7 +193,7 @@ impl NodeLauncher {
                 );
 
             // Construct the JSON-RPC API server.
-            let server = jsonrpsee::server::ServerBuilder::new()
+            let json_rpc = jsonrpsee::server::ServerBuilder::new()
                 .set_config(
                     ServerConfig::builder()
                         .max_connections(JSON_RPC_HANDLERS_COUNT)
@@ -182,11 +207,11 @@ impl NodeLauncher {
                 .await;
 
             // Start the JSON-RPC server.
-            match server {
+            match json_rpc {
                 Ok(server) => {
                     let port = server.local_addr()?.port();
                     info!("JSON-RPC server listening on port {}", port);
-                    let handle = server.start(rpc_module);
+                    let handle = server.start(json_api);
                     tokio::spawn(handle.stopped());
                 }
                 Err(e) => {
@@ -195,7 +220,7 @@ impl NodeLauncher {
             }
         }
 
-        // Start UCCB **after** JSON-RPC is started, to be able to connect to localhost
+        // Start UCCB **after** RPC is started, to be able to connect to localhost
         let uccb = Arc::new(
             Uccb::new(
                 config.clone(),

--- a/zilliqa/src/node_launcher.rs
+++ b/zilliqa/src/node_launcher.rs
@@ -8,6 +8,7 @@ use anyhow::{Result, anyhow};
 use arc_swap::ArcSwap;
 use http::{Method, header};
 use jsonrpsee::{
+    core::middleware::layer::RpcLoggerLayer,
     server::{ServerConfig, middleware::http::ProxyGetRequestLayer},
     ws_client::RpcServiceBuilder,
 };
@@ -141,6 +142,7 @@ impl NodeLauncher {
         // A standalone RPC server is provided mainly to implement the API extensions needed to enable bundler support.
         // A decision may be made to enable the same extensions on the regular API in the future, and to directly incorporate it to the main JSON-RPC.
         let bundler_api = api::bundler::rpc_module(node.clone(), &crate::api::bundler_enabled());
+        let rpc_middleware = RpcServiceBuilder::new().layer(RpcLoggerLayer::new(1_000));
         let bundler_rpc = jsonrpsee::server::ServerBuilder::new()
             .set_config(
                 ServerConfig::builder()
@@ -148,6 +150,7 @@ impl NodeLauncher {
                     .set_id_provider(EthIdProvider)
                     .build(),
             )
+            .set_rpc_middleware(rpc_middleware)
             .build((Ipv4Addr::UNSPECIFIED, 4200)) // hard-coded port number
             .await;
         match bundler_rpc {


### PR DESCRIPTION
The `eth_call()` with state-overrides used by ERC4337 bundlers is exposed on port 4200.