### PR TITLE
fix: resolve withdraw ABI overload and surface encode errors

### DIFF
--- a/z2/src/validators.rs
+++ b/z2/src/validators.rs
@@ -193,13 +193,14 @@ impl SignerClient {
         println!("Withdraw: pulling available unstaked funds from deposit contract");
 
         let client = self.get_signer().await?;
-        // Withdraw the validator's funds.
-        let data = contracts::deposit_v4::WITHDRAW
+        let data = contracts::deposit_v8::WITHDRAW_COUNT
             .encode_input(&[
                 Token::Bytes(bls_public_key.as_bytes()),
                 Token::Uint((count as u128).into()),
             ])
-            .unwrap();
+            .with_context(|| {
+                format!("failed to ABI-encode withdraw(bytes,uint256) with count={count}")
+            })?;
         let tx = TransactionRequest::default()
             .to(contract_addr::DEPOSIT_PROXY)
             .input(TransactionInput::both(data.into()));
@@ -208,10 +209,11 @@ impl SignerClient {
 
         // get the mined tx
         let receipt = pending_tx.get_receipt().await?;
+        let tx_hash = receipt.transaction_hash;
         let tx = client
-            .get_transaction_by_hash(receipt.transaction_hash)
+            .get_transaction_by_hash(tx_hash)
             .await?
-            .unwrap();
+            .with_context(|| format!("transaction {tx_hash} not found after receipt"))?;
 
         println!("Sent tx: {}\n", serde_json::to_string(&tx)?);
         println!("Tx receipt: {}", serde_json::to_string(&receipt)?);

--- a/zilliqa/src/contracts/mod.rs
+++ b/zilliqa/src/contracts/mod.rs
@@ -370,7 +370,7 @@ pub mod deposit_v7 {
 }
 
 pub mod deposit_v8 {
-    use ethabi::{Constructor, Function};
+    use ethabi::{Constructor, Function, ParamType};
     use once_cell::sync::Lazy;
 
     use super::{COMPILED_DEPOSIT_V8, Contract, contract_from};
@@ -410,8 +410,34 @@ pub mod deposit_v8 {
         Lazy::new(|| CONTRACT.abi.function("depositTopup").unwrap().clone());
     pub static UNSTAKE: Lazy<Function> =
         Lazy::new(|| CONTRACT.abi.function("unstake").unwrap().clone());
-    pub static WITHDRAW: Lazy<Function> =
-        Lazy::new(|| CONTRACT.abi.function("withdraw").unwrap().clone());
+    // `withdraw` is overloaded: `withdraw(bytes)` drains all available unstaked
+    // funds, `withdraw(bytes,uint256)` drains up to `count` entries. Resolve each
+    // by exact signature so the selector cannot drift if more overloads are added.
+    pub static WITHDRAW: Lazy<Function> = Lazy::new(|| {
+        CONTRACT
+            .abi
+            .functions_by_name("withdraw")
+            .unwrap()
+            .iter()
+            .find(|f| matches!(f.inputs.as_slice(), [p] if p.kind == ParamType::Bytes))
+            .expect("withdraw(bytes) overload missing from deposit_v8 ABI")
+            .clone()
+    });
+    pub static WITHDRAW_COUNT: Lazy<Function> = Lazy::new(|| {
+        CONTRACT
+            .abi
+            .functions_by_name("withdraw")
+            .unwrap()
+            .iter()
+            .find(|f| {
+                matches!(
+                    f.inputs.as_slice(),
+                    [p1, p2] if p1.kind == ParamType::Bytes && p2.kind == ParamType::Uint(256)
+                )
+            })
+            .expect("withdraw(bytes,uint256) overload missing from deposit_v8 ABI")
+            .clone()
+    });
     pub static CURRENT_EPOCH: Lazy<Function> =
         Lazy::new(|| CONTRACT.abi.function("currentEpoch").unwrap().clone());
     pub static GET_STAKE: Lazy<Function> =


### PR DESCRIPTION
## Summary
- `z2 validators withdraw` panicked with `InvalidData` because `contracts::deposit_v8::WITHDRAW` resolved (via `abi.function("withdraw")`) to the single-arg overload `withdraw(bytes)`, while the CLI passes two args.
- Split the static into `WITHDRAW` (`withdraw(bytes)`) and `WITHDRAW_COUNT` (`withdraw(bytes,uint256)`), each resolved by exact `ParamType` signature so future overloads cannot silently shadow either.
- `Validators::withdraw` now calls `WITHDRAW_COUNT` and propagates ABI-encoding + post-receipt lookup failures via `anyhow::Context` instead of `.unwrap()`.

## Test plan
- [x] `cargo check -p z2 -p zilliqa` clean
- [x] Run `z2 validators withdraw <bls_pubkey> <count>` against a test network and confirm the tx mines instead of panicking
- [x] Force an encode failure (e.g. wrong count type) and confirm the error chain surfaces the context message